### PR TITLE
Added transtations for pad propertys, Rectangular and Trapezoidal

### DIFF
--- a/ja/kicad.po
+++ b/ja/kicad.po
@@ -2,8 +2,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: kicad\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-08-29 08:50+0900\n"
-"PO-Revision-Date: 2015-09-27 04:48+0900\n"
+"POT-Creation-Date: 2015-09-27 20:01+0900\n"
+"PO-Revision-Date: 2015-09-27 20:02+0900\n"
 "Last-Translator: starfort <starfort@nifty.com>\n"
 "Language-Team: kicad_jp <kaoruzen@gmail.com>\n"
 "Language: ja_JP\n"
@@ -11,8 +11,8 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "X-Poedit-KeywordsList: _\n"
-"X-Poedit-Basepath: /Users/yoneken/workspace/emb/kicad/testing\n"
-"X-Generator: Poedit 1.8.5\n"
+"X-Poedit-Basepath: /home/nosuzuki/kicad-source-mirror\n"
+"X-Generator: Poedit 1.7.5\n"
 "X-Poedit-SearchPath-0: kicad\n"
 "X-Poedit-SearchPath-1: pcbnew\n"
 "X-Poedit-SearchPath-2: eeschema\n"
@@ -26,6 +26,9253 @@ msgstr ""
 "X-Poedit-SearchPath-10: include\n"
 "X-Poedit-SearchPath-11: new\n"
 "X-Poedit-SearchPath-12: patches\n"
+
+#: 3d-viewer/3d_canvas.cpp:390
+msgid "Zoom +"
+msgstr "ズーム イン"
+
+#: 3d-viewer/3d_canvas.cpp:394
+msgid "Zoom -"
+msgstr "ズーム アウト"
+
+#: 3d-viewer/3d_canvas.cpp:399
+msgid "Top View"
+msgstr "上から見る"
+
+#: 3d-viewer/3d_canvas.cpp:403
+msgid "Bottom View"
+msgstr "下から見る"
+
+#: 3d-viewer/3d_canvas.cpp:408
+msgid "Right View"
+msgstr "右から見る"
+
+#: 3d-viewer/3d_canvas.cpp:412
+msgid "Left View"
+msgstr "左から見る"
+
+#: 3d-viewer/3d_canvas.cpp:417
+msgid "Front View"
+msgstr "前から見る"
+
+#: 3d-viewer/3d_canvas.cpp:421
+msgid "Back View"
+msgstr "後ろから見る"
+
+#: 3d-viewer/3d_canvas.cpp:426
+msgid "Move left <-"
+msgstr "左へ移動 ←"
+
+#: 3d-viewer/3d_canvas.cpp:430
+msgid "Move right ->"
+msgstr "右へ移動 →"
+
+#: 3d-viewer/3d_canvas.cpp:434
+msgid "Move Up ^"
+msgstr "上へ移動 ↑"
+
+#: 3d-viewer/3d_canvas.cpp:438
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:47
+#: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:151
+#: pcbnew/dialogs/dialog_fp_plugin_options_base.cpp:72
+msgid "Move Down"
+msgstr "下へ移動"
+
+#: 3d-viewer/3d_canvas.cpp:518
+#, c-format
+msgid "Zoom: %3.1f"
+msgstr "ズーム: %3.1f"
+
+#: 3d-viewer/3d_canvas.cpp:654
+msgid "3D Image File Name:"
+msgstr "3D 画像ファイル名:"
+
+#: 3d-viewer/3d_canvas.cpp:710
+msgid "Failed to copy image to clipboard"
+msgstr "クリップボードからイメージをコピーできませんでした"
+
+#: 3d-viewer/3d_canvas.cpp:723
+msgid "Can't save file"
+msgstr "ファイルを保存できません"
+
+#: 3d-viewer/3d_draw.cpp:617
+#, c-format
+msgid "Build time %.3f s"
+msgstr "ビルド時間 %.3f 秒"
+
+#: 3d-viewer/3d_draw.cpp:660 3d-viewer/3d_draw_board_body.cpp:218
+#: 3d-viewer/3d_draw_board_body.cpp:505
+#, c-format
+msgid "Build layer %s"
+msgstr "ビルド レイヤ %s"
+
+#: 3d-viewer/3d_draw.cpp:986
+msgid "Load 3D Shapes"
+msgstr "3Dシェイプの読み込み"
+
+#: 3d-viewer/3d_draw_board_body.cpp:194 3d-viewer/3d_draw_board_body.cpp:471
+msgid ""
+"Unable to calculate the board outlines.\n"
+"Therefore use the board boundary box."
+msgstr ""
+"基板の外形を計算できません;\n"
+"そのためバウンダリボックスを使用します."
+
+#: 3d-viewer/3d_draw_board_body.cpp:369
+msgid "Build board body"
+msgstr "ボード本体の Build"
+
+#: 3d-viewer/3d_frame.cpp:534
+msgid "Background Color, Bottom"
+msgstr "背景色, 下層"
+
+#: 3d-viewer/3d_frame.cpp:539
+msgid "Background Color, Top"
+msgstr "背景色, 上層"
+
+#: 3d-viewer/3d_frame.cpp:788
+msgid "Silk Screen Color"
+msgstr "シルクの色"
+
+#: 3d-viewer/3d_frame.cpp:812 3d-viewer/3d_toolbar.cpp:216
+msgid "Solder Mask Color"
+msgstr "ハンダマスクの色"
+
+#: 3d-viewer/3d_frame.cpp:835
+msgid "Copper Color"
+msgstr "導体の色"
+
+#: 3d-viewer/3d_frame.cpp:861 3d-viewer/3d_toolbar.cpp:225
+msgid "Board Body Color"
+msgstr "基板本体の色"
+
+#: 3d-viewer/3d_frame.cpp:882 3d-viewer/3d_toolbar.cpp:219
+msgid "Solder Paste Color"
+msgstr "ハンダ ペーストの色"
+
+#: 3d-viewer/3d_toolbar.cpp:52
+msgid "Reload board"
+msgstr "ボードを再読み込み"
+
+#: 3d-viewer/3d_toolbar.cpp:58
+msgid "Copy 3D image to clipboard"
+msgstr ""
+
+#: 3d-viewer/3d_toolbar.cpp:64
+msgid "Set display options, and some layers visibility"
+msgstr "ディスプレイ オプションを設定してレイヤを可視化"
+
+#: 3d-viewer/3d_toolbar.cpp:68 common/zoom.cpp:248
+#: eeschema/tool_viewlib.cpp:75 gerbview/toolbars_gerber.cpp:77
+#: pagelayout_editor/toolbars_pl_editor.cpp:78
+#: pcbnew/footprint_wizard_frame.cpp:592 pcbnew/tool_modedit.cpp:123
+#: pcbnew/tool_modview.cpp:79 eeschema/help_common_strings.h:43
+#: pcbnew/help_common_strings.h:19
+msgid "Zoom in"
+msgstr "ズーム イン"
+
+#: 3d-viewer/3d_toolbar.cpp:71 common/zoom.cpp:250
+#: eeschema/tool_viewlib.cpp:80 gerbview/toolbars_gerber.cpp:80
+#: pagelayout_editor/toolbars_pl_editor.cpp:81
+#: pcbnew/footprint_wizard_frame.cpp:597 pcbnew/tool_modedit.cpp:126
+#: pcbnew/tool_modview.cpp:84 eeschema/help_common_strings.h:44
+#: pcbnew/help_common_strings.h:20
+msgid "Zoom out"
+msgstr "ズーム アウト"
+
+#: 3d-viewer/3d_toolbar.cpp:75 common/zoom.cpp:252
+#: eeschema/tool_viewlib.cpp:85 gerbview/toolbars_gerber.cpp:83
+#: pagelayout_editor/toolbars_pl_editor.cpp:84
+#: pcbnew/footprint_wizard_frame.cpp:602 pcbnew/tool_modedit.cpp:129
+#: pcbnew/tool_modview.cpp:89
+msgid "Redraw view"
+msgstr "ビューの再描画"
+
+#: 3d-viewer/3d_toolbar.cpp:78
+msgid "Fit in page"
+msgstr "ページに合わせる"
+
+#: 3d-viewer/3d_toolbar.cpp:83
+msgid "Rotate X <-"
+msgstr "X回転 ←"
+
+#: 3d-viewer/3d_toolbar.cpp:87
+msgid "Rotate X ->"
+msgstr "X回転 →"
+
+#: 3d-viewer/3d_toolbar.cpp:92
+msgid "Rotate Y <-"
+msgstr "Y回転 ←"
+
+#: 3d-viewer/3d_toolbar.cpp:96
+msgid "Rotate Y ->"
+msgstr "Y回転 →"
+
+#: 3d-viewer/3d_toolbar.cpp:101
+msgid "Rotate Z <-"
+msgstr "Z回転 ←"
+
+#: 3d-viewer/3d_toolbar.cpp:105
+msgid "Rotate Z ->"
+msgstr "Z回転 →"
+
+#: 3d-viewer/3d_toolbar.cpp:109
+msgid "Move left"
+msgstr "左へ移動 ←"
+
+#: 3d-viewer/3d_toolbar.cpp:112
+msgid "Move right"
+msgstr "右へ移動 →"
+
+#: 3d-viewer/3d_toolbar.cpp:115
+msgid "Move up"
+msgstr "上へ移動↑"
+
+#: 3d-viewer/3d_toolbar.cpp:118
+msgid "Move down"
+msgstr "下へ移動↓"
+
+#: 3d-viewer/3d_toolbar.cpp:122
+msgid "Enable/Disable orthographic projection"
+msgstr "正投影を有効化/無効化する"
+
+#: 3d-viewer/3d_toolbar.cpp:135 cvpcb/menubar.cpp:141 eeschema/menubar.cpp:506
+#: eeschema/menubar_libedit.cpp:283 eeschema/tool_viewlib.cpp:267
+#: gerbview/menubar.cpp:242 kicad/menubar.cpp:426
+#: pagelayout_editor/menubar.cpp:169 pcbnew/menubar_modedit.cpp:358
+#: pcbnew/menubar_pcbframe.cpp:662 pcbnew/tool_modview.cpp:206
+msgid "&File"
+msgstr "ファイル(&F)"
+
+#: 3d-viewer/3d_toolbar.cpp:138
+msgid "Create Image (png format)"
+msgstr "PNG形式で画像保存"
+
+#: 3d-viewer/3d_toolbar.cpp:141
+msgid "Create Image (jpeg format)"
+msgstr "JPEG形式で画像保存"
+
+#: 3d-viewer/3d_toolbar.cpp:146
+msgid "Copy 3D Image to Clipboard"
+msgstr "クリップボードへ画像をコピー"
+
+#: 3d-viewer/3d_toolbar.cpp:151
+msgid "&Exit"
+msgstr "終了(&E)"
+
+#: 3d-viewer/3d_toolbar.cpp:154 cvpcb/menubar.cpp:142 gerbview/menubar.cpp:243
+#: kicad/menubar.cpp:428 pagelayout_editor/menubar.cpp:170
+msgid "&Preferences"
+msgstr "設定(&P)"
+
+#: 3d-viewer/3d_toolbar.cpp:157
+msgid "Realistic Mode"
+msgstr "リアルモード"
+
+#: 3d-viewer/3d_toolbar.cpp:162
+msgid "Render Options"
+msgstr "レンダオプション"
+
+#: 3d-viewer/3d_toolbar.cpp:165
+msgid "Render Shadows"
+msgstr "影の表示"
+
+#: 3d-viewer/3d_toolbar.cpp:169
+msgid "Show Holes in Zones"
+msgstr "ゾーン中に穴を表示"
+
+#: 3d-viewer/3d_toolbar.cpp:170
+msgid ""
+"Holes inside a copper layer copper zones are shown, but the calculation time "
+"is longer"
+msgstr ""
+"導体レイヤ、導体ゾーンの内部にある穴が表示されていますが、計算時間は長くなり"
+"ます"
+
+#: 3d-viewer/3d_toolbar.cpp:175
+msgid "Render Textures"
+msgstr "テクスチャの表示"
+
+#: 3d-viewer/3d_toolbar.cpp:176
+msgid "Apply a grid/cloud textures to board, solder mask and silk screen"
+msgstr ""
+
+#: 3d-viewer/3d_toolbar.cpp:180
+msgid "Render Smooth Normals"
+msgstr "ノーマル表示でスムーズに描画"
+
+#: 3d-viewer/3d_toolbar.cpp:184
+msgid "Use Model Normals"
+msgstr "モデルをノーマル表示で使用"
+
+#: 3d-viewer/3d_toolbar.cpp:188
+msgid "Render Material Properties"
+msgstr "マテリアル(材質)の描画"
+
+#: 3d-viewer/3d_toolbar.cpp:192
+msgid "Show Model Bounding Boxes"
+msgstr "モデルをバウンディングボックスで表示"
+
+#: 3d-viewer/3d_toolbar.cpp:200
+msgid "Choose Colors"
+msgstr "色の選択"
+
+#: 3d-viewer/3d_toolbar.cpp:204 eeschema/dialogs/dialog_color_config.cpp:193
+msgid "Background Color"
+msgstr "背景色"
+
+#: 3d-viewer/3d_toolbar.cpp:207
+msgid "Background Top Color"
+msgstr "背景上面色"
+
+#: 3d-viewer/3d_toolbar.cpp:210
+msgid "Background Bottom Color"
+msgstr "背景下面色"
+
+#: 3d-viewer/3d_toolbar.cpp:213
+msgid "Silkscreen Color"
+msgstr "シルクの色"
+
+#: 3d-viewer/3d_toolbar.cpp:222
+msgid "Copper/Surface Finish Color"
+msgstr "導体/表面の仕上がり色"
+
+#: 3d-viewer/3d_toolbar.cpp:228
+msgid "Show 3D &Axis"
+msgstr "3Dと軸の表示"
+
+#: 3d-viewer/3d_toolbar.cpp:233
+msgid "3D Grid"
+msgstr "3Dグリッド"
+
+#: 3d-viewer/3d_toolbar.cpp:234
+msgid "No 3D Grid"
+msgstr "3Dグリッド無し"
+
+#: 3d-viewer/3d_toolbar.cpp:235
+msgid "3D Grid 10 mm"
+msgstr "3Dグリッド 10mm"
+
+#: 3d-viewer/3d_toolbar.cpp:236
+msgid "3D Grid 5 mm"
+msgstr "3Dグリッド 5mm"
+
+#: 3d-viewer/3d_toolbar.cpp:237
+msgid "3D Grid 2.5 mm"
+msgstr "3Dグリッド 2.5mm"
+
+#: 3d-viewer/3d_toolbar.cpp:238
+msgid "3D Grid 1 mm"
+msgstr "3Dグリッド 1mm"
+
+#: 3d-viewer/3d_toolbar.cpp:254
+msgid "Show Board Bod&y"
+msgstr "基板の表示(&Y)"
+
+#: 3d-viewer/3d_toolbar.cpp:257
+msgid "Show Copper &Thickness"
+msgstr "銅箔の厚みを表示(&T)"
+
+#: 3d-viewer/3d_toolbar.cpp:260
+msgid "Show 3D M&odels"
+msgstr ""
+
+#: 3d-viewer/3d_toolbar.cpp:263
+msgid "Show Zone &Filling"
+msgstr "ゾーン塗りつぶしを表示"
+
+#: 3d-viewer/3d_toolbar.cpp:269
+msgid "Show &Layers"
+msgstr "レイヤの表示(&L)"
+
+#: 3d-viewer/3d_toolbar.cpp:272
+msgid "Show &Adhesive Layers"
+msgstr "接着剤(Adhesive)レイヤの表示(&A)"
+
+#: 3d-viewer/3d_toolbar.cpp:275
+msgid "Show &Silkscreen Layers"
+msgstr ""
+
+#: 3d-viewer/3d_toolbar.cpp:278
+msgid "Show Solder &Mask Layers"
+msgstr "半田マスクレイヤの表示(&M)"
+
+#: 3d-viewer/3d_toolbar.cpp:281
+msgid "Show Solder &Paste Layers"
+msgstr "半田ペーストレイヤの表示(&P)"
+
+#: 3d-viewer/3d_toolbar.cpp:286
+msgid "Show &Comments and Drawing Layers"
+msgstr ""
+
+#: 3d-viewer/3d_toolbar.cpp:289
+msgid "Show &Eco Layers"
+msgstr "ECOレイヤの表示(&E)"
+
+#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:30
+msgid "Realistic mode"
+msgstr "リアルモード"
+
+#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:36
+msgid "Show copper thickness"
+msgstr "銅箔の厚みを表示"
+
+#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:42
+msgid "Show 3D Models"
+msgstr ""
+
+#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:48 pcbnew/tool_pcb.cpp:368
+msgid "Show filled areas in zones"
+msgstr "ゾーンの塗りつぶし領域を表示"
+
+#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:54
+msgid "Show silkscreen layers"
+msgstr "シルクレイヤを表示"
+
+#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:60
+msgid "Show solder mask layers"
+msgstr "半田マスクレイヤの表示"
+
+#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:66
+msgid "Show solder paste layers"
+msgstr "半田ペーストレイヤ"
+
+#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:72
+msgid "Show adhesive layers"
+msgstr "接着剤(Adhesive)レイヤの表示"
+
+#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:78
+msgid "Show comments and drawings layers"
+msgstr "コメント/図面描画レイヤの表示"
+
+#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:84
+msgid "Show ECO layers"
+msgstr "ECOレイヤの表示"
+
+#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:93
+msgid "Show All"
+msgstr "全てを表示"
+
+#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:96
+msgid "Show None"
+msgstr "全てを非表示"
+
+#: bitmap2component/bitmap2cmp_gui.cpp:270 eeschema/edit_bitmap.cpp:103
+#: pagelayout_editor/pl_editor_frame.cpp:635
+msgid "Choose Image"
+msgstr "イメージの選択"
+
+#: bitmap2component/bitmap2cmp_gui.cpp:271 eeschema/edit_bitmap.cpp:104
+#: pagelayout_editor/pl_editor_frame.cpp:636
+msgid "Image Files "
+msgstr "画像ファイル"
+
+#: bitmap2component/bitmap2cmp_gui.cpp:486
+msgid "Create a logo file"
+msgstr "ロゴファイルの作成"
+
+#: bitmap2component/bitmap2cmp_gui.cpp:505
+#: bitmap2component/bitmap2cmp_gui.cpp:543
+#: bitmap2component/bitmap2cmp_gui.cpp:580
+#: bitmap2component/bitmap2cmp_gui.cpp:617
+#, c-format
+msgid "File '%s' could not be created."
+msgstr ""
+
+#: bitmap2component/bitmap2cmp_gui.cpp:523
+msgid "Create a Postscript file"
+msgstr "Postscriptファイルの作成"
+
+#: bitmap2component/bitmap2cmp_gui.cpp:561
+msgid "Create a component library file for Eeschema"
+msgstr ""
+
+#: bitmap2component/bitmap2cmp_gui.cpp:598
+msgid "Create a footprint file for Pcbnew"
+msgstr ""
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:24
+msgid "Original Picture"
+msgstr "オリジナルの画像"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:29
+msgid "Greyscale Picture"
+msgstr "グレースケール画像"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:32
+msgid "Black&&White Picture"
+msgstr "モノクロ画像(&W)"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:41
+msgid "Bitmap Info:"
+msgstr "ビットマップ情報:"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:50
+#: bitmap2component/bitmap2cmp_gui_base.cpp:66
+#: common/dialogs/dialog_page_settings_base.cpp:32 include/wxunittext.h:50
+msgid "Size:"
+msgstr "サイズ:"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:54
+#: bitmap2component/bitmap2cmp_gui_base.cpp:58
+#: bitmap2component/bitmap2cmp_gui_base.cpp:70
+#: bitmap2component/bitmap2cmp_gui_base.cpp:74
+#: bitmap2component/bitmap2cmp_gui_base.cpp:86
+msgid "0000"
+msgstr "0000"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:62
+msgid "pixels"
+msgstr "ピクセル"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:78 common/common.cpp:144
+#: common/common.cpp:202 common/dialogs/dialog_page_settings.cpp:466
+#: common/draw_frame.cpp:485
+#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:45
+#: pagelayout_editor/pl_editor_frame.cpp:467
+#: pcb_calculator/UnitSelector.cpp:38
+#: pcbnew/dialogs/dialog_create_array_base.cpp:50
+#: pcbnew/dialogs/dialog_create_array_base.cpp:61
+#: pcbnew/dialogs/dialog_create_array_base.cpp:72
+#: pcbnew/dialogs/dialog_create_array_base.cpp:83
+#: pcbnew/dialogs/dialog_create_array_base.cpp:187
+#: pcbnew/dialogs/dialog_create_array_base.cpp:198
+#: pcbnew/dialogs/dialog_export_idf_base.cpp:46
+#: pcbnew/dialogs/dialog_export_vrml_base.cpp:64
+#: pcbnew/dialogs/dialog_export_vrml_base.cpp:98
+#: pcbnew/dialogs/dialog_gen_module_position_file_base.cpp:55
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:35
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:49
+#: pcbnew/import_dxf/dialog_dxf_import_base.cpp:90
+msgid "mm"
+msgstr "mm"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:82
+msgid "BPP:"
+msgstr "Bit/Pixel:"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:90
+msgid "bits"
+msgstr "ビット"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:97
+msgid "Resolution:"
+msgstr "解像度:"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:101
+#: bitmap2component/bitmap2cmp_gui_base.cpp:106
+msgid "300"
+msgstr "300"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:111
+msgid "DPI"
+msgstr "DPI"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:121
+msgid "Load Bitmap"
+msgstr "ビットマップの読み込み"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:124 eeschema/libeditframe.cpp:1155
+msgid "Export"
+msgstr "エクスポート"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:125
+msgid ""
+"Create a library file for Eeschema\n"
+"This library contains only one component: logo"
+msgstr ""
+"Eeschema のライブラリファイルを作成する\n"
+"このライブラリは一つだけのコンポーネントロゴが含まれます。"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:129
+msgid "Eeschema (.lib file)"
+msgstr "Eeschema (.libファイル)"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:129
+msgid "Pcbnew (.kicad_mod file)"
+msgstr "Pcbnew (.kicad_modファイル)"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:129
+msgid "Postscript (.ps file)"
+msgstr "PostScript (.ps ファイル)"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:129
+msgid "Logo for title block (.kicad_wks file)"
+msgstr "タイトルブロック用のロゴ (.kicad_wksファイル)"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:131
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:90
+#: pcbnew/dialogs/dialog_plot_base.cpp:250
+#: pcbnew/dialogs/wizard_add_fplib_base.cpp:187
+msgid "Format"
+msgstr "フォーマット"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:135 common/eda_text.cpp:377
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:56
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:182
+#: eeschema/dialogs/dialog_edit_label_base.cpp:76
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:92
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:97 eeschema/libedit.cpp:498
+#: eeschema/onrightclick.cpp:381 eeschema/sch_text.cpp:758
+#: gerbview/class_GERBER.cpp:359 gerbview/class_GERBER.cpp:363
+#: gerbview/class_GERBER.cpp:366 pcbnew/class_module.cpp:599
+#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:83
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:140
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:98
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:104
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:70
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:100
+#: pcbnew/muonde.cpp:812
+msgid "Normal"
+msgstr "標準"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:135 gerbview/class_GERBER.cpp:359
+msgid "Negative"
+msgstr "ネガ"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:137
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:112
+#: eeschema/dialogs/dialog_erc_base.cpp:123
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:77
+#: pcbnew/dialogs/dialog_block_options_base.cpp:20
+#: pcbnew/dialogs/dialog_exchange_modules_base.cpp:48
+#: pcbnew/dialogs/dialog_fp_lib_table.cpp:209
+#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:98
+#: pcbnew/dialogs/dialog_plot_base.cpp:85
+#: pcbnew/dialogs/dialog_pns_settings_base.cpp:26
+msgid "Options"
+msgstr "オプション"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:141
+msgid "Threshold Value:"
+msgstr "しきい値:"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:146
+msgid ""
+"Adjust the level to convert the greyscale picture to a black and white "
+"picture."
+msgstr "グレースケール画像をモノクロ画像に変換する際のしきい値の調整"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:150
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:348
+msgid "Front silk screen"
+msgstr "表面層のシルク"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:150
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:354
+msgid "Front solder mask"
+msgstr "表面層のレジスト"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:150
+msgid "User layer Eco1"
+msgstr "Eco1 ユーザーレイヤ"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:150
+msgid "User Layer Eco2"
+msgstr "Eco2 ユーザーレイヤ"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:152
+msgid "Board Layer for Outline:"
+msgstr "使用するレイヤ:"
+
+#: bitmap2component/bitmap2cmp_gui_base.cpp:154
+msgid ""
+"Choose the board layer to place the outline.\n"
+"The 2 invisible fields reference and value are always placed on the silk "
+"screen layer."
+msgstr ""
+"外形を配置する基板のレイヤを選択する.\n"
+"２つの不可視フィールド リファレンスと定数は常にシルク レイヤへ置かれます."
+
+#: common/base_screen.cpp:188
+msgid "User Grid"
+msgstr "ユーザ グリッド"
+
+#: common/base_screen.cpp:194
+#, c-format
+msgid "Grid: %.4f mm (%.2f mils)"
+msgstr "グリッド: %.4f mm (%.2f mils)"
+
+#: common/base_screen.cpp:197
+#, c-format
+msgid "Grid: %.2f mils (%.4f mm)"
+msgstr "グリッド: %.2f mils (%.4f mm)"
+
+#: common/base_units.cpp:160
+msgid " mils"
+msgstr "mils"
+
+#: common/base_units.cpp:160
+msgid " in"
+msgstr "インチ"
+
+#: common/base_units.cpp:162 common/base_units.cpp:249
+msgid " mm"
+msgstr "mm"
+
+#: common/base_units.cpp:245
+msgid " \""
+msgstr "\""
+
+#: common/base_units.cpp:253
+msgid " deg"
+msgstr " 度"
+
+#: common/basicframe.cpp:140
+msgid ""
+"The program cannot be closed\n"
+"A quasi-modal dialog window is currently open, please close it first."
+msgstr ""
+"プログラムを終了することができませんでした\n"
+"現在表示されている他のダイアログを先に閉じてください。"
+
+#: common/basicframe.cpp:427
+#, c-format
+msgid ""
+"Html or pdf help file \n"
+"'%s'\n"
+" or\n"
+"'%s' could not be found."
+msgstr ""
+"HTML/PDF形式のヘルプファイル \n"
+"'%s'\n"
+" または\n"
+"'%s' が見つかりませんでした。"
+
+#: common/basicframe.cpp:444
+#, c-format
+msgid "Help file '%s' could not be found."
+msgstr "ヘルプファイル '%s' が見つかりません"
+
+#: common/basicframe.cpp:465
+#, c-format
+msgid "Executable file (%s)|%s"
+msgstr "実行ファイル (%s)|%s"
+
+#: common/basicframe.cpp:468
+msgid "Select Preferred Editor"
+msgstr "好みのエディタの選択"
+
+#: common/basicframe.cpp:494
+msgid "Copy &Version Information"
+msgstr "バージョン情報をコピー(&V)"
+
+#: common/basicframe.cpp:495
+msgid "Copy the version string to clipboard to send with bug reports"
+msgstr "バグレポートを送るためにクリップボードにバージョン文字列をコピーする"
+
+#: common/basicframe.cpp:548
+msgid "Could not open clipboard to write version information."
+msgstr "バージョン情報を書き込むためのクリップボードが開けません"
+
+#: common/basicframe.cpp:549
+msgid "Clipboard Error"
+msgstr "クリップボードのエラー"
+
+#: common/basicframe.cpp:623
+msgid "Version Information (copied to the clipboard)"
+msgstr "バージョン情報をクリップボードにコピー"
+
+#: common/basicframe.cpp:647
+#, c-format
+msgid "You do not have write permissions to folder <%s>."
+msgstr "フォルダー <%s> への書き込み権限がありません。"
+
+#: common/basicframe.cpp:652
+#, c-format
+msgid "You do not have write permissions to save file <%s> to folder <%s>."
+msgstr ""
+"ファイル <%s> をフォルダ <%s>に保存するための書き込み権限がありません。"
+
+#: common/basicframe.cpp:657
+#, c-format
+msgid "You do not have write permissions to save file <%s>."
+msgstr "ファイル <%s> を保存するための書き込み権限がありません。"
+
+#: common/basicframe.cpp:689
+#, c-format
+msgid ""
+"Well this is potentially embarrassing!\n"
+"It appears that the last time you were editing the file\n"
+"'%s'\n"
+"it was not saved properly.  Do you wish to restore the last saved edits you "
+"made?"
+msgstr ""
+"これはもしかすると厄介です！\n"
+"最後のファイル\n"
+"'%s'\n"
+"を修正した際に正しく保存されなかったようです。最後に行った編集内容を復元した"
+"いですか？"
+
+#: common/basicframe.cpp:717
+#, c-format
+msgid "Could not create backup file <%s>"
+msgstr "バックアップファイル <%s> が作成できませんでした"
+
+#: common/basicframe.cpp:725
+msgid "The auto save file could not be renamed to the board file name."
+msgstr "オートセーブファイルをボードファイル名にリネームできませんでした。"
+
+#: common/block_commande.cpp:68
+msgid "Block Move"
+msgstr "ブロックを移動"
+
+#: common/block_commande.cpp:72
+msgid "Block Drag"
+msgstr "ブロックをドラッグ"
+
+#: common/block_commande.cpp:76
+msgid "Drag item"
+msgstr "アイテムのドラッグ"
+
+#: common/block_commande.cpp:80
+msgid "Block Copy"
+msgstr "ブロックをコピー"
+
+#: common/block_commande.cpp:84
+msgid "Block Delete"
+msgstr "ブロックを削除"
+
+#: common/block_commande.cpp:88
+msgid "Block Save"
+msgstr "ブロックを保存"
+
+#: common/block_commande.cpp:92
+msgid "Block Paste"
+msgstr "ブロックを貼り付け"
+
+#: common/block_commande.cpp:96
+msgid "Win Zoom"
+msgstr "選択範囲の拡大"
+
+#: common/block_commande.cpp:100
+msgid "Block Rotate"
+msgstr "ブロックを回転"
+
+#: common/block_commande.cpp:104
+msgid "Block Flip"
+msgstr "ブロックを裏返し"
+
+#: common/block_commande.cpp:109
+msgid "Block Mirror"
+msgstr "ブロックをミラー反転"
+
+#: common/class_marker_base.cpp:203
+msgid "Marker Info"
+msgstr "マーカーの情報"
+
+#: common/common.cpp:140
+msgid "\""
+msgstr "\""
+
+#: common/common.cpp:171 common/dialogs/dialog_page_settings.cpp:466
+#: pagelayout_editor/pl_editor_frame.cpp:463
+msgid "inches"
+msgstr "インチ"
+
+#: common/common.cpp:175
+msgid "millimeters"
+msgstr "ミリメートル"
+
+#: common/common.cpp:179 eeschema/dialogs/dialog_edit_label_base.cpp:57
+#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:125
+#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:137
+#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:149
+#: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.cpp:47
+#: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.cpp:59
+#: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:49
+#: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:72
+msgid "units"
+msgstr "ユニット"
+
+#: common/common.cpp:198
+msgid "in"
+msgstr "インチ"
+
+#: common/common.cpp:209 pcbnew/dialogs/dialog_create_array_base.cpp:219
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:63
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:141
+msgid "deg"
+msgstr "度"
+
+#: common/common.cpp:414
+#, c-format
+msgid "Cannot make path '%s' absolute with respect to '%s'."
+msgstr "絶対パス '%s' を '%s' について設定できません."
+
+#: common/common.cpp:432
+#, c-format
+msgid "Output directory '%s' created.\n"
+msgstr "出力ディレクトリ '%s' が生成されました。\n"
+
+#: common/common.cpp:441
+#, c-format
+msgid "Cannot create output directory '%s'.\n"
+msgstr "出力ディレクトリが作成できませんでした！ '%s'.\n"
+
+#: common/confirm.cpp:75 common/pgm_base.cpp:827
+#: eeschema/dialogs/dialog_color_config.cpp:277 eeschema/symbedit.cpp:111
+msgid "Warning"
+msgstr "警告"
+
+#: common/confirm.cpp:80 kicad/prjconfig.cpp:143
+#: pcbnew/router/length_tuner_tool.cpp:171
+msgid "Error"
+msgstr "エラー"
+
+#: common/confirm.cpp:94
+msgid "Info"
+msgstr "情報"
+
+#: common/confirm.cpp:114
+msgid "Confirmation"
+msgstr "確認"
+
+#: common/dialog_about/AboutDialog_main.cpp:130
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:117
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:163
+#: eeschema/libedit.cpp:508 eeschema/sch_component.cpp:1539
+#: eeschema/viewlibs.cpp:308
+#: pcbnew/dialogs/dialog_footprint_wizard_list_base.cpp:35
+#: pcbnew/dialogs/dialog_fp_lib_table.cpp:210 pcbnew/librairi.cpp:774
+msgid "Description"
+msgstr "説明"
+
+#: common/dialog_about/AboutDialog_main.cpp:134
+msgid ""
+"The KiCad EDA Suite is a set of open source applications for the creation of "
+"electronic schematics and to design printed circuit boards."
+msgstr ""
+"The KiCad EDA Suite は電気回路図作成及びプリント基板設計のための、オープン・"
+"ソース アプリケーション セットです。"
+
+#: common/dialog_about/AboutDialog_main.cpp:141
+msgid "KiCad on the web"
+msgstr "web上のKiCad"
+
+#: common/dialog_about/AboutDialog_main.cpp:147
+msgid "The original site of the initiator of Kicad"
+msgstr "KiCad 創始者のオリジナルサイト"
+
+#: common/dialog_about/AboutDialog_main.cpp:150
+msgid "Project on Launchpad"
+msgstr "Launchpad上のプロジェクト"
+
+#: common/dialog_about/AboutDialog_main.cpp:154
+msgid "The new KiCad site"
+msgstr "新しいKiCadのWebサイト"
+
+#: common/dialog_about/AboutDialog_main.cpp:157
+msgid "Repository with additional component libraries"
+msgstr "追加のコンポーネント ライブラリのリポジトリ"
+
+#: common/dialog_about/AboutDialog_main.cpp:163
+msgid "Contribute to KiCad"
+msgstr "Kicadに貢献"
+
+#: common/dialog_about/AboutDialog_main.cpp:169
+msgid "Report bugs if you found any"
+msgstr "どんなバグでも見つけたらレポートしてください"
+
+#: common/dialog_about/AboutDialog_main.cpp:172
+msgid "File an idea for improvement"
+msgstr "改善のためのアイデアのファイル"
+
+#: common/dialog_about/AboutDialog_main.cpp:176
+msgid "KiCad links to user groups, tutorials and much more"
+msgstr "KiCadユーザグループへのリンク、チュートリアルなど"
+
+#: common/dialog_about/AboutDialog_main.cpp:189
+msgid "The complete KiCad EDA Suite is released under the"
+msgstr "KiCad EDAソフトウエアは、下記のラインセンスのもと提供されています："
+
+#: common/dialog_about/AboutDialog_main.cpp:191
+msgid "GNU General Public License (GPL) version 2 or any later version"
+msgstr "GNU 一般公衆ライセンス (GPL) バージョン 2 以降"
+
+#: common/dialog_about/dialog_about.cpp:83
+msgid "Information"
+msgstr "情報"
+
+#: common/dialog_about/dialog_about.cpp:86
+msgid "Developers"
+msgstr "開発者"
+
+#: common/dialog_about/dialog_about.cpp:87
+msgid "Doc Writers"
+msgstr "ドキュメント作成者"
+
+#: common/dialog_about/dialog_about.cpp:89
+msgid "Artists"
+msgstr "アーティスト"
+
+#: common/dialog_about/dialog_about.cpp:90
+msgid "Translators"
+msgstr "翻訳者"
+
+#: common/dialog_about/dialog_about.cpp:93
+msgid "License"
+msgstr "ライセンス"
+
+#: common/dialog_about/dialog_about_base.cpp:31
+msgid "App Title"
+msgstr "アプリケーション タイトル"
+
+#: common/dialog_about/dialog_about_base.cpp:37
+msgid "Copyright Info"
+msgstr "著作権情報"
+
+#: common/dialog_about/dialog_about_base.cpp:41
+msgid "Build Version Info"
+msgstr "ビルド バージョン情報"
+
+#: common/dialog_about/dialog_about_base.cpp:45
+msgid "Lib Version Info"
+msgstr "ライブラリ バージョン情報"
+
+#: common/dialogs/dialog_display_info_HTML_base.cpp:22
+#: common/dialogs/dialog_hotkeys_editor_base.cpp:33 common/zoom.cpp:300
+#: eeschema/dialogs/dialog_annotate_base.cpp:212
+#: eeschema/dialogs/dialog_bom_base.cpp:62
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:134
+#: eeschema/dialogs/dialog_print_using_printer_base.cpp:53
+#: eeschema/dialogs/dialog_schematic_find_base.cpp:125
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:109
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:113
+#: pcbnew/dialogs/dialog_exchange_modules_base.cpp:107
+#: pcbnew/dialogs/dialog_find_base.cpp:45
+#: pcbnew/dialogs/dialog_gendrill_base.cpp:180
+#: pcbnew/dialogs/dialog_netlist_fbp.cpp:95
+#: pcbnew/dialogs/dialog_orient_footprints_base.cpp:58
+#: pcbnew/dialogs/dialog_plot_base.cpp:389
+#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:57
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:144
+msgid "Close"
+msgstr "閉じる"
+
+#: common/dialogs/dialog_env_var_config.cpp:105
+msgid "Invalid Input"
+msgstr "不正な入力"
+
+#: common/dialogs/dialog_env_var_config.cpp:119
+msgid "Environment variable name cannot be empty."
+msgstr "環境変数名は空欄にできません。"
+
+#: common/dialogs/dialog_env_var_config.cpp:129
+msgid "Environment variable value cannot be empty."
+msgstr "環境変数値は空欄にできません。"
+
+#: common/dialogs/dialog_env_var_config.cpp:140
+msgid ""
+"The first character of an environment variable name cannot be a digit (0-9)."
+msgstr "環境変数名の最初の文字に数字 (0-9) は使用できません。"
+
+#: common/dialogs/dialog_env_var_config.cpp:152
+msgid "Cannot have duplicate environment variable names."
+msgstr "重複した環境変数名を持つことはできません。"
+
+#: common/dialogs/dialog_env_var_config.cpp:255
+msgid ""
+"Enter the name and path for each environment variable.  Grey entries are "
+"names that have been defined externally at the system or user level.  "
+"Environment variables defined at the system or user level take precedence "
+"over the ones defined in this table.  This means the values in this table "
+"are ignored."
+msgstr ""
+"各々の環境変数へ名前とパスを入力して下さい。灰色の項目は、システムまたはユー"
+"ザーによって外部で定義された名前です。システムまたはユーザーによって定義され"
+"た環境変数は、このテーブルの定義に優先します。これは、このテーブルの定義が無"
+"視されることを意味します。"
+
+#: common/dialogs/dialog_env_var_config.cpp:261
+msgid ""
+"To ensure environment variable names are valid on all platforms, the name "
+"field will only accept upper case letters, digits, and the underscore "
+"characters."
+msgstr ""
+"全てのプラットフォームで有効な環境変数名とするため、名前フィールドは大文字、"
+"数字、アンダースコアだけを受け付けます。"
+
+#: common/dialogs/dialog_env_var_config.cpp:264
+msgid ""
+"<b>KIGITHUB</b> is used by KiCad to define the URL of the repository of the "
+"official KiCad libraries."
+msgstr ""
+"<b>KIGITHUB</b> は 、公式 KiCad ライブラリのリポジトリの URL を定義するために"
+"KiCad で使用されます。"
+
+#: common/dialogs/dialog_env_var_config.cpp:267
+msgid ""
+"<b>KISYS3DMOD</b> is the base path of system footprint 3D shapes (.3Dshapes "
+"folders)."
+msgstr ""
+"<b>KISYS3DMOD</b> は、フットプリント 3D シェイプ用のシステムの基本パスです "
+"(.3Dshapes フォルダ)。"
+
+#: common/dialogs/dialog_env_var_config.cpp:270
+msgid ""
+"<b>KISYSMOD</b> is the base path of locally installed system footprint "
+"libraries (.pretty folders)."
+msgstr ""
+"<b>KISYSMOD</b> は、フットプリント・ライブラリ用にローカルでインストールされ"
+"たシステムの基本パスです (.pretty フォルダ)。"
+
+#: common/dialogs/dialog_env_var_config.cpp:273
+msgid ""
+"<b>KIPRJMOD</b> is internally defined by KiCad (cannot be edited) and is set "
+"to the absolute path of the currently loaded project file.  This environment "
+"variable can be used to define files and paths relative to the currently "
+"loaded project.  For instance, ${KIPRJMOD}/libs/footprints.pretty can be "
+"defined as a folder containing a project specific footprint library named "
+"footprints.pretty."
+msgstr ""
+"<b>KIPRJMOD</b> は、KiCad によって内部定義され (編集できません) 、現在読み込"
+"まれているプロジェクト・ファイルの絶対パスがセットされます。この環境変数は、"
+"読み込まれているプロジェクトへの相対的なファイルやパスを定義するために使用で"
+"きます。例えば、${KIPRJMOD}/libs/footprints.pretty は footprints.pretty と名"
+"付けられたプロジェクト固有のフットプリント・ライブラリを含むフォルダとして定"
+"義できます。"
+
+#: common/dialogs/dialog_env_var_config.cpp:279
+msgid ""
+"<b>KICAD_PTEMPLATES</b> is optional and can be defined if you want to create "
+"your own project templates folder."
+msgstr ""
+"<b>KICAD_PTEMPLATES</b> は、オプションです。独自のプロジェクト・テンプレー"
+"ト・フォルダを作りたい場合に定義します。"
+
+#: common/dialogs/dialog_env_var_config.cpp:282
+msgid "Environment Variable Help"
+msgstr "環境変数に関するヘルプ"
+
+#: common/dialogs/dialog_env_var_config_base.cpp:35
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:82
+#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:183
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:181
+#: eeschema/dialogs/dialog_lib_edit_pin_table.cpp:151
+#: eeschema/lib_pin.cpp:1977 eeschema/libedit.cpp:477
+#: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:26
+#: pcbnew/dialogs/dialog_footprint_wizard_list_base.cpp:34
+#: pcbnew/dialogs/dialog_layers_setup.cpp:342
+msgid "Name"
+msgstr "名前"
+
+#: common/dialogs/dialog_env_var_config_base.cpp:36
+msgid "Path"
+msgstr "パス"
+
+#: common/dialogs/dialog_env_var_config_base.cpp:56
+#: common/dialogs/dialog_get_component_base.cpp:45
+#: common/dialogs/dialog_hotkeys_editor_base.cpp:30
+#: eeschema/dialogs/dialog_netlist_base.cpp:129
+#: gerbview/dialogs/dialog_select_one_pcb_layer.cpp:178
+#: pcbnew/dialogs/dialog_design_rules_base.cpp:378
+#: pcbnew/dialogs/dialog_orient_footprints_base.cpp:54
+#: pcbnew/dialogs/wizard_add_fplib.cpp:841 pcbnew/muonde.cpp:800
+msgid "OK"
+msgstr "OK"
+
+#: common/dialogs/dialog_env_var_config_base.cpp:60
+#: common/dialogs/dialog_exit_base.cpp:69
+#: common/dialogs/dialog_get_component_base.cpp:52 common/selcolor.cpp:237
+#: eeschema/dialogs/dialog_netlist_base.cpp:49
+#: eeschema/dialogs/dialog_netlist_base.cpp:133
+#: eeschema/libedit_onrightclick.cpp:70 eeschema/onrightclick.cpp:153
+#: eeschema/onrightclick.cpp:186
+#: gerbview/dialogs/dialog_select_one_pcb_layer.cpp:182
+#: gerbview/onrightclick.cpp:59 gerbview/onrightclick.cpp:81
+#: pagelayout_editor/onrightclick.cpp:115
+#: pcbnew/dialogs/dialog_design_rules_base.cpp:382
+#: pcbnew/dialogs/dialog_global_pads_edition_base.cpp:55
+#: pcbnew/modedit_onclick.cpp:229 pcbnew/modedit_onclick.cpp:272
+#: pcbnew/muonde.cpp:803 pcbnew/onrightclick.cpp:81 pcbnew/onrightclick.cpp:97
+msgid "Cancel"
+msgstr "キャンセル"
+
+#: common/dialogs/dialog_env_var_config_base.cpp:63
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:36
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:186
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:225
+#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:38
+#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:87
+#: pcbnew/dialogs/dialog_design_rules_base.cpp:74
+msgid "Add"
+msgstr "追加"
+
+#: common/dialogs/dialog_env_var_config_base.cpp:64
+msgid "Add a new entry to the table."
+msgstr "テーブルへ項目を新規追加"
+
+#: common/dialogs/dialog_env_var_config_base.cpp:68
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:189
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:231
+#: pagelayout_editor/events_functions.cpp:573
+#: pagelayout_editor/onrightclick.cpp:103
+#: pcbnew/dialogs/dialog_fp_plugin_options_base.cpp:62
+#: pcbnew/dialogs/dialog_netlist_fbp.cpp:55
+#: pcbnew/dialogs/dialog_netlist_fbp.cpp:63
+#: pcbnew/dialogs/dialog_netlist_fbp.cpp:71 pcbnew/onrightclick.cpp:650
+#: pcbnew/onrightclick.cpp:967 pcbnew/onrightclick.cpp:1019
+msgid "Delete"
+msgstr "削除"
+
+#: common/dialogs/dialog_env_var_config_base.cpp:69
+msgid "Remove the selectect entry from the table."
+msgstr "一覧より選択した項目を削除します。"
+
+#: common/dialogs/dialog_env_var_config_base.cpp:73
+#: eeschema/dialogs/dialog_bom_base.cpp:65
+msgid "Help"
+msgstr "ヘルプ"
+
+#: common/dialogs/dialog_exit_base.cpp:34
+msgid "Save the changes before closing?"
+msgstr "閉じる前に変更を保存しますか？"
+
+#: common/dialogs/dialog_exit_base.cpp:43
+msgid "If you don't save, all your changes will be permanently lost."
+msgstr "保存しない場合、変更はすべて失われます．"
+
+#: common/dialogs/dialog_exit_base.cpp:62
+msgid "Save and Exit"
+msgstr "保存して終了"
+
+#: common/dialogs/dialog_exit_base.cpp:66
+msgid "Exit without Save"
+msgstr "保存しないで終了"
+
+#: common/dialogs/dialog_get_component_base.cpp:22
+#: eeschema/dialogs/dialog_bom_base.cpp:44
+#: eeschema/dialogs/dialog_netlist_base.cpp:115
+#: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.cpp:28
+#: pcbnew/librairi.cpp:607
+msgid "Name:"
+msgstr "名前:"
+
+#: common/dialogs/dialog_get_component_base.cpp:30
+msgid "History list:"
+msgstr "履歴リスト:"
+
+#: common/dialogs/dialog_get_component_base.cpp:49
+msgid "Search by Keyword"
+msgstr "キーワードで検索"
+
+#: common/dialogs/dialog_get_component_base.cpp:55
+msgid "List All"
+msgstr "全てのリスト"
+
+#: common/dialogs/dialog_get_component_base.cpp:58
+msgid "Select by Browser"
+msgstr "ブラウザーで選択"
+
+#: common/dialogs/dialog_hotkeys_editor.cpp:45
+msgid "Command"
+msgstr "コマンド"
+
+#: common/dialogs/dialog_hotkeys_editor.cpp:46
+msgid "Hotkey"
+msgstr "ホットキー"
+
+#: common/dialogs/dialog_hotkeys_editor.cpp:375
+#, c-format
+msgid ""
+"<%s> is already assigned to \"%s\" in section \"%s\". Are you sure you want "
+"to change its assignment?"
+msgstr ""
+"<%s>は既に \"%s\" のセクション \"%s\" へ割り当てられています。現在の割り当て"
+"を変更して宜しいですか？"
+
+#: common/dialogs/dialog_hotkeys_editor.cpp:380
+msgid "Confirm change"
+msgstr "変更の確認"
+
+#: common/dialogs/dialog_hotkeys_editor_base.cpp:19
+msgid "Select a row and press a new key combination to alter the binding."
+msgstr "項目を選択し、新しいキーを押して割り当てを変更してください。"
+
+#: common/dialogs/dialog_hotkeys_editor_base.cpp:36
+msgid "Undo"
+msgstr "元に戻す"
+
+#: common/dialogs/dialog_image_editor.cpp:130
+msgid "Incorrect scale number"
+msgstr "無効な倍率です"
+
+#: common/dialogs/dialog_image_editor.cpp:138
+msgid "Scale is too small for this image"
+msgstr "このイメージに対してスケール値が小さすぎます。"
+
+#: common/dialogs/dialog_image_editor.cpp:143
+msgid "Scale is too large for this image"
+msgstr "このイメージに対してスケール値が大きすぎます。"
+
+#: common/dialogs/dialog_image_editor_base.cpp:33
+msgid "Mirror X"
+msgstr "X軸で反転"
+
+#: common/dialogs/dialog_image_editor_base.cpp:36
+msgid "Mirror Y"
+msgstr "Y軸で反転"
+
+#: common/dialogs/dialog_image_editor_base.cpp:39
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:174
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:84
+#: pcbnew/modedit_onclick.cpp:290 pcbnew/onrightclick.cpp:1007
+#: pcbnew/tools/common_actions.cpp:121
+msgid "Rotate"
+msgstr "回転"
+
+#: common/dialogs/dialog_image_editor_base.cpp:42
+msgid "Grey"
+msgstr "グレースケール"
+
+#: common/dialogs/dialog_image_editor_base.cpp:45
+msgid "Half Size"
+msgstr "半分のサイズ"
+
+#: common/dialogs/dialog_image_editor_base.cpp:49
+msgid "Undo Last"
+msgstr "一つ前のコマンドを元に戻す"
+
+#: common/dialogs/dialog_image_editor_base.cpp:52
+msgid "Image Scale:"
+msgstr "画像の倍率:"
+
+#: common/dialogs/dialog_list_selector_base.cpp:19
+#: eeschema/dialogs/dialog_choose_component_base.cpp:22
+#: pcbnew/dialogs/dialog_orient_footprints_base.cpp:31
+msgid "Filter:"
+msgstr "フィルター: "
+
+#: common/dialogs/dialog_list_selector_base.cpp:21
+msgid ""
+"Enter a string to filter items.\n"
+"Only names containing this string will be listed"
+msgstr ""
+"アイテムを抽出するために文字列を入力してください．\n"
+"入力した文字列を含む名前だけがリストされます．"
+
+#: common/dialogs/dialog_list_selector_base.cpp:28
+msgid "Items:"
+msgstr "アイテム: "
+
+#: common/dialogs/dialog_list_selector_base.cpp:37
+#: eeschema/dialogs/dialog_erc_base.cpp:68
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:146
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1172
+#: pcbnew/dialogs/dialog_design_rules_base.cpp:368
+#: pcbnew/dialogs/dialog_drc_base.cpp:109
+#: pcbnew/dialogs/dialog_exchange_modules_base.cpp:89
+#: pcbnew/dialogs/dialog_gendrill_base.cpp:190
+msgid "Messages:"
+msgstr "メッセージ: "
+
+#: common/dialogs/dialog_page_settings.cpp:61
+msgid "A4 210x297mm"
+msgstr "A4 210x297mm"
+
+#: common/dialogs/dialog_page_settings.cpp:62
+msgid "A3 297x420mm"
+msgstr "A3 297x420mm"
+
+#: common/dialogs/dialog_page_settings.cpp:63
+msgid "A2 420x594mm"
+msgstr "A2 420x594mm"
+
+#: common/dialogs/dialog_page_settings.cpp:64
+msgid "A1 594x841mm"
+msgstr "A1 594x841mm"
+
+#: common/dialogs/dialog_page_settings.cpp:65
+msgid "A0 841x1189mm"
+msgstr "A0 841x1189mm"
+
+#: common/dialogs/dialog_page_settings.cpp:66
+msgid "A 8.5x11in"
+msgstr "A 8.5x11in"
+
+#: common/dialogs/dialog_page_settings.cpp:67
+msgid "B 11x17in"
+msgstr "B 11x17in"
+
+#: common/dialogs/dialog_page_settings.cpp:68
+msgid "C 17x22in"
+msgstr "C 17x22in"
+
+#: common/dialogs/dialog_page_settings.cpp:69
+msgid "D 22x34in"
+msgstr "D 22x34in"
+
+#: common/dialogs/dialog_page_settings.cpp:70
+msgid "E 34x44in"
+msgstr "E 34x44in"
+
+#: common/dialogs/dialog_page_settings.cpp:71
+msgid "USLetter 8.5x11in"
+msgstr "USLetter 8.5x11in"
+
+#: common/dialogs/dialog_page_settings.cpp:72
+msgid "USLegal 8.5x14in"
+msgstr "USLegal 8.5x14in"
+
+#: common/dialogs/dialog_page_settings.cpp:73
+msgid "USLedger 11x17in"
+msgstr "USLedger 11x17in"
+
+#: common/dialogs/dialog_page_settings.cpp:74
+msgid "User (Custom)"
+msgstr "ユーザ設定 (カスタム)"
+
+#: common/dialogs/dialog_page_settings.cpp:267
+#: common/dialogs/dialog_page_settings.cpp:713
+#: common/dialogs/dialog_page_settings_base.cpp:46
+msgid "Portrait"
+msgstr "縦向き"
+
+#: common/dialogs/dialog_page_settings.cpp:431
+#, c-format
+msgid "Page layout description file <%s> not found. Abort"
+msgstr "図枠ファイル <%s> が見つかりませんでした。中断します。"
+
+#: common/dialogs/dialog_page_settings.cpp:462
+#, c-format
+msgid ""
+"Selected custom paper size\n"
+"is out of the permissible limits\n"
+"%.1f - %.1f %s!\n"
+"Select another custom paper size?"
+msgstr ""
+"選択された用紙サイズは\n"
+"使用できる限界を超えています。\n"
+"%.1f - %.1f %s!\n"
+"他の用紙サイズを選択しますか？"
+
+#: common/dialogs/dialog_page_settings.cpp:468
+msgid "Warning!"
+msgstr "警告!"
+
+#: common/dialogs/dialog_page_settings.cpp:715
+#: common/dialogs/dialog_page_settings_base.cpp:46
+msgid "Landscape"
+msgstr "横向き"
+
+#: common/dialogs/dialog_page_settings.cpp:801
+msgid "Select Page Layout Descr File"
+msgstr "図枠ファイルの洗濯"
+
+#: common/dialogs/dialog_page_settings.cpp:819
+#, c-format
+msgid ""
+"The page layout descr filename has changed.\n"
+"Do you want to use the relative path:\n"
+"'%s'\n"
+"instead of\n"
+"'%s'"
+msgstr ""
+"図枠ファイルの指定が変更されました。\n"
+"相対パスを使用して図枠ファイルを参照しますか:\n"
+"'%s'\n"
+"(以下に代わって) \n"
+"'%s'"
+
+#: common/dialogs/dialog_page_settings_base.cpp:25
+msgid "Paper"
+msgstr "紙"
+
+#: common/dialogs/dialog_page_settings_base.cpp:36
+msgid "dummy text"
+msgstr "ダミーテキスト"
+
+#: common/dialogs/dialog_page_settings_base.cpp:42
+#: pcbnew/dialogs/dialog_orient_footprints_base.cpp:22
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:131
+msgid "Orientation:"
+msgstr "角度:"
+
+#: common/dialogs/dialog_page_settings_base.cpp:52
+msgid "Custom Size:"
+msgstr "カスタムサイズ:"
+
+#: common/dialogs/dialog_page_settings_base.cpp:62
+#: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:77
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:76
+msgid "Height:"
+msgstr "高さ:"
+
+#: common/dialogs/dialog_page_settings_base.cpp:68
+msgid "Custom paper height."
+msgstr "カスタム用紙の高さ"
+
+#: common/dialogs/dialog_page_settings_base.cpp:78
+#: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:65
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:43
+#: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:25
+#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:86
+msgid "Width:"
+msgstr "幅:"
+
+#: common/dialogs/dialog_page_settings_base.cpp:84
+msgid "Custom paper width."
+msgstr "カスタム用紙の幅"
+
+#: common/dialogs/dialog_page_settings_base.cpp:94
+msgid "Layout Preview"
+msgstr "レイアウトプレビュー"
+
+#: common/dialogs/dialog_page_settings_base.cpp:113
+msgid "Title Block Parameters"
+msgstr "図枠の設定"
+
+#: common/dialogs/dialog_page_settings_base.cpp:123
+#, c-format
+msgid "Number of sheets: %d"
+msgstr "シートの数: %d"
+
+#: common/dialogs/dialog_page_settings_base.cpp:130
+#, c-format
+msgid "Sheet number: %d"
+msgstr "シート番号: %d"
+
+#: common/dialogs/dialog_page_settings_base.cpp:140
+msgid "Issue Date"
+msgstr "変更日"
+
+#: common/dialogs/dialog_page_settings_base.cpp:153
+#: pcbnew/dialogs/dialog_design_rules_base.cpp:115
+msgid "<<<"
+msgstr "<<<"
+
+#: common/dialogs/dialog_page_settings_base.cpp:159
+#: common/dialogs/dialog_page_settings_base.cpp:184
+#: common/dialogs/dialog_page_settings_base.cpp:209
+#: common/dialogs/dialog_page_settings_base.cpp:234
+#: common/dialogs/dialog_page_settings_base.cpp:259
+#: common/dialogs/dialog_page_settings_base.cpp:284
+#: common/dialogs/dialog_page_settings_base.cpp:309
+#: common/dialogs/dialog_page_settings_base.cpp:334
+msgid "Export to other sheets"
+msgstr "他のシートへエクスポート"
+
+#: common/dialogs/dialog_page_settings_base.cpp:171
+msgid "Revision"
+msgstr "リビジョン"
+
+#: common/dialogs/dialog_page_settings_base.cpp:196
+msgid "Title"
+msgstr "タイトル"
+
+#: common/dialogs/dialog_page_settings_base.cpp:221
+msgid "Company"
+msgstr "会社名"
+
+#: common/dialogs/dialog_page_settings_base.cpp:246
+msgid "Comment1"
+msgstr "コメント1"
+
+#: common/dialogs/dialog_page_settings_base.cpp:271
+msgid "Comment2"
+msgstr "コメント2"
+
+#: common/dialogs/dialog_page_settings_base.cpp:296
+msgid "Comment3"
+msgstr "コメント3"
+
+#: common/dialogs/dialog_page_settings_base.cpp:321
+msgid "Comment4"
+msgstr "コメント4"
+
+#: common/dialogs/dialog_page_settings_base.cpp:346
+msgid "Page layout description file"
+msgstr "図枠ファイル"
+
+#: common/dialogs/dialog_page_settings_base.cpp:356
+#: kicad/dialogs/dialog_template_selector_base.cpp:36
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:210
+#: pcbnew/dialogs/dialog_gendrill_base.cpp:29
+#: pcbnew/dialogs/dialog_netlist_fbp.cpp:152
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:69
+#: pcbnew/dialogs/wizard_add_fplib_base.cpp:73
+#: pcbnew/import_dxf/dialog_dxf_import_base.cpp:33
+msgid "Browse"
+msgstr "参照"
+
+#: common/dialogs/wx_html_report_panel.cpp:130
+msgid "<b>Error: </b></font><font size=2>"
+msgstr "<b>エラー: </b></font><font size=2>"
+
+#: common/dialogs/wx_html_report_panel.cpp:132
+msgid "<b>Warning: </b></font><font size=2>"
+msgstr "<b>警告: </b></font><font size=2>"
+
+#: common/dialogs/wx_html_report_panel.cpp:134
+msgid "<b>Info: </b>"
+msgstr "<b>情報: </b>"
+
+#: common/dialogs/wx_html_report_panel.cpp:148
+msgid "Error: "
+msgstr "エラー:"
+
+#: common/dialogs/wx_html_report_panel.cpp:150
+msgid "Warning: "
+msgstr "警告: "
+
+#: common/dialogs/wx_html_report_panel.cpp:152
+msgid "Info: "
+msgstr "情報: "
+
+#: common/dialogs/wx_html_report_panel.cpp:233
+msgid "Save report to file"
+msgstr "レポートをファイルに保存"
+
+#: common/dialogs/wx_html_report_panel.cpp:250
+#, c-format
+msgid "Cannot write report to file '%s'."
+msgstr "レポートをファイル '%s' へ書き出すことが出来ませんでした."
+
+#: common/dialogs/wx_html_report_panel.cpp:252
+msgid "File save error"
+msgstr "ファイル保存エラー"
+
+#: common/draw_frame.cpp:164 common/draw_frame.cpp:481
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:31
+#: pagelayout_editor/pl_editor_frame.cpp:117
+#: pcbnew/dialogs/dialog_gen_module_position_file_base.cpp:55
+#: pcbnew/dialogs/dialog_gendrill_base.cpp:44
+#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:33
+#: pcbnew/dialogs/dialog_set_grid_base.cpp:25
+#: pcbnew/dialogs/dialog_set_grid_base.cpp:79
+#: pcbnew/dialogs/dialog_set_grid_base.cpp:91
+msgid "Inches"
+msgstr "インチ"
+
+#: common/draw_frame.cpp:322 cvpcb/class_DisplayFootprintsFrame.cpp:176
+#: pcbnew/tool_modedit.cpp:208 pcbnew/tool_pcb.cpp:337
+msgid "Hide grid"
+msgstr "グリッドを非表示"
+
+#: common/draw_frame.cpp:322
+msgid "Show grid"
+msgstr "グリッドの表示"
+
+#: common/draw_frame.cpp:489
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:33
+#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:35
+#: pcbnew/dialogs/dialog_set_grid_base.cpp:27
+#: pcbnew/footprint_wizard_frame.cpp:270
+msgid "Units"
+msgstr "単位"
+
+#: common/dsnlexer.cpp:39
+msgid "clipboard"
+msgstr "クリップボード"
+
+#: common/dsnlexer.cpp:360 common/dsnlexer.cpp:368
+#, c-format
+msgid "Expecting '%s'"
+msgstr "例外 '%s'"
+
+#: common/dsnlexer.cpp:376 common/dsnlexer.cpp:392
+#, c-format
+msgid "Unexpected '%s'"
+msgstr "例外 '%s'"
+
+#: common/dsnlexer.cpp:384
+#, c-format
+msgid "%s is a duplicate"
+msgstr "%s は重複しています"
+
+#: common/dsnlexer.cpp:437
+#, c-format
+msgid "need a NUMBER for '%s'"
+msgstr "'%s'　のための番号が必要です"
+
+#: common/dsnlexer.cpp:709 common/dsnlexer.cpp:769
+msgid "Un-terminated delimited string"
+msgstr "区切り文字で囲まれていません"
+
+#: common/dsnlexer.cpp:731
+msgid "String delimiter must be a single character of ', \", or $"
+msgstr "区切り文字は', \", か $の1文字にしてください"
+
+#: common/eda_doc.cpp:144
+#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:456
+msgid "Doc Files"
+msgstr "ドキュメント ファイル"
+
+#: common/eda_doc.cpp:159
+#, c-format
+msgid "Doc File '%s' not found"
+msgstr "ドキュメントファイル '%s' が見つかりません"
+
+#: common/eda_doc.cpp:202
+#, c-format
+msgid "Unknown MIME type for doc file <%s>"
+msgstr "ドキュメント ファイル <%s> の不明なMIMEタイプ"
+
+#: common/eda_text.cpp:378
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:182
+#: eeschema/dialogs/dialog_edit_label_base.cpp:76
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:92
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:97 eeschema/sch_text.cpp:758
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:109
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:104
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:100
+msgid "Italic"
+msgstr "斜体字"
+
+#: common/eda_text.cpp:379
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:182
+#: eeschema/dialogs/dialog_edit_label_base.cpp:76
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:92
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:97 eeschema/sch_text.cpp:758
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:90
+msgid "Bold"
+msgstr "太字"
+
+#: common/eda_text.cpp:380
+msgid "Bold+Italic"
+msgstr "<b><i>斜太字</i></b>"
+
+#: common/footprint_info.cpp:320 common/footprint_info.cpp:341
+msgid "Errors were encountered loading footprints"
+msgstr "フットプリント読み込み中にエラーが発生しました"
+
+#: common/footprint_info.cpp:339
+msgid "Load Error"
+msgstr "読込みエラー"
+
+#: common/fp_lib_table.cpp:373
+#, c-format
+msgid "'%s' is a duplicate footprint library nickName"
+msgstr "フットプリントライブラリのニックネーム<%s>は重複しています"
+
+#: common/fp_lib_table.cpp:620
+#, c-format
+msgid "fp-lib-table files contain no lib with nickname '%s'"
+msgstr "fp-lib-table ファイルは別名 '%s' のライブラリを含んでいません"
+
+#: common/fp_lib_table.cpp:716
+#, c-format
+msgid "Cannot create global library table path '%s'."
+msgstr "グローバル ライブラリ テーブルのパス '%s' が生成できません."
+
+#: common/fpid.cpp:185 common/fpid.cpp:202
+msgid "Illegal character found in FPID string"
+msgstr "FPID文字列中に不正な文字があります"
+
+#: common/fpid.cpp:306
+msgid "Illegal character found in logical library name"
+msgstr "論理的なライブラリ名の中に不正な文字があります"
+
+#: common/fpid.cpp:323 new/sch_lpid.cpp:440
+msgid "Illegal character found in revision"
+msgstr "リビジョン中に不正な文字があります"
+
+#: common/gestfich.cpp:238
+#, c-format
+msgid "Command <%s> could not found"
+msgstr "コマンド <%s> は見つかりません"
+
+#: common/gestfich.cpp:433
+#, c-format
+msgid ""
+"Problem while running the PDF viewer\n"
+"Command is '%s'"
+msgstr ""
+"PDFビューア実行中に問題が発生しました\n"
+"コマンド: '%s'"
+
+#: common/gestfich.cpp:441
+#, c-format
+msgid "Unable to find a PDF viewer for <%s>"
+msgstr "<%s> を開くためのPDFビューアが見つかりませんでした"
+
+#: common/grid_tricks.cpp:113
+msgid "Cut\tCTRL+X"
+msgstr "切り取り\tCTRL+X"
+
+#: common/grid_tricks.cpp:113
+msgid "Clear selected cells pasting original contents to clipboard"
+msgstr "クリップボードへ元の内容を保存して、選択したセルをクリア"
+
+#: common/grid_tricks.cpp:114
+msgid "Copy\tCTRL+C"
+msgstr "コピー\tCTRL+C"
+
+#: common/grid_tricks.cpp:114
+msgid "Copy selected cells to clipboard"
+msgstr "選択範囲をコピー"
+
+#: common/grid_tricks.cpp:115
+msgid "Paste\tCTRL+V"
+msgstr "ペースト\tCTRL+V"
+
+#: common/grid_tricks.cpp:115
+msgid "Paste clipboard cells to matrix at current cell"
+msgstr "現在のセル位置へ、クリップボードの内容を貼り付け"
+
+#: common/grid_tricks.cpp:116
+msgid "Select All\tCTRL+A"
+msgstr "全て選択\tCtrl+A"
+
+#: common/grid_tricks.cpp:116
+msgid "Select all cells"
+msgstr "すべてのセルを洗濯"
+
+#: common/hotkeys_basic.cpp:464 common/hotkeys_basic.cpp:493
+#: common/hotkeys_basic.cpp:497
+msgid "Hotkeys List"
+msgstr "ホットキーの一覧"
+
+#: common/hotkeys_basic.cpp:757
+msgid "Read Hotkey Configuration File:"
+msgstr "ホットキー設定ファイルの読込み:"
+
+#: common/hotkeys_basic.cpp:788
+msgid "Write Hotkey Configuration File:"
+msgstr "ホットキー設定ファイルの保存:"
+
+#: common/hotkeys_basic.cpp:817
+msgid "&List Current Keys"
+msgstr "現在のキー設定の一覧(&L)"
+
+#: common/hotkeys_basic.cpp:818
+msgid "Displays the current hotkeys list and corresponding commands"
+msgstr "現在のホットキーリストと割り付けコマンドの表示"
+
+#: common/hotkeys_basic.cpp:823
+msgid "&Edit Hotkeys"
+msgstr "ホットキーの編集(&E)"
+
+#: common/hotkeys_basic.cpp:824
+msgid "Call the hotkeys editor"
+msgstr "ホットキーエディタの呼び出し"
+
+#: common/hotkeys_basic.cpp:831
+msgid "E&xport Hotkeys"
+msgstr "ホットキー設定のエクスポート(&X)"
+
+#: common/hotkeys_basic.cpp:832
+msgid "Create a hotkey configuration file to export the current hotkeys"
+msgstr ""
+"現在のホットキー構成をエクスポートするため、ホットキー設定ファイルを作成"
+
+#: common/hotkeys_basic.cpp:837
+msgid "&Import Hotkeys"
+msgstr "ホットキー設定のインポート(&I)"
+
+#: common/hotkeys_basic.cpp:838
+msgid "Load an existing hotkey configuration file"
+msgstr "既存のホットキー構成ファイルを読込む"
+
+#: common/hotkeys_basic.cpp:843
+msgid "&Hotkeys"
+msgstr "ホットキー(&H)"
+
+#: common/hotkeys_basic.cpp:844
+msgid "Hotkeys configuration and preferences"
+msgstr "ホットキーの設定と詳細"
+
+#: common/page_layout/page_layout_reader.cpp:816
+#, c-format
+msgid "The file <%s> was not fully read"
+msgstr "ファイル <%s> が最後まで読み込めませんでした"
+
+#: common/pcbcommon.cpp:47
+msgid "No layers"
+msgstr "レイヤがありません"
+
+#: common/pcbcommon.cpp:67
+msgid "Internal"
+msgstr "内層"
+
+#: common/pcbcommon.cpp:70
+msgid "Non-copper"
+msgstr "非導体層"
+
+#: common/pgm_base.cpp:109 pcbnew/dialogs/dialog_design_rules_base.cpp:59
+#: pcbnew/dialogs/dialog_global_edit_tracks_and_vias.cpp:102
+#: pcbnew/dialogs/dialog_global_edit_tracks_and_vias.cpp:116
+#: pcbnew/dialogs/dialog_global_edit_tracks_and_vias.cpp:126
+#: pcbnew/dialogs/dialog_global_edit_tracks_and_vias.cpp:136
+#: pcbnew/dialogs/dialog_global_edit_tracks_and_vias.cpp:148
+msgid "Default"
+msgstr "標準"
+
+#: common/pgm_base.cpp:126
+msgid "French"
+msgstr "フランス語"
+
+#: common/pgm_base.cpp:134
+msgid "Finnish"
+msgstr "フィンランド語"
+
+#: common/pgm_base.cpp:142
+msgid "Spanish"
+msgstr "スペイン語"
+
+#: common/pgm_base.cpp:150
+msgid "Portuguese"
+msgstr "ポルトガル語"
+
+#: common/pgm_base.cpp:158
+msgid "Italian"
+msgstr "イタリア語"
+
+#: common/pgm_base.cpp:166
+msgid "German"
+msgstr "ドイツ語"
+
+#: common/pgm_base.cpp:174
+msgid "Greek"
+msgstr "ギリシャ語"
+
+#: common/pgm_base.cpp:182
+msgid "Slovenian"
+msgstr "スロベニア語"
+
+#: common/pgm_base.cpp:190
+msgid "Hungarian"
+msgstr "ハンガリー語"
+
+#: common/pgm_base.cpp:198
+msgid "Polish"
+msgstr "ポーランド語"
+
+#: common/pgm_base.cpp:206
+msgid "Czech"
+msgstr "チェコスロバキア語"
+
+#: common/pgm_base.cpp:214
+msgid "Russian"
+msgstr "ロシア語"
+
+#: common/pgm_base.cpp:222
+msgid "Korean"
+msgstr "韓国語"
+
+#: common/pgm_base.cpp:230
+msgid "Chinese simplified"
+msgstr "簡体中国語"
+
+#: common/pgm_base.cpp:238
+msgid "Catalan"
+msgstr "カタロニア語"
+
+#: common/pgm_base.cpp:246
+msgid "Dutch"
+msgstr "オランダ語"
+
+#: common/pgm_base.cpp:254
+msgid "Japanese"
+msgstr "日本語"
+
+#: common/pgm_base.cpp:262
+msgid "Bulgarian"
+msgstr "ブルガリア語"
+
+#: common/pgm_base.cpp:332
+msgid "No default editor found, you must choose it"
+msgstr "デフォルトのエディタが指定されていません。エディタを指定して下さい。"
+
+#: common/pgm_base.cpp:339
+msgid "Preferred Editor:"
+msgstr "エディタの指定:"
+
+#: common/pgm_base.cpp:368
+#, c-format
+msgid "%s is already running, Continue?"
+msgstr "%s は既に起動しています。続けますか？"
+
+#: common/pgm_base.cpp:744
+msgid "Language"
+msgstr "言語"
+
+#: common/pgm_base.cpp:745
+msgid "Select application language (only for testing!)"
+msgstr "アプリケーション言語の設定 (テスト用)"
+
+#: common/pgm_base.cpp:820
+msgid ""
+"Warning!  Some of paths you have configured have been defined \n"
+"externally to the running process and will be temporarily overwritten."
+msgstr ""
+"警告！ あなたが設定したいくつかのパスは、実行中のプロセスへ\n"
+"外部から定義され、現状のものを上書きします."
+
+#: common/pgm_base.cpp:822
+msgid ""
+"The next time KiCad is launched, any paths that have already\n"
+"been defined are honored and any settings defined in the path\n"
+"configuration dialog are ignored.  If you did not intend for this\n"
+"behavior, either rename any conflicting entries or remove the\n"
+"external environment variable definition(s) from your system."
+msgstr ""
+"次に kiCad を起動する時、既に定義されたパスは\n"
+"受け入れられ、パス設定ダイアログでの設定は全て\n"
+"無視されます。このような動作を望まないので\n"
+"あれば、衝突している項目をリネームし、システム\n"
+"の環境変数定義を削除して下さい。"
+
+#: common/pgm_base.cpp:829
+msgid "Do not show this message again."
+msgstr "二度とこのメッセージを表示しない"
+
+#: common/project.cpp:243
+#, c-format
+msgid "Unable to find '%s' template config file."
+msgstr "'%s' テンプレート設定ファイルが見つかりませんでした。"
+
+#: common/project.cpp:266
+#, c-format
+msgid "Cannot create prj file '%s' (Directory not writable)"
+msgstr ""
+"プロジェクトファイル '%s' を作成できません (ディレクトリは書き込み禁止)"
+
+#: common/richio.cpp:197
+#, c-format
+msgid "Unable to open filename '%s' for reading"
+msgstr "読み込み用にファイル '%s' を開けません。"
+
+#: common/richio.cpp:241 common/richio.cpp:338
+msgid "Maximum line length exceeded"
+msgstr "ライン長が超過しています。"
+
+#: common/richio.cpp:303
+msgid "Line length exceeded"
+msgstr "ライン長が超過しています。"
+
+#: common/richio.cpp:569
+#, c-format
+msgid "cannot open or save file '%s'"
+msgstr "ファイル \"%s\" を読み込み、または保存できません"
+
+#: common/richio.cpp:588 pcbnew/legacy_plugin.cpp:3268
+#, c-format
+msgid "error writing to file '%s'"
+msgstr "'%s' ファイルの書き込み中のエラー"
+
+#: common/richio.cpp:609
+msgid "OUTPUTSTREAM_OUTPUTFORMATTER write error"
+msgstr "OUTPUTSTREAM_OUTPUTFORMATTER 書き出しエラー"
+
+#: common/selcolor.cpp:85
+msgid "Colors"
+msgstr "カラー"
+
+#: common/wildcards_and_files_ext.cpp:70
+msgid "KiCad drawing symbol file (*.sym)|*.sym"
+msgstr "Kicad図形シンボル ファイル (*.sym)|*.sym"
+
+#: common/wildcards_and_files_ext.cpp:71
+msgid "KiCad component library file (*.lib)|*.lib"
+msgstr "Kicadコンポーネント ライブラリ ファイル (*.lib)|*.lib"
+
+#: common/wildcards_and_files_ext.cpp:72
+msgid "KiCad project files (*.pro)|*.pro"
+msgstr "KiCad プロジェクト ファイル (*.pro)|*.pro"
+
+#: common/wildcards_and_files_ext.cpp:73
+msgid "KiCad schematic files (*.sch)|*.sch"
+msgstr "KiCad 回路図ファイル (*.sch)|*.sch"
+
+#: common/wildcards_and_files_ext.cpp:74
+msgid "KiCad netlist files (*.net)|*.net"
+msgstr "KiCad ネットリスト ファイル (*.net)|*.net"
+
+#: common/wildcards_and_files_ext.cpp:75
+msgid "Gerber files (*.pho)|*.pho"
+msgstr "ガーバー ファイル (.pho)|*.pho)"
+
+#: common/wildcards_and_files_ext.cpp:76
+msgid "KiCad printed circuit board files (*.brd)|*.brd"
+msgstr "KiCad プリント基板ファイル (*.brd)|*.brd"
+
+#: common/wildcards_and_files_ext.cpp:77
+msgid "Eagle ver. 6.x XML PCB files (*.brd)|*.brd"
+msgstr "Eagle ver. 6.x XML PCBファイル (*.brd)|*.brd"
+
+#: common/wildcards_and_files_ext.cpp:78
+msgid "P-Cad 200x ASCII PCB files (*.pcb)|*.pcb"
+msgstr "P-Cad 200x ASCII PCBファイル (*.pcb)|*.pcb"
+
+#: common/wildcards_and_files_ext.cpp:79
+msgid "KiCad s-expr printed circuit board files (*.kicad_pcb)|*.kicad_pcb"
+msgstr "KiCad s-expre プリント基板ファイル (*.kicad_pcb)|*.kicad_pcb"
+
+#: common/wildcards_and_files_ext.cpp:80
+msgid "KiCad footprint s-expre file (*.kicad_mod)|*.kicad_mod"
+msgstr ""
+"Kicadフットプリント s-expre ライブラリファイル (*.kicad_mod)|*.kicad_mod"
+
+#: common/wildcards_and_files_ext.cpp:81
+msgid "KiCad footprint s-expre library path (*.pretty)|*.pretty"
+msgstr "Kicadフットプリント s-expre ライブラリパス  (*.pretty)|*.pretty"
+
+#: common/wildcards_and_files_ext.cpp:82
+msgid "Legacy footprint library file (*.mod)|*.mod"
+msgstr "レガシーフットプリントライブラリファイル (*.mod)|*.mod"
+
+#: common/wildcards_and_files_ext.cpp:83
+msgid "Eagle ver. 6.x XML library files (*.lbr)|*.lbr"
+msgstr "Eagle ver. 6.x XML ライブラリファイル (*.lbr)|*.lbr"
+
+#: common/wildcards_and_files_ext.cpp:84
+msgid "Geda PCB footprint library file (*.fp)|*.fp"
+msgstr "Geda PCB フットプリントライブラリファイル (*.fp)|*.fp"
+
+#: common/wildcards_and_files_ext.cpp:85
+msgid "KiCad recorded macros (*.mcr)|*.mcr"
+msgstr "KiCad マクロ記録 (*.mcr)|*.mcr"
+
+#: common/wildcards_and_files_ext.cpp:86
+msgid "Component-footprint link file (*.cmp)|*cmp"
+msgstr "コンポーネント-フットプリント関連付けファイル (*.cmp)|*.cmp"
+
+#: common/wildcards_and_files_ext.cpp:87
+msgid "Page layout descr file (*.kicad_wks)|*kicad_wks"
+msgstr "図枠ファイル (*.kicad_wks)|*kicad_wks"
+
+#: common/wildcards_and_files_ext.cpp:89
+msgid "All files (*)|*"
+msgstr "全てのファイル (*)|*"
+
+#: common/wildcards_and_files_ext.cpp:92
+msgid "KiCad cmp/footprint link files (*.cmp)|*.cmp"
+msgstr "Kicad コンポーネント-フットプリント関連付けファイル (*.cmp)|*.cmp"
+
+#: common/wildcards_and_files_ext.cpp:95
+msgid "Drill files (*.drl)|*.drl;*.DRL"
+msgstr "ドリル ファイル (*.drl)|*.drl"
+
+#: common/wildcards_and_files_ext.cpp:96
+msgid "SVG files (*.svg)|*.svg;*.SVG"
+msgstr "SVGファイル (*.svg)|*.svg;*.SVG"
+
+#: common/wildcards_and_files_ext.cpp:97
+msgid "HTML files (*.html)|*.htm;*.html"
+msgstr "HTML ファイル (*.html)|*.htm;*.html"
+
+#: common/wildcards_and_files_ext.cpp:98
+msgid "Portable document format files (*.pdf)|*.pdf"
+msgstr "PDFファイル (*.pdf)|*.pdf"
+
+#: common/wildcards_and_files_ext.cpp:99
+msgid "PostScript files (.ps)|*.ps"
+msgstr "PostScript ファイル (.ps)|*.ps"
+
+#: common/wildcards_and_files_ext.cpp:100
+msgid "Report files (*.rpt)|*.rpt"
+msgstr "レポートファイル (.rpt)|*.rpt"
+
+#: common/wildcards_and_files_ext.cpp:101
+msgid "Footprint place files (*.pos)|*.pos"
+msgstr "Footprint配置情報 (*.pos)|*.pos"
+
+#: common/wildcards_and_files_ext.cpp:102
+msgid "Vrml and x3d files (*.wrl *.x3d)|*.wrl;*.x3d"
+msgstr "Vrml / x3d ファイル (*.wrl *.x3d)|*.wrl;*.x3d"
+
+#: common/wildcards_and_files_ext.cpp:103
+msgid "IDFv3 component files (*.idf)|*.idf"
+msgstr "IDFv3 コンポーネントファイル (*.idf)|*.idf"
+
+#: common/wildcards_and_files_ext.cpp:104
+msgid "Text files (*.txt)|*.txt"
+msgstr "テキストファイル (*.txt)|*.txt"
+
+#: common/wxunittext.cpp:195
+msgid "default "
+msgstr "標準"
+
+#: common/wxwineda.cpp:61
+#, c-format
+msgid "Size%s"
+msgstr "サイズ %s"
+
+#: common/wxwineda.cpp:166 common/wxwineda.cpp:180
+msgid "Pos "
+msgstr "座標"
+
+#: common/wxwineda.cpp:170
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:90
+#: pcbnew/dialogs/dialog_target_properties_base.cpp:54
+msgid "X"
+msgstr "X"
+
+#: common/wxwineda.cpp:183
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:102
+msgid "Y"
+msgstr "Y"
+
+#: common/zoom.cpp:246
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:148
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:154
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:54
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:62
+#: gerbview/class_GERBER.cpp:363 gerbview/class_GERBER.cpp:366
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:84
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:103
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:106
+#: pcbnew/tools/common_actions.cpp:206
+msgid "Center"
+msgstr "中央"
+
+#: common/zoom.cpp:254 eeschema/tool_viewlib.cpp:90
+#: gerbview/toolbars_gerber.cpp:86 pagelayout_editor/toolbars_pl_editor.cpp:87
+#: pcbnew/footprint_wizard_frame.cpp:607 pcbnew/tool_modedit.cpp:133
+#: pcbnew/tool_modview.cpp:94
+msgid "Zoom auto"
+msgstr "自動ズーム"
+
+#: common/zoom.cpp:260
+msgid "Zoom select"
+msgstr "ズームの選択"
+
+#: common/zoom.cpp:273
+msgid "Zoom: "
+msgstr "ズーム:"
+
+#: common/zoom.cpp:284
+msgid "Grid Select"
+msgstr "グリッドの選択:"
+
+#: cvpcb/autosel.cpp:107
+#, c-format
+msgid "Equivalence file '%s' could not be found in the default search paths."
+msgstr ""
+
+#: cvpcb/autosel.cpp:128
+#, c-format
+msgid "Error opening equivalence file '%s'."
+msgstr ""
+
+#: cvpcb/autosel.cpp:180
+msgid "Equivalence File Load Error"
+msgstr ""
+
+#: cvpcb/autosel.cpp:188
+#, c-format
+msgid "%lu footprint/cmp equivalences found."
+msgstr ""
+
+#: cvpcb/autosel.cpp:254
+#, c-format
+msgid ""
+"Component %s: footprint %s not found in any of the project footprint "
+"libraries."
+msgstr ""
+"コンポーネント %s: フットプリント %s は、どのプロジェクトフットプリントライブ"
+"ラリにも存在しません。"
+
+#: cvpcb/autosel.cpp:288
+msgid "CvPcb Warning"
+msgstr "CvPcbの警告"
+
+#: cvpcb/cfg.cpp:79 cvpcb/dialogs/dialog_config_equfiles.cpp:52
+#, c-format
+msgid "Project file: '%s'"
+msgstr "プロジェクトファイル: '%s'"
+
+#: cvpcb/cfg.cpp:84
+#, c-format
+msgid "Project file '%s' is not writable"
+msgstr "プロジェクトファイル '%s' は書き込み禁止されています"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:75
+msgid "Footprint Viewer"
+msgstr "フットプリント ビューア"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:180 pcbnew/basepcbframe.cpp:466
+#: pcbnew/tool_pcb.cpp:340
+msgid "Display polar coordinates"
+msgstr "極座標表示"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:184 eeschema/tool_lib.cpp:232
+#: pcbnew/tool_modedit.cpp:216 pcbnew/tool_pcb.cpp:343
+msgid "Units in inches"
+msgstr "インチ単位"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:188 eeschema/tool_lib.cpp:236
+#: pcbnew/tool_modedit.cpp:220 pcbnew/tool_pcb.cpp:346
+msgid "Units in millimeters"
+msgstr "ミリメートル単位"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:192 eeschema/tool_lib.cpp:240
+#: eeschema/tool_sch.cpp:285 gerbview/toolbars_gerber.cpp:167
+#: pcbnew/tool_pcb.cpp:349
+msgid "Change cursor shape"
+msgstr "カーソルの形を変える"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:197 pcbnew/basepcbframe.cpp:476
+#: pcbnew/tool_pcb.cpp:379
+msgid "Show pads in outline mode"
+msgstr "アウトライン モードでパッドを表示"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:201
+msgid "Show texts in line mode"
+msgstr "テキストをラインモードで表示"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:205
+msgid "Show outlines in line mode"
+msgstr "外形をラインモードで表示"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:220
+msgid "Display options"
+msgstr "表示オプション"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:225
+msgid "Zoom in (F1)"
+msgstr "ズーム イン (F1)"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:228
+msgid "Zoom out (F2)"
+msgstr "ズーム アウト (F2)"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:231
+msgid "Redraw view (F3)"
+msgstr "ビューの再描画 (F3)"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:234
+msgid "Zoom auto (Home)"
+msgstr "自動ズーム (Home)"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:238
+msgid "3D Display (Alt+3)"
+msgstr "3D表示 (Alt+3)"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:250
+msgid "Show texts in filled mode"
+msgstr "テキストを塗りつぶしモードで表示"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:251
+msgid "Show texts in sketch mode"
+msgstr "テキストをスケッチモードで表示"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:265
+msgid "Show outlines in filled mode"
+msgstr "外形を塗りつぶしモードで表示"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:266
+#: pcbnew/dialogs/dialog_display_options_base.cpp:70
+msgid "Show outlines in sketch mode"
+msgstr "外形をスケッチモードで表示"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:401 pcbnew/moduleframe.cpp:691
+#: pcbnew/pcbframe.cpp:656
+msgid "3D Viewer"
+msgstr "3Dビューア"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:472
+#, c-format
+msgid "Footprint '%s' not found"
+msgstr "フットプリント '%s' が見つかりません。"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:488
+#, c-format
+msgid "Footprint: %s"
+msgstr "フットプリント: %s"
+
+#: cvpcb/class_DisplayFootprintsFrame.cpp:500
+#, c-format
+msgid "Lib: %s"
+msgstr "ライブラリ: %s"
+
+#: cvpcb/cvframe.cpp:246
+msgid ""
+"Component to Footprint links modified.\n"
+"Save before exit ?"
+msgstr ""
+"コンポーネントとフットプリントとの関連付けが変更されています。。\n"
+"終了前に保存しますか？"
+
+#: cvpcb/cvframe.cpp:373
+msgid "Delete selections"
+msgstr "選択の削除"
+
+#: cvpcb/cvframe.cpp:453
+#, c-format
+msgid ""
+"Error occurred saving the global footprint library table:\n"
+"'%s'\n"
+"%s"
+msgstr ""
+"グローバル フットプリント ライブラリ テーブルの保存中にエラーが発生しまし"
+"た:\n"
+"'%s'\n"
+"%s"
+
+#: cvpcb/cvframe.cpp:457 cvpcb/cvframe.cpp:477 pcbnew/moduleframe.cpp:863
+#: pcbnew/moduleframe.cpp:883 pcbnew/pcbnew_config.cpp:142
+#: pcbnew/pcbnew_config.cpp:164
+msgid "File Save Error"
+msgstr "ファイル保存エラー"
+
+#: cvpcb/cvframe.cpp:473
+#, c-format
+msgid ""
+"Error occurred saving the project footprint library table:\n"
+"'%s'\n"
+"%s"
+msgstr ""
+"プロジェクト フットプリント ライブラリ テーブルの保存中にエラーが発生しまし"
+"た:\n"
+"'%s'\n"
+"%s"
+
+#: cvpcb/cvframe.cpp:605
+#, c-format
+msgid "Components: %d, unassigned: %d"
+msgstr "コンポーネント: %d  (未割付: %d)"
+
+#: cvpcb/cvframe.cpp:623
+msgid "Filter list: "
+msgstr "フィルター: "
+
+#: cvpcb/cvframe.cpp:636 pcbnew/loadcmp.cpp:479
+msgid "Description: "
+msgstr "説明:"
+
+#: cvpcb/cvframe.cpp:639
+msgid "Key words: "
+msgstr "キーワード: "
+
+#: cvpcb/cvframe.cpp:650
+msgid "key words"
+msgstr "キーワード"
+
+#: cvpcb/cvframe.cpp:657
+msgid "pin count"
+msgstr "ピン数"
+
+#: cvpcb/cvframe.cpp:665
+msgid "library"
+msgstr "ライブラリ"
+
+#: cvpcb/cvframe.cpp:669
+msgid "No filtering"
+msgstr "絞り込みなし"
+
+#: cvpcb/cvframe.cpp:671
+#, c-format
+msgid "Filtered by %s"
+msgstr "フィルター: %s"
+
+#: cvpcb/cvframe.cpp:687
+msgid ""
+"No PCB footprint libraries are listed in the current footprint library table."
+msgstr ""
+"現在の フットプリント ライブラリ テーブルには、 PCB フットプリントライブラリ"
+"がありません。"
+
+#: cvpcb/cvframe.cpp:688
+msgid "Configuration Error"
+msgstr "構成エラー"
+
+#: cvpcb/cvframe.cpp:711
+#, c-format
+msgid "Project: '%s'"
+msgstr "プロジェクト: '%s'"
+
+#: cvpcb/cvframe.cpp:716 eeschema/libedit.cpp:61 eeschema/schframe.cpp:1312
+#: kicad/prjconfig.cpp:335 pcbnew/moduleframe.cpp:763 pcbnew/pcbframe.cpp:977
+msgid " [Read Only]"
+msgstr " [読み取り専用]"
+
+#: cvpcb/cvframe.cpp:719
+msgid "[no project]"
+msgstr "[プロジェクトなし]"
+
+#: cvpcb/cvframe.cpp:762 pcbnew/netlist.cpp:93
+#, c-format
+msgid ""
+"Error loading netlist.\n"
+"%s"
+msgstr ""
+"ネットリスト読み込み中のエラーです。\n"
+"%s"
+
+#: cvpcb/cvframe.cpp:763 pcbnew/dialogs/dialog_netlist.cpp:431
+#: pcbnew/netlist.cpp:94
+msgid "Netlist Load Error"
+msgstr "ネットリストの読み込みエラー"
+
+#: cvpcb/cvpcb.cpp:57
+msgid "Component/footprint equ files (*.equ)|*.equ"
+msgstr "コンポーネント/フットプリントのequファイル (*.equ)|*.equ"
+
+#: cvpcb/cvpcb.cpp:170
+msgid ""
+"You have run CvPcb for the first time using the new footprint library table "
+"method for finding footprints.  CvPcb has either copied the default table or "
+"created an empty table in your home folder.  You must first configure the "
+"library table to include all footprint libraries not included with KiCad.  "
+"See the \"Footprint Library Table\" section of the CvPcb documentation for "
+"more information."
+msgstr ""
+"始めにフットプリントの検索に新しいフットプリントライブラリテーブルを使うよう "
+"CvPcb を実行します。 CvPcb はデフォルト テーブルをコピーし、あなたのホーム"
+"フォルダへ空のテーブルを作ります。あなたはまず KiCad がデフォルトで含んでいな"
+"い全てのフットプリントを含んだライブラリテーブルを設定しなければなりません。"
+"詳細は CvPcb マニュアルの \"フットプリント ライブラリ テーブル\" の章を参照し"
+"て下さい。"
+
+#: cvpcb/cvpcb.cpp:184 pcbnew/pcbnew.cpp:339
+#, c-format
+msgid ""
+"An error occurred attempting to load the global footprint library table:\n"
+"\n"
+"%s"
+msgstr ""
+"グローバル フットプリント ライブラリ テーブルを読み込もうとしたところ、エラー"
+"が発生しました。\n"
+"\n"
+"%s"
+
+#: cvpcb/dialogs/dialog_config_equfiles.cpp:99
+msgid "No editor defined in Kicad. Please chose it"
+msgstr "エディタが設定されていません。一つ選択してください。"
+
+#: cvpcb/dialogs/dialog_config_equfiles.cpp:259
+msgid "Equ files:"
+msgstr "Equファイル:"
+
+#: cvpcb/dialogs/dialog_config_equfiles.cpp:304
+#, c-format
+msgid "File '%s' already exists in list"
+msgstr "ファイル '%s' は既にリスト中に存在します"
+
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:20
+msgid "Footprint/Component equ files (.equ files)"
+msgstr "フットプリント/コンポーネントequファイル(.equ ファイル)"
+
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:39
+#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:48
+#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:93
+#: pcbnew/dialogs/dialog_design_rules_base.cpp:79
+#: pcbnew/tools/common_actions.cpp:129
+msgid "Remove"
+msgstr "削除"
+
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:40
+#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:49
+msgid "Unload the selected library"
+msgstr "選択したライブラリを削除"
+
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:44
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:134
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:40
+#: pcbnew/dialogs/dialog_design_rules_base.cpp:84
+#: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:146
+#: pcbnew/dialogs/dialog_fp_plugin_options_base.cpp:67
+msgid "Move Up"
+msgstr "上に移動"
+
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:50
+msgid "Edit Equ File"
+msgstr "Equファイルの編集"
+
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:65
+msgid "Available environment variables for relative paths:"
+msgstr "相対パス用の有効な環境変数:"
+
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:83
+#: eeschema/dialogs/dialog_color_config.cpp:79
+#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:186
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:184
+#: eeschema/dialogs/dialog_rescue_each.cpp:108 eeschema/lib_field.cpp:581
+#: eeschema/lib_field.cpp:759 eeschema/onrightclick.cpp:423
+#: eeschema/sch_component.cpp:1518 eeschema/template_fieldnames.cpp:42
+#: pcbnew/class_edge_mod.cpp:261 pcbnew/class_text_mod.cpp:365
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:43
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:59
+#: pcbnew/dialogs/dialog_fp_plugin_options_base.cpp:40
+#: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:31
+#: pcbnew/footprint_wizard_frame.cpp:269
+msgid "Value"
+msgstr "定数"
+
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:101
+msgid "Absolute path"
+msgstr "絶対パス"
+
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:101
+msgid "Relative path"
+msgstr "相対パス"
+
+#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:103
+msgid "Path option:"
+msgstr "環境変数の設定:"
+
+#: cvpcb/dialogs/dialog_display_options_base.cpp:23
+msgid "Draw options"
+msgstr "表示オプション"
+
+#: cvpcb/dialogs/dialog_display_options_base.cpp:25
+msgid "Graphic items sketch mode"
+msgstr "図形アイテムをスケッチモードで表示"
+
+#: cvpcb/dialogs/dialog_display_options_base.cpp:28
+msgid "Texts sketch mode"
+msgstr "テキストをスケッチモードで表示"
+
+#: cvpcb/dialogs/dialog_display_options_base.cpp:31
+msgid "Pad sketch mode"
+msgstr "パッドをスケッチモードで描画"
+
+#: cvpcb/dialogs/dialog_display_options_base.cpp:34
+msgid "Show pad &number"
+msgstr "パッド番号を表示(&N)"
+
+#: cvpcb/dialogs/dialog_display_options_base.cpp:41
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:84
+#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:163
+msgid "Pan and Zoom"
+msgstr "拡大縮小"
+
+#: cvpcb/dialogs/dialog_display_options_base.cpp:43
+msgid "Do not center and warp cusor on zoom"
+msgstr "拡大縮小時にカーソルを中心へ移動させない"
+
+#: cvpcb/dialogs/dialog_display_options_base.cpp:44
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:194
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:87
+#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:167
+msgid "Keep the cursor at its current location when zooming"
+msgstr "拡大縮小時に現在のカーソル位置を保持する"
+
+#: cvpcb/dialogs/dialog_display_options_base.cpp:48
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:91
+msgid "Use middle mouse button to pan"
+msgstr "画面のパンにマウスの中ボタンを使う"
+
+#: cvpcb/dialogs/dialog_display_options_base.cpp:51
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:94
+msgid "Limit panning to scroll size"
+msgstr "パン可能な領域を、スクロールバーサイズ範囲内に制限する"
+
+#: cvpcb/dialogs/fp_conflict_assignment_selector.cpp:37
+msgid "Ref"
+msgstr "リファレンス"
+
+#: cvpcb/dialogs/fp_conflict_assignment_selector.cpp:38
+msgid "Schematic assignment"
+msgstr "回路図の割り当て"
+
+#: cvpcb/dialogs/fp_conflict_assignment_selector.cpp:41
+msgid "Cmp file assignment"
+msgstr "Cmpファイルの割り当て"
+
+#: cvpcb/menubar.cpp:69
+msgid "&Save Edits\tCtrl+S"
+msgstr "編集を保存(&S)\tCtrl+S"
+
+#: cvpcb/menubar.cpp:76 eeschema/dialogs/dialog_erc_base.cpp:98
+#: eeschema/menubar.cpp:170 gerbview/menubar.cpp:145 kicad/menubar.cpp:279
+#: pagelayout_editor/menubar.cpp:111 pcbnew/menubar_pcbframe.cpp:272
+msgid "&Close"
+msgstr "閉じる(&C)"
+
+#: cvpcb/menubar.cpp:76
+msgid "Close CvPcb"
+msgstr "CvPcbの終了"
+
+#: cvpcb/menubar.cpp:83
+msgid "Footprint Li&braries"
+msgstr "フットプリントライブラリ(&B)"
+
+#: cvpcb/menubar.cpp:83 pcbnew/menubar_modedit.cpp:312
+#: pcbnew/menubar_pcbframe.cpp:487
+msgid "Configure footprint libraries"
+msgstr "フットプリント ライブラリの設定"
+
+#: cvpcb/menubar.cpp:89 kicad/menubar.cpp:306 pcbnew/menubar_modedit.cpp:318
+#: pcbnew/menubar_pcbframe.cpp:493
+msgid "Configure Pa&ths"
+msgstr "環境変数の設定(&T)"
+
+#: cvpcb/menubar.cpp:90 kicad/menubar.cpp:307 pcbnew/menubar_modedit.cpp:319
+#: pcbnew/menubar_pcbframe.cpp:494
+msgid "Edit path configuration environment variables"
+msgstr "環境変数の設定"
+
+#: cvpcb/menubar.cpp:94
+msgid "Edit &Equ Files List"
+msgstr "Equファイルリストの編集(&E)"
+
+#: cvpcb/menubar.cpp:95
+msgid ""
+"Setup equ files list (.equ files)\n"
+"They are files which give the footprint name from the component value"
+msgstr ""
+"等価ファイル (.equ ファイル) のセットアップ\n"
+"これはコンポーネントの名前からフットプリント名を割り当てるためのファイルです"
+
+#: cvpcb/menubar.cpp:104
+msgid "&Keep Open On Save"
+msgstr "保存後に終了しない(&K)"
+
+#: cvpcb/menubar.cpp:105
+msgid "Prevent CvPcb from exiting after saving netlist file"
+msgstr "ネットリストファイル保存後もCvPcbを継続"
+
+#: cvpcb/menubar.cpp:113
+msgid "&Save Project File"
+msgstr "プロジェクトへ設定を保存(&S)"
+
+#: cvpcb/menubar.cpp:114
+msgid "Save changes to the project configuration file"
+msgstr "プロジェクト設定ファイルの変更を保存"
+
+#: cvpcb/menubar.cpp:124
+msgid "CvPcb &Manual"
+msgstr ""
+
+#: cvpcb/menubar.cpp:125
+msgid "Open CvPcb Manual"
+msgstr ""
+
+#: cvpcb/menubar.cpp:130 eeschema/menubar.cpp:494
+#: eeschema/menubar_libedit.cpp:269 eeschema/tool_viewlib.cpp:255
+#: gerbview/menubar.cpp:230 kicad/menubar.cpp:412
+#: pagelayout_editor/menubar.cpp:157 pcbnew/menubar_modedit.cpp:346
+#: pcbnew/menubar_pcbframe.cpp:651 pcbnew/tool_modview.cpp:194
+msgid "&Getting Started in KiCad"
+msgstr "KiCadを始めよう(&G)"
+
+#: cvpcb/menubar.cpp:131 eeschema/menubar.cpp:495 gerbview/menubar.cpp:231
+#: kicad/menubar.cpp:413 pagelayout_editor/menubar.cpp:158
+msgid "Open \"Getting Started in KiCad\" guide for beginners"
+msgstr "チュートリアル\"KiCadを始めよう\"を開く"
+
+#: cvpcb/menubar.cpp:136 eeschema/menubar.cpp:501
+#: eeschema/menubar_libedit.cpp:278 gerbview/menubar.cpp:237
+#: pagelayout_editor/menubar.cpp:164 pcbnew/menubar_modedit.cpp:353
+#: pcbnew/menubar_pcbframe.cpp:657
+msgid "&About Kicad"
+msgstr ""
+
+#: cvpcb/menubar.cpp:137 eeschema/menubar.cpp:502
+#: eeschema/menubar_libedit.cpp:279 gerbview/menubar.cpp:238
+#: pagelayout_editor/menubar.cpp:165 pcbnew/menubar_modedit.cpp:354
+#: pcbnew/menubar_pcbframe.cpp:658
+msgid "About Kicad"
+msgstr ""
+
+#: cvpcb/menubar.cpp:143 eeschema/menubar.cpp:512
+#: eeschema/menubar_libedit.cpp:288 eeschema/tool_viewlib.cpp:270
+#: gerbview/menubar.cpp:245 kicad/menubar.cpp:430
+#: pagelayout_editor/menubar.cpp:171 pcbnew/menubar_modedit.cpp:364
+#: pcbnew/menubar_pcbframe.cpp:671 pcbnew/tool_modview.cpp:209
+msgid "&Help"
+msgstr "ヘルプ(&H)"
+
+#: cvpcb/readwrite_dlgs.cpp:196
+msgid ""
+"Some of the assigned footprints are legacy entries (are missing lib "
+"nicknames). Would you like CvPcb to attempt to convert them to the new "
+"required FPID format? (If you answer no, then these assignments will be "
+"cleared out and you will have to re-assign these footprints yourself.)"
+msgstr ""
+"配置されたフットプリントのいくつかは、(ライブラリの別名がない)古い形式です. "
+"CvPcb を使って新しく必要な FPID フォーマットへの変換を試みますか？ (ノーを選"
+"択した場合、これらの配置は消去され、各々のフットプリントを手動で再配置する必"
+"要があります.)"
+
+#: cvpcb/readwrite_dlgs.cpp:229
+#, c-format
+msgid "Component '%s' footprint '%s' was <b>not found</b> in any library.\n"
+msgstr ""
+"コンポーネント '%s' フットプリント '%s' がどのライブラリからも<b>見つかりませ"
+"んでした</b>\n"
+
+#: cvpcb/readwrite_dlgs.cpp:237
+#, c-format
+msgid "Component '%s' footprint '%s' was found in <b>multiple</b> libraries.\n"
+msgstr ""
+"コンポーネント '%s' フットプリント '%s' が<b>複数のライブラリから</b>見つかり"
+"ました\n"
+
+#: cvpcb/readwrite_dlgs.cpp:250
+msgid "First check your footprint library table entries."
+msgstr "最初にフットプリントライブラリ一覧の内容を確認して下さい。"
+
+#: cvpcb/readwrite_dlgs.cpp:252
+msgid "Problematic Footprint Library Tables"
+msgstr "フットプリントライブラリのエラー"
+
+#: cvpcb/readwrite_dlgs.cpp:260
+msgid ""
+"The following errors occurred attempting to convert the footprint "
+"assignments:\n"
+"\n"
+msgstr ""
+"フットプリントの割り当て処理中に下記のエラーが発生しました:\n"
+"\n"
+
+#: cvpcb/readwrite_dlgs.cpp:263
+msgid ""
+"\n"
+"You will need to reassign them manually if you want them to be updated "
+"correctly the next time you import the netlist in Pcbnew."
+msgstr ""
+"\n"
+"次回 Pcbnew にネットリストをインポートする時に正しくアップデートされているた"
+"めには、手動で再配置する必要があります"
+
+#: cvpcb/readwrite_dlgs.cpp:379
+msgid "Edits sent to Eeschema"
+msgstr "Eeschema へ編集内容を送る"
+
+#: cvpcb/tool_cvpcb.cpp:57
+msgid "Edit footprint library table"
+msgstr "フットプリントライブラリ一覧の編集"
+
+#: cvpcb/tool_cvpcb.cpp:62
+msgid "View selected footprint"
+msgstr "選択したフットプリントを見る"
+
+#: cvpcb/tool_cvpcb.cpp:67
+msgid "Select previous unlinked component"
+msgstr "前の関連付けの無いコンポーネントを選択"
+
+#: cvpcb/tool_cvpcb.cpp:71
+msgid "Select next unlinked component"
+msgstr "次の関連付けの無いコンポーネントを選択"
+
+#: cvpcb/tool_cvpcb.cpp:76
+msgid "Perform automatic footprint association"
+msgstr "フットプリントの関連付けを自動実行する"
+
+# what is associations
+#: cvpcb/tool_cvpcb.cpp:80
+msgid "Delete all associations (links)"
+msgstr "全ての関連付けを削除"
+
+#: cvpcb/tool_cvpcb.cpp:85
+msgid "Display footprint documentation"
+msgstr "フットプリントのドキュメントを表示"
+
+#: cvpcb/tool_cvpcb.cpp:92
+msgid "Filter footprint list by keywords"
+msgstr "キーワードでフットプリントを絞込み"
+
+#: cvpcb/tool_cvpcb.cpp:99
+msgid "Filter footprint list by pin count"
+msgstr "ピン数でフットプリントを絞込み"
+
+#: cvpcb/tool_cvpcb.cpp:105
+msgid "Filter footprint list by library"
+msgstr "ライブラリでフットプリントを絞込み"
+
+#: eeschema/annotate.cpp:89
+#, c-format
+msgid "%d duplicate time stamps were found and replaced."
+msgstr "%d 重複したタイムスタンプが見つかり、置き換えられました。"
+
+#: eeschema/backanno.cpp:225
+msgid "Load Component Footprint Link File"
+msgstr "コンポーネントとフットプリントの関連付けファイルの読み込み"
+
+#: eeschema/backanno.cpp:239
+msgid "Keep existing footprint field visibility"
+msgstr "既存フットプリントのフィールドの表示設定を変更しない"
+
+#: eeschema/backanno.cpp:240
+msgid "Show all footprint fields"
+msgstr "全てのフットプリントフィールドを表示"
+
+#: eeschema/backanno.cpp:241
+msgid "Hide all footprint fields"
+msgstr "全てのフットプリントフィールドを隠す"
+
+#: eeschema/backanno.cpp:243
+msgid "Select the footprint field visibility setting."
+msgstr "フットプリントのフィールドの表示設定を選択する."
+
+#: eeschema/backanno.cpp:244
+msgid "Change Visibility"
+msgstr "表示設定の変更"
+
+#: eeschema/backanno.cpp:255
+#, c-format
+msgid "Failed to open component-footprint link file '%s'"
+msgstr ""
+"コンポーネントとフットプリントの関連付けファイル '%s' が開けませんでした"
+
+#: eeschema/block.cpp:458
+msgid "No item to paste."
+msgstr "ペーストするアイテムがありません！"
+
+#: eeschema/block.cpp:488 eeschema/sheet.cpp:249
+#, c-format
+msgid ""
+"The sheet changes cannot be made because the destination sheet already has "
+"the sheet <%s> or one of it's subsheets as a parent somewhere in the "
+"schematic hierarchy."
+msgstr ""
+"シートの変更ができません。保存先のシートは、既にシート <%s> を持っているか、"
+"階層のどこかで親シートとしてサブシートの一つに持っています."
+
+#: eeschema/class_drc_erc_item.cpp:40
+msgid "ERC err unspecified"
+msgstr "不明なERCエラー"
+
+#: eeschema/class_drc_erc_item.cpp:42
+msgid "Duplicate sheet names within a given sheet"
+msgstr "与えられたシートの中でシート名が重複しています"
+
+#: eeschema/class_drc_erc_item.cpp:44
+msgid "Pin not connected (and no connect symbol found on this pin)"
+msgstr ""
+"ピンは接続されていません (そして、このピンに接続するシンボルが見つかりません)"
+
+#: eeschema/class_drc_erc_item.cpp:46
+msgid "Pin connected to some others pins but no pin to drive it"
+msgstr "ピンは他のピンと接続されていますが、このピンを駆動するピンがありません"
+
+#: eeschema/class_drc_erc_item.cpp:48
+msgid "Conflict problem between pins. Severity: warning"
+msgstr "ピン間の衝突問題。　重大度: 警告"
+
+#: eeschema/class_drc_erc_item.cpp:50
+msgid "Conflict problem between pins. Severity: error"
+msgstr "ピン間の衝突問題。　重大度: エラー"
+
+#: eeschema/class_drc_erc_item.cpp:52
+msgid "Mismatch between hierarchical labels and pins sheets"
+msgstr "階層ラベルとピンシート間のミスマッチ"
+
+#: eeschema/class_drc_erc_item.cpp:54
+msgid "A no connect symbol is connected to more than 1 pin"
+msgstr "未接続シンボルが1つ以上のピンと接続しています"
+
+#: eeschema/class_drc_erc_item.cpp:56
+msgid "Global label not connected to any other global label"
+msgstr ""
+
+#: eeschema/class_libentry.cpp:108 eeschema/class_libentry.cpp:268
+msgid "none"
+msgstr "なし"
+
+#: eeschema/class_libentry.cpp:531
+#, c-format
+msgid ""
+"An attempt was made to remove the %s field from component %s in library %s."
+msgstr ""
+"フィールド %s は、コンポーネント %s  (ライブラリ %s 中) から削除されようとし"
+"ています。"
+
+#: eeschema/class_library.cpp:53
+#, c-format
+msgid ""
+"Library '%s' has duplicate entry name '%s'.\n"
+"This may cause some unexpected behavior when loading components into a "
+"schematic."
+msgstr ""
+"ライブラリ '%s' は重複するエントリ名 '%s' を持っています。\n"
+"回路図にコンポーネントを読み込む際に予期せぬ動作が発生する可能性があります。"
+
+#: eeschema/class_library.cpp:300
+#, c-format
+msgid "Cannot add duplicate alias '%s' to library '%s'."
+msgstr "重複したエイリアス'%s'をライブラリ'%s'に追加できません。"
+
+#: eeschema/class_library.cpp:467
+msgid "The component library file name is not set."
+msgstr "コンポーネント ライブラリ ファイル名がセットされていません。"
+
+#: eeschema/class_library.cpp:475
+msgid "The file could not be opened."
+msgstr "そのファイルは開けません。"
+
+#: eeschema/class_library.cpp:483
+msgid "The file is empty!"
+msgstr "ファイルが空です！"
+
+#: eeschema/class_library.cpp:508
+msgid "The file is NOT an Eeschema library!"
+msgstr "このファイルは Eeschema ライブラリではありません"
+
+#: eeschema/class_library.cpp:514
+msgid "The file header is missing version and time stamp information."
+msgstr "ファイルのヘッダからバージョンとタイムスタンプの情報が失われています。"
+
+#: eeschema/class_library.cpp:558
+msgid "An error occurred attempting to read the header."
+msgstr "ヘッダの読込み中にエラーが発生しました。"
+
+#: eeschema/class_library.cpp:587
+#, c-format
+msgid "Library '%s' component load error %s."
+msgstr "ライブラリ '%s' コンポーネント読込みエラー %s。"
+
+#: eeschema/class_library.cpp:660
+#, c-format
+msgid "Could not open component document library file '%s'."
+msgstr "コンポーネント ドキュメント ライブラリ ファイル '%s' を開けません."
+
+#: eeschema/class_library.cpp:667
+#, c-format
+msgid "Part document library file '%s' is empty."
+msgstr "コンポーネントのドキュメント ライブラリ ファイル '%s' が空です。"
+
+#: eeschema/class_library.cpp:675
+#, c-format
+msgid "File '%s' is not a valid component library document file."
+msgstr ""
+"ファイル '%s' は不正なコンポーネント ライブラリ ドキュメント ファイルです。"
+
+#: eeschema/class_library.cpp:1074
+#, c-format
+msgid "Unable to load project's '%s' file"
+msgstr "プロジェクト '%s' をロードできません"
+
+#: eeschema/class_library.cpp:1165
+#, c-format
+msgid ""
+"Part library '%s' failed to load. Error:\n"
+"%s"
+msgstr ""
+"パーツライブラリ '%s' の読み込みに失敗しました。エラー:\n"
+"%s"
+
+#: eeschema/class_library.cpp:1190
+#, c-format
+msgid ""
+"Part library '%s' failed to load.\n"
+"Error: %s"
+msgstr ""
+"パーツライブラリ '%s' の読み込みに失敗しました。エラー:\n"
+"エラー: %s"
+
+#: eeschema/component_references_lister.cpp:521
+#, c-format
+msgid "Item not annotated: %s%s (unit %d)\n"
+msgstr "次のアイテムがアノテートされませんでした: %s%s (ユニット %d)\n"
+
+#: eeschema/component_references_lister.cpp:528
+#, c-format
+msgid "Item not annotated: %s%s\n"
+msgstr "次のアイテムがアノテートされませんでした: %s%s\n"
+
+#: eeschema/component_references_lister.cpp:551
+#, c-format
+msgid "Error item %s%s unit %d and no more than %d parts\n"
+msgstr "エラー : アイテム %s%s ユニット %d は %d パーツしかありません\n"
+
+#: eeschema/component_references_lister.cpp:591
+#: eeschema/component_references_lister.cpp:623
+#, c-format
+msgid "Multiple item %s%s (unit %d)\n"
+msgstr "複数のアイテム %s%s (ユニット %d)\n"
+
+#: eeschema/component_references_lister.cpp:598
+#: eeschema/component_references_lister.cpp:630
+#, c-format
+msgid "Multiple item %s%s\n"
+msgstr "複数のアイテム %s%s\n"
+
+#: eeschema/component_references_lister.cpp:646
+#, c-format
+msgid "Different values for %s%d%s (%s) and %s%d%s (%s)"
+msgstr "値に相違があります %s%d%s (%s) :: %s%d%s (%s)"
+
+#: eeschema/component_references_lister.cpp:681
+#, c-format
+msgid "Duplicate time stamp (%s) for %s%d and %s%d"
+msgstr "重複するタイムスタンプ - (%s) %s%d と %s%d のもの"
+
+#: eeschema/component_tree_search_container.cpp:203
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:25
+#: eeschema/lib_draw_item.cpp:72 eeschema/libedit.cpp:493
+#: eeschema/onrightclick.cpp:465
+#: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:38
+#: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:50
+#: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:62
+#: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:74
+#: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:113
+#: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:125
+#: pcbnew/dialogs/dialog_layers_setup_base.cpp:70
+#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:35
+#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:47
+#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:59
+#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:71
+#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:94
+#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:138
+#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:150
+#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:173
+#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:185
+msgid "Unit"
+msgstr "ユニット"
+
+#: eeschema/controle.cpp:165 eeschema/libeditframe.cpp:1251
+msgid "Clarify Selection"
+msgstr "明示的な選択:"
+
+#: eeschema/dialogs/dialog_annotate.cpp:195
+msgid "Clear and annotate all of the components on the entire schematic?"
+msgstr ""
+"全回路図の全てコンポーネントについて、アノテーションをクリアしてやり直します"
+"か？"
+
+#: eeschema/dialogs/dialog_annotate.cpp:197
+msgid "Clear and annotate all of the components on the current sheet?"
+msgstr ""
+"現在のシートの全てコンポーネントについて、アノテーションをクリアしてやり直し"
+"ますか？"
+
+#: eeschema/dialogs/dialog_annotate.cpp:203
+msgid "Annotate only the unannotated components on the entire schematic?"
+msgstr ""
+"全回路図のアノテートされていないコンポーネントに対してのみ、アノテーションを"
+"実行しますか？"
+
+#: eeschema/dialogs/dialog_annotate.cpp:205
+msgid "Annotate only the unannotated components on the current sheet?"
+msgstr ""
+"現在のシートのアノテートされていないコンポーネントに対してのみ、アノテーショ"
+"ンを実行しますか？"
+
+#: eeschema/dialogs/dialog_annotate.cpp:208
+msgid ""
+"\n"
+"\n"
+"This operation will change the current annotation and cannot be undone."
+msgstr ""
+"\n"
+"\n"
+"この操作は現在のアノテーションを変更し、取り消すことができません。"
+
+#: eeschema/dialogs/dialog_annotate.cpp:248
+msgid "Clear the existing annotation for the entire schematic?"
+msgstr "全回路図の既存のアノテーションを削除しますか？"
+
+#: eeschema/dialogs/dialog_annotate.cpp:250
+msgid "Clear the existing annotation for the current sheet?"
+msgstr "現在のシートの既存のアノテーションを削除しますか？"
+
+#: eeschema/dialogs/dialog_annotate.cpp:252
+msgid ""
+"\n"
+"\n"
+"This operation will clear the existing annotation and cannot be undone."
+msgstr ""
+"\n"
+"\n"
+"この操作は既存のアノテーションをクリアし、取り消すことができません。"
+
+#: eeschema/dialogs/dialog_annotate_base.cpp:28
+msgid "Scope"
+msgstr "実行範囲"
+
+#: eeschema/dialogs/dialog_annotate_base.cpp:37
+msgid "Use the &entire schematic"
+msgstr "全ての回路図、階層を使用(&E)"
+
+#: eeschema/dialogs/dialog_annotate_base.cpp:40
+msgid "Use the current &page only"
+msgstr "現在のページでのみ使用(&P)"
+
+#: eeschema/dialogs/dialog_annotate_base.cpp:46
+msgid "&Keep existing annotation"
+msgstr "既存のアノテーションをキープ(&K)"
+
+#: eeschema/dialogs/dialog_annotate_base.cpp:49
+msgid "&Reset existing annotation"
+msgstr "既存のアノテーションをリセット(&R)"
+
+#: eeschema/dialogs/dialog_annotate_base.cpp:52
+msgid "R&eset, but do not swap any annotated multi-unit parts"
+msgstr ""
+"既存のアノテーションをリセット、ただし複数ユニットを持つ部品はキープ(&E)"
+
+#: eeschema/dialogs/dialog_annotate_base.cpp:61
+msgid "Annotation Order"
+msgstr "アノテーションの順番"
+
+#: eeschema/dialogs/dialog_annotate_base.cpp:73
+msgid "Sort components by &X position"
+msgstr "コンポーネントを X位置でソート(&X)"
+
+#: eeschema/dialogs/dialog_annotate_base.cpp:88
+msgid "Sort components by &Y position"
+msgstr "コンポーネントを Y位置でソート(&Y)"
+
+#: eeschema/dialogs/dialog_annotate_base.cpp:109
+msgid "Annotation Choice"
+msgstr "アノテーションの選択"
+
+#: eeschema/dialogs/dialog_annotate_base.cpp:121
+msgid "Use first free number in schematic"
+msgstr "回路図中の最初の空き番号から使用する"
+
+#: eeschema/dialogs/dialog_annotate_base.cpp:133
+msgid "Start to  sheet number*100 and use first free number"
+msgstr "シートのRef番号を *100から開始し、最初の空き番号から使用する"
+
+#: eeschema/dialogs/dialog_annotate_base.cpp:145
+msgid "Start to  sheet number*1000 and use first free number"
+msgstr "シートのRef番号を *1000 から開始し、最初の空き番号から使用する"
+
+#: eeschema/dialogs/dialog_annotate_base.cpp:166
+msgid "Dialog"
+msgstr "ダイアログ"
+
+#: eeschema/dialogs/dialog_annotate_base.cpp:178
+msgid "Keep this dialog open"
+msgstr "ダイアログを自動的に閉じない"
+
+#: eeschema/dialogs/dialog_annotate_base.cpp:190
+msgid "Always ask for confirmation"
+msgstr "常に確認ダイアログを表示する"
+
+#: eeschema/dialogs/dialog_annotate_base.cpp:215
+msgid "Clear Annotation"
+msgstr "アノテーション クリア"
+
+#: eeschema/dialogs/dialog_annotate_base.cpp:218
+msgid "Annotate"
+msgstr "アノテーション"
+
+#: eeschema/dialogs/dialog_bom.cpp:321
+#, c-format
+msgid "Failed to open file '%s'"
+msgstr "ファイル '%s' が開けませんでした"
+
+#: eeschema/dialogs/dialog_bom.cpp:447
+msgid "Plugin name in plugin list"
+msgstr "プラグイン リストにあるプラグイン名"
+
+#: eeschema/dialogs/dialog_bom.cpp:448
+msgid "Plugin name"
+msgstr "プラグイン名"
+
+#: eeschema/dialogs/dialog_bom.cpp:458
+msgid "This name already exists. Abort"
+msgstr "このファイル名は既に使用されています。中止しました。"
+
+#: eeschema/dialogs/dialog_bom.cpp:486 eeschema/dialogs/dialog_netlist.cpp:840
+msgid "Plugin files:"
+msgstr "プラグイン ファイル:"
+
+#: eeschema/dialogs/dialog_bom.cpp:577
+msgid "Plugin file name not found. Cannot edit plugin file"
+msgstr ""
+"プラグインファイル名が見つかりませんでした。プラグインファイルの編集はできま"
+"せん。"
+
+#: eeschema/dialogs/dialog_bom.cpp:587
+msgid "No text editor selected in KiCad. Please choose it"
+msgstr "エディタが設定されていません。一つ選択してください。"
+
+#: eeschema/dialogs/dialog_bom.cpp:592
+msgid "Bom Generation Help"
+msgstr "部品表生成に関するヘルプ"
+
+#: eeschema/dialogs/dialog_bom_base.cpp:37
+msgid "Plugins"
+msgstr "プラグイン"
+
+#: eeschema/dialogs/dialog_bom_base.cpp:58
+#: eeschema/dialogs/dialog_netlist_base.cpp:46
+msgid "Generate"
+msgstr "生成"
+
+#: eeschema/dialogs/dialog_bom_base.cpp:71
+#: eeschema/dialogs/dialog_netlist_base.cpp:52
+msgid "Add Plugin"
+msgstr "プラグインの追加"
+
+#: eeschema/dialogs/dialog_bom_base.cpp:74
+#: eeschema/dialogs/dialog_netlist_base.cpp:55
+msgid "Remove Plugin"
+msgstr "プラグインの削除"
+
+#: eeschema/dialogs/dialog_bom_base.cpp:77
+msgid "Edit Plugin File"
+msgstr "プラグインファイルの編集"
+
+#: eeschema/dialogs/dialog_bom_base.cpp:89
+msgid "Command line:"
+msgstr "コマンドライン:"
+
+#: eeschema/dialogs/dialog_bom_base.cpp:102
+msgid "Plugin Info:"
+msgstr "プラグイン情報:"
+
+#: eeschema/dialogs/dialog_choose_component.cpp:250
+msgid "Description\n"
+msgstr "説明\n"
+
+#: eeschema/dialogs/dialog_choose_component.cpp:263
+msgid "Keywords\n"
+msgstr "キーワード\n"
+
+#: eeschema/dialogs/dialog_choose_component.cpp:271
+#: pcbnew/class_module.cpp:561
+msgid "Unknown"
+msgstr "不明"
+
+#: eeschema/dialogs/dialog_choose_component.cpp:277
+msgid "Alias of "
+msgstr "エイリアス: "
+
+#: eeschema/dialogs/dialog_color_config.cpp:61
+msgid "Wire"
+msgstr "ワイヤ"
+
+#: eeschema/dialogs/dialog_color_config.cpp:62
+msgid "Bus"
+msgstr "バス"
+
+#: eeschema/dialogs/dialog_color_config.cpp:63 eeschema/sch_junction.h:86
+msgid "Junction"
+msgstr "ジャンクション (接続点)"
+
+#: eeschema/dialogs/dialog_color_config.cpp:64 eeschema/sch_text.cpp:712
+msgid "Label"
+msgstr "ラベル"
+
+#: eeschema/dialogs/dialog_color_config.cpp:65
+msgid "Global label"
+msgstr "グローバル ラベル"
+
+#: eeschema/dialogs/dialog_color_config.cpp:66
+msgid "Net name"
+msgstr "ネット名"
+
+#: eeschema/dialogs/dialog_color_config.cpp:67
+msgid "Notes"
+msgstr "注釈"
+
+#: eeschema/dialogs/dialog_color_config.cpp:68
+msgid "No connect symbol"
+msgstr ""
+
+#: eeschema/dialogs/dialog_color_config.cpp:73 eeschema/libedit.cpp:500
+msgid "Body"
+msgstr "ボディ形状"
+
+#: eeschema/dialogs/dialog_color_config.cpp:74
+msgid "Body background"
+msgstr "ボディ背景色"
+
+#: eeschema/dialogs/dialog_color_config.cpp:75 eeschema/lib_pin.cpp:255
+msgid "Pin"
+msgstr "ピン"
+
+#: eeschema/dialogs/dialog_color_config.cpp:76
+msgid "Pin number"
+msgstr "ピン ナンバー"
+
+#: eeschema/dialogs/dialog_color_config.cpp:77
+msgid "Pin name"
+msgstr "ピン名"
+
+#: eeschema/dialogs/dialog_color_config.cpp:78
+#: eeschema/dialogs/dialog_rescue_each.cpp:107 eeschema/lib_field.cpp:574
+#: eeschema/onrightclick.cpp:428 eeschema/sch_component.cpp:1514
+#: eeschema/template_fieldnames.cpp:39
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:26
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:42
+#: pcbnew/dialogs/dialog_netlist_fbp.cpp:33
+msgid "Reference"
+msgstr "リファレンス"
+
+#: eeschema/dialogs/dialog_color_config.cpp:80
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:114
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:24
+msgid "Fields"
+msgstr "フィールド"
+
+#: eeschema/dialogs/dialog_color_config.cpp:85
+#: eeschema/dialogs/dialog_color_config.cpp:104
+msgid "Sheet"
+msgstr "シート"
+
+#: eeschema/dialogs/dialog_color_config.cpp:86
+msgid "Sheet file name"
+msgstr "シート ファイル名"
+
+#: eeschema/dialogs/dialog_color_config.cpp:87
+msgid "Sheet name"
+msgstr "シート名"
+
+#: eeschema/dialogs/dialog_color_config.cpp:88
+msgid "Sheet label"
+msgstr "シート ラベル"
+
+#: eeschema/dialogs/dialog_color_config.cpp:89
+msgid "Hierarchical label"
+msgstr "階層ラベル"
+
+#: eeschema/dialogs/dialog_color_config.cpp:94
+msgid "ERC warning"
+msgstr ""
+
+#: eeschema/dialogs/dialog_color_config.cpp:95
+msgid "ERC error"
+msgstr ""
+
+#: eeschema/dialogs/dialog_color_config.cpp:96
+#: gerbview/class_gerbview_layer_widget.cpp:110
+#: pcbnew/class_pcb_layer_widget.cpp:74
+#: pcbnew/dialogs/dialog_create_array_base.cpp:170
+#: pcbnew/tools/selection_tool.cpp:116
+msgid "Grid"
+msgstr "グリッド"
+
+#: eeschema/dialogs/dialog_color_config.cpp:102
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:28
+#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:22
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:382
+msgid "General"
+msgstr "一般設定"
+
+#: eeschema/dialogs/dialog_color_config.cpp:103
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:23
+#: eeschema/sch_component.cpp:1523
+msgid "Component"
+msgstr "コンポーネント"
+
+#: eeschema/dialogs/dialog_color_config.cpp:105
+msgid "Miscellaneous"
+msgstr "その他"
+
+#: eeschema/dialogs/dialog_color_config.cpp:191
+msgid "White"
+msgstr "白"
+
+#: eeschema/dialogs/dialog_color_config.cpp:192
+msgid "Black"
+msgstr "黒"
+
+#: eeschema/dialogs/dialog_color_config.cpp:274
+msgid ""
+"Some items have the same color as the background\n"
+"and they will not be seen on the screen.  Are you\n"
+"sure you want to use these colors?"
+msgstr ""
+
+#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:72
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.h:114
+msgid "Library Component Properties"
+msgstr "ライブラリ コンポーネントのプロパティ"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:81
+#, c-format
+msgid "Properties for %s (alias of %s)"
+msgstr "%s のプロパティ( %s のエイリアス)"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:86
+#, c-format
+msgid "Properties for %s"
+msgstr "%s のプロパティ"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:165
+#, c-format
+msgid "Number of Units (max allowed %d)"
+msgstr "ユニット数(最大値は %d)"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:299
+#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:375
+#, c-format
+msgid "Alias <%s> cannot be removed while it is being edited!"
+msgstr "エイリアス <%s> は編集中に削除できません！"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:305
+msgid "Remove all aliases from list?"
+msgstr "リストから全てのエイリアスを削除しますか？"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:326
+msgid "New alias:"
+msgstr "新規エイリアス:"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:326
+msgid "Component Alias"
+msgstr "コンポーネント エイリアス"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:340
+#, c-format
+msgid "Alias or component name <%s> already in use."
+msgstr "エイリアス又はコンポーネント名 <%s> は既に使用中です。"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:349
+#, c-format
+msgid "Alias or component name <%s> already exists in library <%s>."
+msgstr ""
+"エイリアスかコンポーネント名 <%s> は既にライブラリ <%s> 中に存在します。"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:406
+msgid "Delete extra parts from component?"
+msgstr "コンポーネントから余計なパーツを削除しますか？"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:426
+msgid "Add new pins for alternate body style ( DeMorgan ) to component?"
+msgstr ""
+"(ド・モルガン) 代替ボディスタイル用にコンポーネントに新しいピンを追加します"
+"か？"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:431
+msgid "Delete alternate body style (DeMorgan) draw items from component?"
+msgstr ""
+"(ド・モルガン) 代替ボディスタイル用の図形アイテムをコンポーネントから削除しま"
+"すか？"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:492
+msgid "OK to delete the footprint filter list ?"
+msgstr "フットプリントフィルタの一覧を削除して宜しいですか?"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:513
+msgid "Add Footprint Filter"
+msgstr "フットプリント フィルタの追加"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:513
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:244
+msgid "Footprint Filter"
+msgstr "フットプリント フィルター"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:530
+#, c-format
+msgid "Foot print filter <%s> is already defined."
+msgstr "フットプリント フィルタ <%s> は既に定義されています。"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:566
+msgid "Edit footprint filter"
+msgstr "フットプリントフィルタの編集"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:30
+msgid "Has alternate symbol (DeMorgan)"
+msgstr "(ド・モルガン)代替ボディスタイルが存在します"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:31
+msgid ""
+"Check this option if the component has an alternate body style (De Morgan)"
+msgstr ""
+"コンポーネントが代替表示形式(ド・モルガン)を持っている場合に、チェックを入れ"
+"て下さい"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:35
+msgid "Show pin number"
+msgstr "ピン番号の表示"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:37
+msgid "Show or hide pin numbers"
+msgstr "ピン番号を表示/非表示"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:41
+msgid "Show pin name"
+msgstr "ピン名を表示"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:43
+msgid "Show or hide pin names"
+msgstr "ピン名の表示/非表示"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:47
+msgid "Place pin names inside"
+msgstr "ピン名を内側に配置"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:49
+msgid ""
+"Check this option to have pin names inside the body and pin number outside.\n"
+"If not checked pins names and pins numbers are outside."
+msgstr ""
+"ピン名をボディ内側に表示し、ピン番号を外側に表示する場合にチェックしてくださ"
+"い。\n"
+"チェックがない場合、ピン名とピン番号は外側に表示されます。"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:65
+msgid "Number of Units"
+msgstr "ユニット数"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:67
+msgid ""
+"Enter the number of units for a component that contains more than one unit"
+msgstr ""
+"1つのコンポーネントが複数の部品を保つ場合、いくつの部品を持つか数を入力して下"
+"さい"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:80
+msgid "Pin Name Position Offset"
+msgstr "ピン名の位置オフセット"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:82
+msgid ""
+"Margin (in 0.001 inches) between a pin name position and the component "
+"body.\n"
+"A value from 10 to 40 is usually good."
+msgstr ""
+"ピン名とコンポーネントのボディ間の余白 (0.001インチ単位指定) \n"
+"通常は10～40を推奨します。"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:98
+msgid "Define as power symbol"
+msgstr "電源シンボルとして定義"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:99
+msgid "Check this option when the component is a power symbol"
+msgstr ""
+"電源シンボルとしてコンポーネントを作成するとき、このオプションをチェック"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:103
+msgid "All units are not interchangeable"
+msgstr "複数ユニットでのユニット交換不可"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:104
+msgid ""
+"Check this option when creating multiple unit components and all units are "
+"not interchangeable"
+msgstr ""
+"複数ユニットから成るコンポーネントの場合、ユニットの入れ替えを許可しない場合"
+"にチェックを入れて下さい。"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:119
+msgid ""
+"A short description that is displayed in Eeschema.\n"
+"Can be a very good help when selecting components in libraries components "
+"lists."
+msgstr ""
+"Eeschema に表示される短い説明です。\n"
+"ライブラリコンポーネントリストからコンポーネントを選択する際の助けになりま"
+"す。"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:127
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:34
+msgid "Keywords"
+msgstr "キーワード"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:129
+msgid ""
+"Enter key words that can be used to select this component.\n"
+"Key words cannot have spaces and are separated by a space."
+msgstr ""
+"コンポーネントを選択するのに使うキーワードの入力。\n"
+"キーワードはスペース区切りで入力できます。"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:137
+msgid "Documentation File Name"
+msgstr "ドキュメントファイル名"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:139
+msgid ""
+"Enter the documentation file (a .pdf document) associated to the component."
+msgstr ""
+"コンポーネントに関連付けるドキュメントファイル (1つのpdfドキュメント) を入力"
+"します。"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:150
+msgid "Copy Document from Parent"
+msgstr "親要素からドキュメント情報をコピー"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:153
+msgid "Browse Files"
+msgstr "ファイルを開く"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:171
+msgid "Alias List"
+msgstr "エイリアスの一覧"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:173
+msgid ""
+"An alias is a component that uses the body of its root component.\n"
+"It has its own documentation and keywords.\n"
+"A fast way to extend a library with similar components"
+msgstr ""
+"エイリアスとは、元となるコンポーネントの形状を引き継いだ、別名のコンポーネン"
+"トです。\n"
+"エイリアスは形状は元コンポーネントのものを使用しますが、独自のドキュメントと"
+"キーワードを持ちます。\n"
+"同じコンポーネント形状を用いてライブラリを拡張する早い方法です。"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:192
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:234
+msgid "Delete All"
+msgstr "全て削除"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:202
+#: eeschema/libedit.cpp:488 eeschema/viewlibs.cpp:307
+msgid "Alias"
+msgstr "エイリアス"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:210
+#: pcbnew/dialogs/dialog_global_deletion_base.cpp:37
+msgid "Footprints"
+msgstr "フットプリント"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:212
+msgid ""
+"A list of footprints names that can be used for this component.\n"
+"Footprints names can used jockers.\n"
+"(like sm* to allow all footprints names starting by sm)."
+msgstr ""
+"このコンポーネントに使用できるフットプリント名のリストです。\n"
+"フットプリント名にはワイルドカードを使用できます。\n"
+"(sm で始まる全てのフットプリント名を許可するには sm* のように)"
+
+#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:228
+#: eeschema/onrightclick.cpp:418
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:37
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:54
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:53
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:70
+#: pcbnew/modedit_onclick.cpp:418 pcbnew/onrightclick.cpp:1011
+msgid "Edit"
+msgstr "編集"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:220
+#, c-format
+msgid "Component '%s' found in library '%s'"
+msgstr "コンポーネント '%s' はライブラリ '%s' 中に見つかりました"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:226
+#, c-format
+msgid "Component '%s' not found in any library"
+msgstr "コンポーネント '%s' がどのライブラリにも見つかりませんでした"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:242
+msgid "However, some candidates are found:"
+msgstr "他のいくつかの候補が見つかりました:"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:248
+#, c-format
+msgid "'%s' found in library '%s'"
+msgstr "'%s' はライブラリ '%s' から見つかりました"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:310
+msgid "No Component Name!"
+msgstr "コンポーネント名がありません。"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:319
+#, c-format
+msgid "Component '%s' not found!"
+msgstr "コンポーネント '%s' が見つかりません!"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:393
+msgid "Illegal reference. A reference must start with a letter"
+msgstr "無効なリファレンスです。リファレンスは英字で始める必要があります。"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:419
+#, c-format
+msgid ""
+"The field name <%s> does not have a value and is not defined in the field "
+"template list.  Empty field values are invalid an will be removed from the "
+"component.  Do you wish to remove this and all remaining undefined fields?"
+msgstr ""
+"フィールド名 <%s> は値を持っておらず、フィールドテンプレートリストにも定義さ"
+"れていません。空のフィールド値は無効であり、コンポーネントから削除されます。"
+"これと残りの未定義フィールド全てを削除しますか？"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:426
+msgid "Remove Fields"
+msgstr "フィールドの削除"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:845
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:216
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:697
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:124
+msgid "Show in Browser"
+msgstr "ブラウザ内に表示"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:847
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:699
+msgid "Assign Footprint"
+msgstr "フットプリントの割り当て"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:982
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:41
+#: eeschema/lib_pin.cpp:2000 gerbview/class_gerber_draw_item.cpp:572
+#: gerbview/class_gerber_draw_item.cpp:573 pcbnew/class_pcb_text.cpp:145
+#: pcbnew/class_text_mod.cpp:380
+msgid "Yes"
+msgstr "はい"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:984
+#: eeschema/lib_pin.cpp:2002 gerbview/class_gerber_draw_item.cpp:572
+#: gerbview/class_gerber_draw_item.cpp:573 pcbnew/class_pcb_text.cpp:143
+#: pcbnew/class_text_mod.cpp:378
+msgid "No"
+msgstr "いいえ"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:37
+msgid "Units are interchangeable:"
+msgstr "変換可能な単位系:"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:48
+#: pcbnew/dialogs/dialog_create_array_base.cpp:69
+#: pcbnew/dialogs/dialog_create_array_base.cpp:80
+#: pcbnew/dialogs/dialog_create_array_base.cpp:184
+#: pcbnew/dialogs/dialog_create_array_base.cpp:195
+#: pcbnew/dialogs/dialog_create_array_base.cpp:214
+#: pcbnew/dialogs/dialog_export_idf_base.cpp:62
+#: pcbnew/dialogs/dialog_export_idf_base.cpp:76
+#: pcbnew/dialogs/dialog_export_vrml_base.cpp:74
+#: pcbnew/dialogs/dialog_export_vrml_base.cpp:82
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:32
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:46
+#: pcbnew/dialogs/dialog_move_exact_base.cpp:60
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:135
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:237
+msgid "0"
+msgstr "0"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:48
+msgid "+90"
+msgstr "+90"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:48
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:135
+msgid "180"
+msgstr "180"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:48
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:135
+msgid "-90"
+msgstr "-90"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:50
+msgid "Orientation (Degrees)"
+msgstr "角度 (度)"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:52
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:58
+msgid "Select if the component is to be rotated when drawn"
+msgstr "描画時にコンポーネントを回転する場合に選択"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:56
+msgid "Mirror ---"
+msgstr "横軸ミラー"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:56
+msgid "Mirror |"
+msgstr "縦軸ミラー"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:58
+#: gerbview/class_gerber_draw_item.cpp:574
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:79
+#: pcbnew/class_pcb_text.cpp:143 pcbnew/class_pcb_text.cpp:145
+#: pcbnew/class_text_mod.cpp:392
+#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:83
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:100
+#: pcbnew/modedit_onclick.cpp:292
+msgid "Mirror"
+msgstr "ミラー"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:60
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:66
+msgid ""
+"Pick the graphical transformation to be used when displaying the component, "
+"if any"
+msgstr "コンポーネントを表示する際に使用するグラフィック変換を指定します。"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:64
+msgid "Converted Shape"
+msgstr "変換された形状"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:65
+msgid ""
+"Use the alternate shape of this component.\n"
+"For gates, this is the \"De Morgan\" conversion"
+msgstr ""
+"ゲート用にコンポーネントの代替シェイプを使う\n"
+"\"ド・モルガン\"変換を行います。"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:70
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:670
+msgid "Chip Name"
+msgstr "シンボル名"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:74
+msgid "The name of the symbol in the library from which this component came"
+msgstr "このコンポーネントを持ってきたライブラリ中のシンボル名です。"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:81
+msgid "Test"
+msgstr "テスト"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:84
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:41
+msgid "Select"
+msgstr "選択"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:93
+#: pcbnew/dialogs/dialog_netlist_fbp.cpp:33
+msgid "Timestamp"
+msgstr "タイムスタンプ"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:98
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:122
+msgid ""
+"An unique ID (a time stamp) to identify the component.\n"
+"This is an alternate identifier to the reference."
+msgstr ""
+"コンポーネントを識別するために、固有ID (タイムスタンプ情報) を使用します。\n"
+"これはリファレンスを管理する際に使用される情報です。"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:105
+msgid "Reset to Library Defaults"
+msgstr "ライブラリのデフォルト値にリセット"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:106
+msgid ""
+"Set position and style of fields and component orientation  to default lib "
+"value.\n"
+"Fields texts are not modified."
+msgstr ""
+"フィールドの書式と位置およびコンポーネントの角度を、デフォルトのライブラリ値"
+"にセット\n"
+"フィールド文字は修正されません。"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:124
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:30
+msgid "Add Field"
+msgstr "フィールドの追加"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:125
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:31
+msgid "Add a new custom field"
+msgstr "フィールドを新規追加"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:129
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:35
+msgid "Delete Field"
+msgstr "フィールドの削除"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:130
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:36
+msgid "Delete one of the optional fields"
+msgstr "選択したフィールドを削除"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:135
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:41
+msgid "Move the selected optional fields up one position"
+msgstr "選択したオプションフィールドを一つ上と入れ替え"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:148
+#: eeschema/dialogs/dialog_edit_label_base.cpp:70
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:54
+#: eeschema/lib_pin.cpp:167
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:84
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:106
+msgid "Left"
+msgstr "左"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:148
+#: eeschema/dialogs/dialog_edit_label_base.cpp:70
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:54
+#: eeschema/lib_pin.cpp:166
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:84
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:106
+msgid "Right"
+msgstr "右"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:150
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:56
+msgid "Horiz. Justify"
+msgstr "水平に整列"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:154
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:62
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:103
+msgid "Bottom"
+msgstr "下"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:154
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:62
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:103
+msgid "Top"
+msgstr "上"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:156
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:64
+msgid "Vert. Justify"
+msgstr "垂直に整列"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:167
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:77
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:125
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:154
+msgid "Visibility"
+msgstr "表示"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:169
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:79
+msgid "Show"
+msgstr "表示する"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:170
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:80
+msgid "Check if you want this field visible"
+msgstr "このフィールドを可視化するならチェック"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:175
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:85
+msgid "Check if you want this field's text rotated 90 degrees"
+msgstr "このフィールドのテキストを90度回転させたいならチェック"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:182
+#: eeschema/dialogs/dialog_edit_label_base.cpp:76
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:92
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:97 eeschema/sch_text.cpp:758
+msgid "Bold Italic"
+msgstr "斜太字"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:184
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:94
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:84
+msgid "Style:"
+msgstr "スタイル:"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:186
+msgid "The style of the currently selected field's text in the schemati"
+msgstr "選択中のフィールドの文字書式"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:196
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:104
+#: eeschema/dialogs/dialog_eeschema_options.cpp:47
+msgid "Field Name"
+msgstr "フィールド名"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:202
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:212
+msgid ""
+"The name of the currently selected field\n"
+"Some fixed fields names are not editable"
+msgstr ""
+"現在選択中のフォールドの名前\n"
+"いくつかの固定フィールド名は編集不可"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:206
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:114
+msgid "Field Value"
+msgstr "フィールドの値"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:217
+msgid ""
+"If your datasheet is an http:// link or a complete file path, then it may "
+"show in your browser by pressing this button."
+msgstr ""
+"もし設定されているデータシートのパスが、http://から始まるリンクや、完全なファ"
+"イルパスであった場合、このボタンをクリックすることでブラウザで表示させること"
+"ができます。"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:230
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:138
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:53 eeschema/sch_text.cpp:790
+#: pcbnew/dialogs/dialog_target_properties_base.cpp:28 pcbnew/muonde.cpp:821
+msgid "Size"
+msgstr "サイズ"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:236
+msgid "The size of the currently selected field's text in the schematic"
+msgstr "選択中のフィールドの文字サイズ"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:240
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:254
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:268
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:148
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:160
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:174
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:98
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:110
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:234
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:257
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:271
+#: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:73
+#: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:85
+#: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:97
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:42
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:54
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:66
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:78
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:74
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:103
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:114
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:125
+#: pcbnew/dialogs/dialog_target_properties_base.cpp:35
+#: pcbnew/dialogs/dialog_target_properties_base.cpp:46
+#: pcbnew/dialogs/dialog_track_via_size_base.cpp:32
+#: pcbnew/dialogs/dialog_track_via_size_base.cpp:43
+#: pcbnew/dialogs/dialog_track_via_size_base.cpp:54
+msgid "unit"
+msgstr "単位"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:244
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:152
+msgid "PosX"
+msgstr "X座標"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:250
+msgid "The X coordinate of the text relative to the component"
+msgstr "コンポーネントからテキストの相対X位置"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:258
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:164
+msgid "PosY"
+msgstr "Y座標"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:264
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:170
+msgid "The Y coordinate of the text relative to the component"
+msgstr "コンポーネントからテキストの相対Y位置"
+
+#: eeschema/dialogs/dialog_edit_label.cpp:151
+msgid "Global Label Properties"
+msgstr "グローバルラベルのプロパティ"
+
+#: eeschema/dialogs/dialog_edit_label.cpp:155
+msgid "Hierarchical Label Properties"
+msgstr "階層ラベルのプロパティ"
+
+#: eeschema/dialogs/dialog_edit_label.cpp:159
+msgid "Label Properties"
+msgstr "ラベルのプロパティ"
+
+#: eeschema/dialogs/dialog_edit_label.cpp:163
+msgid "Hierarchical Sheet Pin Properties."
+msgstr "階層シートピンのプロパティ"
+
+#: eeschema/dialogs/dialog_edit_label.cpp:167
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.h:76
+msgid "Text Properties"
+msgstr "テキストのプロパティ"
+
+#: eeschema/dialogs/dialog_edit_label.cpp:228
+#, c-format
+msgid "H%s x W%s"
+msgstr "高さ%s x 幅%s"
+
+#: eeschema/dialogs/dialog_edit_label.cpp:294
+msgid "Empty Text!"
+msgstr "空のテキスト !"
+
+#: eeschema/dialogs/dialog_edit_label_base.cpp:25
+msgid "&Text:"
+msgstr "テキスト(&T):"
+
+#: eeschema/dialogs/dialog_edit_label_base.cpp:27
+msgid "Enter the text to be used within the schematic"
+msgstr "回路図内で使用されるテキストの入力"
+
+#: eeschema/dialogs/dialog_edit_label_base.cpp:47
+#: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:64
+msgid "&Size:"
+msgstr "サイズ(&S):"
+
+#: eeschema/dialogs/dialog_edit_label_base.cpp:70
+#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:53 eeschema/lib_pin.cpp:168
+msgid "Up"
+msgstr "上へ"
+
+#: eeschema/dialogs/dialog_edit_label_base.cpp:70
+#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:56 eeschema/lib_pin.cpp:169
+msgid "Down"
+msgstr "下へ"
+
+#: eeschema/dialogs/dialog_edit_label_base.cpp:72
+msgid "O&rientation"
+msgstr "角度(&R)"
+
+#: eeschema/dialogs/dialog_edit_label_base.cpp:78
+msgid "St&yle"
+msgstr "スタイル(&Y)"
+
+#: eeschema/dialogs/dialog_edit_label_base.cpp:82
+#: eeschema/dialogs/dialog_sch_edit_sheet_pin.cpp:30 eeschema/lib_pin.cpp:183
+#: eeschema/sch_text.cpp:777
+msgid "Input"
+msgstr "入力"
+
+#: eeschema/dialogs/dialog_edit_label_base.cpp:82
+#: eeschema/dialogs/dialog_sch_edit_sheet_pin.cpp:31 eeschema/lib_pin.cpp:184
+#: eeschema/sch_text.cpp:778
+msgid "Output"
+msgstr "出力"
+
+#: eeschema/dialogs/dialog_edit_label_base.cpp:82
+#: eeschema/dialogs/dialog_sch_edit_sheet_pin.cpp:32 eeschema/lib_pin.cpp:185
+#: eeschema/sch_text.cpp:779
+msgid "Bidirectional"
+msgstr "双方向"
+
+#: eeschema/dialogs/dialog_edit_label_base.cpp:82 eeschema/sch_text.cpp:780
+msgid "Tri-State"
+msgstr "トライステート"
+
+#: eeschema/dialogs/dialog_edit_label_base.cpp:82
+#: eeschema/dialogs/dialog_sch_edit_sheet_pin.cpp:34 eeschema/lib_pin.cpp:187
+#: eeschema/sch_text.cpp:781
+msgid "Passive"
+msgstr "パッシブ"
+
+#: eeschema/dialogs/dialog_edit_label_base.cpp:84
+msgid "S&hape"
+msgstr "シェイプ(&H)"
+
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:243
+msgid "Illegal reference prefix. A reference must start by a letter"
+msgstr ""
+"無効なリファレンス接頭字です。リファレンスはアルファベット文字で始まる必要が"
+"あります。"
+
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:259
+#, c-format
+msgid ""
+"A new name is entered for this component\n"
+"An alias %s already exists!\n"
+"Cannot update this component"
+msgstr ""
+"コンポーネントに入力された新しい名前\n"
+"エイリアス %s は既に存在します！\n"
+"コンポーネントを更新できません"
+
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:110
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:120
+msgid "The text (or value) of the currently selected field"
+msgstr "現在選択中のフィールドのテキスト (または値)"
+
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:125
+msgid ""
+"If your datasheet is given as an http:// link, then pressing this button "
+"should bring it up in your webbrowser."
+msgstr ""
+"もし設定されているデータシートのパスが、http://から始まるリンクであった場合、"
+"このボタンをクリックすることでブラウザで表示させることができます。"
+
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:144
+msgid ""
+"The vertical height of the currently selected field's text in the schematic"
+msgstr "選択中のフィールドの文字の文字高さ"
+
+#: eeschema/dialogs/dialog_edit_one_field.cpp:172
+#, c-format
+msgid ""
+"Whitespace is not permitted inside references or values (symbol names in "
+"lib).\n"
+"The text you entered has been converted to use underscores: %s"
+msgstr ""
+"空白文字の使用は、リファレンスと定数(ライブラリ内のシンボル名)の内部で許され"
+"ていません.\n"
+"入力された文字列内の空白文字はアンダースコアへ変換されます(: %s )"
+
+#: eeschema/dialogs/dialog_eeschema_config.cpp:137
+#, c-format
+msgid "Project '%s'"
+msgstr "プロジェクト '%s'"
+
+#: eeschema/dialogs/dialog_eeschema_config.cpp:315
+msgid "Library files:"
+msgstr "ライブラリ ファイル:"
+
+#: eeschema/dialogs/dialog_eeschema_config.cpp:375
+#, c-format
+msgid "'%s' : library already in use"
+msgstr "ライブラリ '%s' は使用中です"
+
+#: eeschema/dialogs/dialog_eeschema_config.cpp:390
+msgid "Default Path for Libraries"
+msgstr "ライブラリのデフォルト パス"
+
+#: eeschema/dialogs/dialog_eeschema_config.cpp:417
+msgid "Use a relative path?"
+msgstr "相対パスを使用しますか？"
+
+#: eeschema/dialogs/dialog_eeschema_config.cpp:417
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:509
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:380
+msgid "Path type"
+msgstr "パスのタイプ"
+
+#: eeschema/dialogs/dialog_eeschema_config.cpp:437
+msgid "Path already in use"
+msgstr "パスは既に使用中です"
+
+#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:22
+msgid "Component library files"
+msgstr "コンポーネント ライブラリ ファイル:"
+
+#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:30
+msgid ""
+"List of active library files.\n"
+"Only library files in this list are loaded by Eeschema.\n"
+"The order of this list is important:\n"
+"Eeschema searchs for a given component using this list order priority."
+msgstr ""
+"アクティブなライブラリファイルのリスト\n"
+"Eeschema に読み込まれているライブラリファイルのリストを表示します。\n"
+"このリストの順番は重要です。\n"
+"Eeschema はこのリストの優先順序でフットプリントを検索します。"
+
+#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:39
+msgid "Add a new library after the selected library, and load it"
+msgstr "指定したライブラリを一覧の最後に追加"
+
+#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:43
+#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:90
+#: pcbnew/class_module.cpp:603
+msgid "Insert"
+msgstr "挿入"
+
+#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:44
+msgid "Add a new library before the selected library, and load it"
+msgstr "選択した項目の前に、指定したライブラリを追加"
+
+#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:71
+msgid "User defined search path"
+msgstr "ユーザ定義の検索パス"
+
+#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:79
+msgid ""
+"Additional paths used in this project. The priority is higher than default "
+"KiCad paths."
+msgstr ""
+"このプロジェクトに追加するパスを記述します。これらはデフォルトのKicadパスより"
+"も高い優先度となります。"
+
+#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:108
+msgid "Current search path list"
+msgstr "現在の検索パスのリスト"
+
+#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:113
+msgid ""
+"System and user paths used to search and load library files and component "
+"doc files.\n"
+"Sorted by decreasing priority order."
+msgstr ""
+"ライブラリファイルとコンポーネントドキュメントファイルの読み込みと検索に使用"
+"するシステムパスとユーザパスです。\n"
+"これは降順の優先度でソートされます。"
+
+#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:120
+msgid "Check for cache/library conflicts when loading schematic"
+msgstr ""
+
+#: eeschema/dialogs/dialog_eeschema_options.cpp:51
+msgid "Default Value"
+msgstr "標準値"
+
+#: eeschema/dialogs/dialog_eeschema_options.cpp:55
+#: eeschema/dialogs/dialog_eeschema_options.cpp:192 eeschema/lib_pin.cpp:2004
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:116
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:129
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:158
+msgid "Visible"
+msgstr "表示"
+
+#: eeschema/dialogs/dialog_eeschema_options.cpp:192
+msgid "Hidden"
+msgstr "非表示"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:53
+msgid "&Measurement units:"
+msgstr "計測単位(&M):"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:65
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:36
+msgid "&Grid size:"
+msgstr "グリッド サイズ(&G):"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:74
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:85
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:96
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:107
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:118
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:129
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:45
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:56
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:67
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:78
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:89
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:100
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:111
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:125
+msgid "mils"
+msgstr "mil"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:78
+msgid "&Default bus thickness:"
+msgstr "デフォルトのバス線幅(&D):"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:89
+msgid "D&efault line thickness:"
+msgstr "デフォルトの線幅(&e):"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:100
+msgid "De&fault text size:"
+msgstr "デフォルトのテキストサイズ(&f):"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:111
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:93
+msgid "&Horizontal pitch of repeated items:"
+msgstr "繰り返し配置の水平間隔(&H):"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:122
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:104
+msgid "&Vertical pitch of repeated items:"
+msgstr "繰り返し配置の垂直間隔(&V):"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:133
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:129
+msgid "&Increment of repeated labels:"
+msgstr "繰り返しラベルの増分値(&I):"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:143
+msgid "&Auto-save time interval"
+msgstr "自動保存の時間間隔(&A)"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:150
+msgid "minutes"
+msgstr "分"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:154
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:139
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:182
+msgid "Ma&ximum undo items (0 = unlimited):"
+msgstr "最大 undo アイテム数 (&x) (0 = 制限なし):"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:161
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:146
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:189
+msgid "actions"
+msgstr "アクション"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:165
+msgid "&Part id notation:"
+msgstr "部品IDの表記方法(&P):"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:169
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:276
+msgid "A"
+msgstr "A"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:169
+msgid ".A"
+msgstr ".A"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:169
+msgid "-A"
+msgstr "-A"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:169
+msgid "_A"
+msgstr "_A"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:169
+msgid ".1"
+msgstr ".1"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:169
+msgid "-1"
+msgstr "-1"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:169
+msgid "_1"
+msgstr "_1"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:187
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:159
+msgid "&Show grid"
+msgstr "グリッドの表示(&S)"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:190
+msgid "Sho&w hidden pins"
+msgstr "非表示ピンを表示(&w)"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:193
+#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:165
+msgid "Ce&nter and warp cursor on zoom"
+msgstr "拡大縮小時にカーソルを中心へ移動(&n)"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:198
+msgid "&Use middle mouse button to pan"
+msgstr "画面のパンにマウスの中ボタンを使う(&U)"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:199
+#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:172
+msgid "Use middle mouse button dragging to pan"
+msgstr "画面のパンにマウスの中ボタンのドラッグを使う"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:203
+msgid "&Limit panning to scroll size"
+msgstr "パン可能な領域を、スクロールバーサイズ範囲内に制限する"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:204
+#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:177
+msgid "Middle mouse button panning limited by current scrollbar size"
+msgstr ""
+"マウス中ボタンによる画面パン時に、移動領域サイズを現在のスクロールバーサイズ"
+"へ制限します"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:208
+msgid "Pan while moving ob&ject"
+msgstr "オブジェクト移動時に表示領域を移動(&J)"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:211
+msgid "&Restrict buses and wires to H and V orientation"
+msgstr "バス、配線を90度入力に制限(&R)"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:214
+msgid "Show page limi&ts"
+msgstr "ページの境界を表示(&t)"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:227
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:95
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:617
+msgid "General Options"
+msgstr "全般 オプション"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:229
+msgid "User defined field names for schematic components. "
+msgstr "回路図コンポーネントに定義されたフィールド名を使用"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:240
+msgid "Field Settings"
+msgstr "フィールドの設定"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:242
+msgid "&Name"
+msgstr "名前(&N)"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:249
+msgid "D&efault Value"
+msgstr "デフォルト値(&e)"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:256
+#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:95
+msgid "&Visible"
+msgstr "可視化(&V)"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:262
+msgid "&Add"
+msgstr "追加(&A)"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:265
+#: eeschema/menubar.cpp:190 eeschema/menubar_libedit.cpp:140
+#: pcbnew/menubar_modedit.cpp:171 pcbnew/menubar_pcbframe.cpp:284
+msgid "&Delete"
+msgstr "削除(&D)"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.cpp:272
+msgid "Template Field Names"
+msgstr "フィールド名のテンプレート"
+
+#: eeschema/dialogs/dialog_erc.cpp:213
+msgid "Marker not found"
+msgstr "マーカーが見つかりません"
+
+#: eeschema/dialogs/dialog_erc.cpp:337
+msgid "No error or warning"
+msgstr "エラー/警告無し"
+
+#: eeschema/dialogs/dialog_erc.cpp:342
+msgid "Generate warning"
+msgstr "警告を生成"
+
+#: eeschema/dialogs/dialog_erc.cpp:347
+msgid "Generate error"
+msgstr "生成エラー"
+
+#: eeschema/dialogs/dialog_erc.cpp:451
+msgid "Annotation required!"
+msgstr "アノテーションの実行が必要です！"
+
+#: eeschema/dialogs/dialog_erc.cpp:556
+msgid "ERC File"
+msgstr "ERC ファイル"
+
+#: eeschema/dialogs/dialog_erc.cpp:557
+msgid "Electronic rule check file (.erc)|*.erc"
+msgstr "エレクトリック ルール チェック ファイル (.erc)|*.erc"
+
+#: eeschema/dialogs/dialog_erc_base.cpp:30
+msgid "ERC Report:"
+msgstr "ERCレポート:"
+
+#: eeschema/dialogs/dialog_erc_base.cpp:35
+msgid "Total:"
+msgstr "合計:"
+
+#: eeschema/dialogs/dialog_erc_base.cpp:42
+msgid "Warnings:"
+msgstr "警告:"
+
+#: eeschema/dialogs/dialog_erc_base.cpp:49
+msgid "Errors:"
+msgstr "エラー:"
+
+#: eeschema/dialogs/dialog_erc_base.cpp:59
+msgid "Create ERC file report"
+msgstr "ERCレポートファイルの生成"
+
+#: eeschema/dialogs/dialog_erc_base.cpp:81
+msgid "Error list:"
+msgstr "エラー一覧:"
+
+#: eeschema/dialogs/dialog_erc_base.cpp:91
+msgid "&Delete Markers"
+msgstr "マーカーの削除(&D)"
+
+#: eeschema/dialogs/dialog_erc_base.cpp:94
+msgid "&Run"
+msgstr "実行(&R)"
+
+#: eeschema/dialogs/dialog_erc_base.cpp:108
+msgid "ERC"
+msgstr "ERC"
+
+#: eeschema/dialogs/dialog_erc_base.cpp:113
+#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:86
+msgid "Reset"
+msgstr "リセット"
+
+#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:34
+msgid "&Width:"
+msgstr "幅(&W):"
+
+#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:52
+#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:81
+msgid "Sharing"
+msgstr "共有"
+
+#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:64
+#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:83
+msgid "Common to all &units in component"
+msgstr "コンポーネント内のすべてのパーツで共通化(&u)"
+
+#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:76
+#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:86
+msgid "Common to all body &styles (DeMorgan)"
+msgstr "全てのボディスタイル(ド・モルガン)で共有する(&S)"
+
+#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:85
+msgid "Fill Style"
+msgstr "塗りつぶしのスタイル"
+
+#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:100
+msgid "Do &not fill"
+msgstr "塗りつぶし無し(&N)"
+
+#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:104
+msgid "Fill &foreground"
+msgstr "前面色で塗りつぶし(&F)"
+
+#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:107
+msgid "Fill &background"
+msgstr "背景色で塗りつぶし(&B)"
+
+#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:33
+msgid "Pin &name:"
+msgstr "ピン名(&N):"
+
+#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:41
+msgid "Pin n&umber:"
+msgstr "ピン番号(&U)"
+
+#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:43
+msgid "Pin number: 1 to 4 ASCII letters and/or digits"
+msgstr "ピン番号: 1から4文字のASCII文字および数字"
+
+#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:51
+msgid "&Orientation:"
+msgstr "角度(&O):"
+
+#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:58
+msgid "&Electrical type:"
+msgstr "エレクトリック タイプ(&E):"
+
+#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:60
+msgid "Used by the ERC."
+msgstr "ERCで使用"
+
+#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:67
+msgid "Graphic &Style:"
+msgstr "グラフィック スタイル(&S):"
+
+#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:93
+msgid "Schematic Properties"
+msgstr "回路図上のプロパティ"
+
+#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:117
+msgid "N&ame text size:"
+msgstr "ピン名の文字サイズ(&A):"
+
+#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:129
+msgid "Number te&xt size:"
+msgstr "ピン番号の文字サイズ(&X):"
+
+#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:141
+msgid "&Length:"
+msgstr "長さ(&L):"
+
+#: eeschema/dialogs/dialog_lib_edit_pin_table.cpp:144
+#: eeschema/lib_pin.cpp:1984
+msgid "Number"
+msgstr "ピン番号"
+
+#: eeschema/dialogs/dialog_lib_edit_pin_table.cpp:158
+#: eeschema/lib_draw_item.cpp:65 eeschema/lib_pin.cpp:1986
+#: eeschema/libedit.cpp:507 eeschema/sch_text.cpp:785
+#: gerbview/class_gerber_draw_item.cpp:549
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:29
+#: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:47
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:168
+#: pcbnew/class_drawsegment.cpp:366 pcbnew/class_marker_pcb.cpp:97
+#: pcbnew/class_text_mod.cpp:375 pcbnew/class_track.cpp:1142
+#: pcbnew/class_track.cpp:1169 pcbnew/class_track.cpp:1218
+#: pcbnew/class_zone.cpp:584 pcbnew/dialogs/dialog_layers_setup.cpp:346
+msgid "Type"
+msgstr "タイプ"
+
+#: eeschema/dialogs/dialog_lib_edit_pin_table.cpp:165 pcbnew/class_pad.cpp:682
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:80
+msgid "Position"
+msgstr "ポジション"
+
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:28 eeschema/lib_text.cpp:51
+#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:113
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:67
+#: pcbnew/class_text_mod.cpp:365 pcbnew/class_text_mod.cpp:372
+#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:21
+#: pcbnew/dialogs/dialog_global_deletion_base.cpp:28
+msgid "Text"
+msgstr "テキスト"
+
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:67
+msgid "Power component value text cannot be modified!"
+msgstr "電源コンポーネントの定数テキストは変更できません！"
+
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:79
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:110
+msgid "Vertical"
+msgstr "垂直"
+
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:85
+msgid "Common to all units"
+msgstr "全てのユニットで統一化"
+
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:88
+msgid "Common to all body styles"
+msgstr "全てのボディスタイルで統一化"
+
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:91
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:116
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:129
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:158
+msgid "Invisible"
+msgstr "非表示"
+
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:99
+#: eeschema/lib_field.cpp:746 eeschema/lib_pin.cpp:1997
+#: eeschema/sch_text.cpp:767
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:106
+msgid "Style"
+msgstr "スタイル"
+
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:103
+msgid "Align left"
+msgstr "左寄せ"
+
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:103
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:109
+msgid "Align center"
+msgstr "中央寄せ"
+
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:103
+msgid "Align right"
+msgstr "右寄せ"
+
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:105
+msgid "Horizontal Justify"
+msgstr "水平に整列"
+
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:109
+msgid "Align bottom"
+msgstr "下寄せ"
+
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:109
+msgid "Align top"
+msgstr "上寄せ"
+
+#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:111
+msgid "Vertical Justify"
+msgstr "垂直に整列"
+
+#: eeschema/dialogs/dialog_lib_new_component_base.cpp:22
+#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.h:97
+msgid "General Settings"
+msgstr "一般設定"
+
+#: eeschema/dialogs/dialog_lib_new_component_base.cpp:34
+msgid "Component &name:"
+msgstr "コンポーネント名(&N):"
+
+#: eeschema/dialogs/dialog_lib_new_component_base.cpp:36
+msgid ""
+"This is the component name in library,\n"
+"and also the default component value when loaded in the schematic."
+msgstr ""
+"これはライブラリ中のコンポーネント名であり、\n"
+"回路図に読込む際のデフォルトのコンポーネントの値でもあります。"
+
+#: eeschema/dialogs/dialog_lib_new_component_base.cpp:44
+msgid "Default reference designator:"
+msgstr "デフォルトのリファレンス記号:"
+
+#: eeschema/dialogs/dialog_lib_new_component_base.cpp:48
+msgid "U"
+msgstr "U"
+
+#: eeschema/dialogs/dialog_lib_new_component_base.cpp:51
+msgid "Number of units per package:"
+msgstr "パッケージ内のユニット数:"
+
+#: eeschema/dialogs/dialog_lib_new_component_base.cpp:64
+msgid "Create component with alternate body style (DeMorgan)"
+msgstr "(ド・モルガン) 代替ボディスタイルを使ってコンポーネントを作成"
+
+#: eeschema/dialogs/dialog_lib_new_component_base.cpp:67
+msgid "Create component as power symbol"
+msgstr "電源シンボルとしてコンポーネントを作成する"
+
+#: eeschema/dialogs/dialog_lib_new_component_base.cpp:70
+msgid "Units are not interchangeable"
+msgstr "変換できない単位系です"
+
+#: eeschema/dialogs/dialog_lib_new_component_base.cpp:85
+msgid "General Pin Settings"
+msgstr "一般ピン設定"
+
+#: eeschema/dialogs/dialog_lib_new_component_base.cpp:96
+msgid "Pin text position offset:"
+msgstr "ピンテキストの位置オフセット"
+
+#: eeschema/dialogs/dialog_lib_new_component_base.cpp:109
+msgid "Show pin number text"
+msgstr "ピン番号のテキストの表示"
+
+#: eeschema/dialogs/dialog_lib_new_component_base.cpp:113
+msgid "Show pin name text"
+msgstr "ピン名テキストの表示"
+
+#: eeschema/dialogs/dialog_lib_new_component_base.cpp:117
+msgid "Pin name inside"
+msgstr "ピン名を内側に配置"
+
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:49
+msgid "&Default line width:"
+msgstr "デフォルトの線幅(&D):"
+
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:60
+msgid "D&efault pin length:"
+msgstr "デフォルトのピンの長さ(&e): "
+
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:71
+msgid "De&fault pin number size:"
+msgstr "デフォルトのピン番号サイズ(&f): "
+
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:82
+msgid "Def&ault pin name size:"
+msgstr "デフォルトのピン名サイズ(&a):"
+
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:115
+msgid "&Pitch of repeated pins:"
+msgstr "繰り返しピンのピッチ(&P):"
+
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:119
+msgid "100"
+msgstr "100"
+
+#: eeschema/dialogs/dialog_libedit_options_base.cpp:119
+msgid "50"
+msgstr "50"
+
+#: eeschema/dialogs/dialog_netlist.cpp:295
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:77
+#: pcbnew/dialogs/dialog_drc_base.cpp:25
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:82
+msgid "Options:"
+msgstr "オプション:"
+
+#: eeschema/dialogs/dialog_netlist.cpp:299
+msgid "Default format"
+msgstr "デフォルトの出力形式に設定"
+
+# NET作成して動作確認済み
+#: eeschema/dialogs/dialog_netlist.cpp:381
+msgid "Prefix references 'U' and 'IC' with 'X'"
+msgstr "リファレンス 'U' と 'IC' の前に接頭字 'X' を付ける"
+
+#: eeschema/dialogs/dialog_netlist.cpp:386
+msgid "Use net number as net name"
+msgstr "ネット名にネット番号を使用"
+
+#: eeschema/dialogs/dialog_netlist.cpp:390
+msgid "Simulator command:"
+msgstr "シミュレータ コマンド:"
+
+#: eeschema/dialogs/dialog_netlist.cpp:403
+msgid "&Run Simulator"
+msgstr "シミュレータの起動(&R)"
+
+#: eeschema/dialogs/dialog_netlist.cpp:443
+#: eeschema/dialogs/dialog_netlist_base.cpp:105
+msgid "Netlist command:"
+msgstr "ネットリスト コマンド:"
+
+#: eeschema/dialogs/dialog_netlist.cpp:456
+msgid "Title:"
+msgstr "タイトル:"
+
+#: eeschema/dialogs/dialog_netlist.cpp:536
+msgid "Save Netlist File"
+msgstr "ネットリスト ファイルの保存"
+
+#: eeschema/dialogs/dialog_netlist.cpp:571
+#, c-format
+msgid "%s Export"
+msgstr "エクスポート %s"
+
+#: eeschema/dialogs/dialog_netlist.cpp:622
+msgid "SPICE netlist file (.cir)|*.cir"
+msgstr "SPICEネットリスト ファイル (.cir)|*.cir"
+
+#: eeschema/dialogs/dialog_netlist.cpp:627
+msgid "CadStar netlist file (.frp)|*.frp"
+msgstr "CadStarネットリスト ファイル (.frp)|*.frp"
+
+#: eeschema/dialogs/dialog_netlist.cpp:783
+msgid "This plugin already exists. Abort"
+msgstr "このプラグインは既に存在するため、中止します。"
+
+#: eeschema/dialogs/dialog_netlist.cpp:810
+msgid "Error. You must provide a command String"
+msgstr "エラー: コマンド文字列を設定する必要があります"
+
+#: eeschema/dialogs/dialog_netlist.cpp:816
+msgid "Error. You must provide a Title"
+msgstr "エラー タイトルを設定してください"
+
+#: eeschema/dialogs/dialog_netlist.cpp:874
+msgid "Do not forget to choose a title for this netlist control page"
+msgstr ""
+"このネットリストのコントロールページからタイトルを選択することを忘れないでく"
+"ださい"
+
+#: eeschema/dialogs/dialog_netlist_base.cpp:61
+msgid "Use default netname"
+msgstr "デフォルトのネット名を使用"
+
+#: eeschema/dialogs/dialog_netlist_base.cpp:70
+msgid "Default Netlist Filename:"
+msgstr "デフォルトのネットリスト ファイル名:"
+
+#: eeschema/dialogs/dialog_netlist_base.cpp:136
+msgid "Browse Plugins"
+msgstr "プラグインの参照"
+
+#: eeschema/dialogs/dialog_plot_schematic.cpp:171
+#: pcbnew/dialogs/dialog_SVG_print.cpp:215
+#: pcbnew/dialogs/dialog_gendrill.cpp:295 pcbnew/dialogs/dialog_plot.cpp:311
+#: pcbnew/exporters/gen_modules_placefile.cpp:177
+#: pcbnew/exporters/gen_modules_placefile.cpp:566
+msgid "Select Output Directory"
+msgstr "出力するディレクトリの選択"
+
+#: eeschema/dialogs/dialog_plot_schematic.cpp:183
+#: pcbnew/dialogs/dialog_plot.cpp:321
+#, c-format
+msgid ""
+"Do you want to use a path relative to\n"
+"'%s'"
+msgstr ""
+"下記の相対パスを使用しますか?\n"
+"'%s'"
+
+#: eeschema/dialogs/dialog_plot_schematic.cpp:186
+#: eeschema/dialogs/dialog_plot_schematic.cpp:194
+#: pcbnew/dialogs/dialog_SVG_print.cpp:223
+#: pcbnew/dialogs/dialog_SVG_print.cpp:234
+#: pcbnew/dialogs/dialog_gendrill.cpp:303
+#: pcbnew/dialogs/dialog_gendrill.cpp:314 pcbnew/dialogs/dialog_plot.cpp:324
+#: pcbnew/dialogs/dialog_plot.cpp:331
+#: pcbnew/exporters/gen_modules_placefile.cpp:185
+#: pcbnew/exporters/gen_modules_placefile.cpp:194
+msgid "Plot Output Directory"
+msgstr "出力するディレクトリの選択"
+
+#: eeschema/dialogs/dialog_plot_schematic.cpp:193
+#: pcbnew/dialogs/dialog_plot.cpp:330
+msgid "Cannot make path relative (target volume different from file volume)!"
+msgstr ""
+"パスの関連付けを作成できません (ターゲットボリュームがボードファイルのボ"
+"リュームと異なります"
+
+#: eeschema/dialogs/dialog_plot_schematic.cpp:348
+#: pcbnew/dialogs/dialog_SVG_print.cpp:275
+#, c-format
+msgid "Could not write plot files to folder '%s'."
+msgstr "フォルダ '%s' へプロットファイルを生成できませんでした。"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:24
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:21
+#: pcbnew/dialogs/dialog_gen_module_position_file_base.cpp:26
+#: pcbnew/dialogs/dialog_gendrill_base.cpp:23
+#: pcbnew/dialogs/dialog_plot_base.cpp:45
+msgid "Output directory:"
+msgstr "出力ディレクトリ:"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:33
+msgid ""
+"Target directory for plot files. Can be absolute or relative to the "
+"schematic main file location."
+msgstr ""
+"出図ファイルのターゲットディレクトリです。ボードファイルの位置に絶対パス、ま"
+"たは相対パスが使用できます。"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:37
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:35
+#: pcbnew/dialogs/dialog_gen_module_position_file_base.cpp:40
+#: pcbnew/dialogs/dialog_plot_base.cpp:58
+msgid "Browse..."
+msgstr "参照..."
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:48
+msgid "Paper Options"
+msgstr "用紙設定"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:50
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
+msgid "Schematic size"
+msgstr "回路図の大きさ"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:50
+msgid "Force size A4"
+msgstr "サイズを強制的にA4へ"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:50
+msgid "Force size A"
+msgstr "サイズを強制的にAへ"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:52
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:58
+msgid "Page Size:"
+msgstr "ページ サイズ:"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:56
+#: pcbnew/dialogs/dialog_plot_base.cpp:259
+msgid "HPGL Options"
+msgstr "HPGL オプション"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
+msgid "Page size A4"
+msgstr "ページ サイズ A4"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
+msgid "Page size A3"
+msgstr "ページ サイズ A3"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
+msgid "Page size A2"
+msgstr "ページ サイズ A2"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
+msgid "Page size A1"
+msgstr "ページ サイズ A1"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
+msgid "Page size A0"
+msgstr "ページ サイズ A0"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
+msgid "Page size A"
+msgstr "ページ サイズ A"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
+msgid "Page size B"
+msgstr "ページ サイズ B"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
+msgid "Page size C"
+msgstr "ページ サイズ C"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
+msgid "Page size D"
+msgstr "ページ サイズ D"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
+msgid "Page size E"
+msgstr "ページ サイズ E"
+
+# orペア下層
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:68
+msgid "Bottom left corner"
+msgstr "左下の角"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:68
+msgid "Center of the page"
+msgstr "ページ中央"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:70
+#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:48
+#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:92
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:247
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:302
+#: pcbnew/dialogs/dialog_set_grid_base.cpp:63
+msgid "Origin"
+msgstr "原点"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:74
+msgid "Pen width"
+msgstr "ペン幅"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:88
+#: pcbnew/dialogs/dialog_plot_base.cpp:33
+msgid "Postscript"
+msgstr "PostScript"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:88
+#: pcbnew/dialogs/dialog_gendrill_base.cpp:74
+#: pcbnew/dialogs/dialog_plot_base.cpp:33
+msgid "PDF"
+msgstr "PDF"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:88
+#: pcbnew/dialogs/dialog_gendrill_base.cpp:74
+#: pcbnew/dialogs/dialog_plot_base.cpp:33
+msgid "SVG"
+msgstr "SVG"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:88
+#: pcbnew/dialogs/dialog_gendrill_base.cpp:74
+#: pcbnew/dialogs/dialog_plot_base.cpp:33
+msgid "DXF"
+msgstr "DXF"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:88
+#: pcbnew/dialogs/dialog_gendrill_base.cpp:74
+#: pcbnew/dialogs/dialog_plot_base.cpp:33
+msgid "HPGL"
+msgstr "HPGL"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:97
+msgid "Default line thickness"
+msgstr "標準の線幅"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:103
+msgid ""
+"Selection of the default pen thickness used to draw items, when their "
+"thickness is set to 0."
+msgstr ""
+"太さが０にセットされているアイテムを描画する時の、デフォルトのペン太さを選択"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:107
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:85
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:73
+#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:34
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:112
+msgid "Color"
+msgstr "カラー"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:107
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:85
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:73
+#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:34
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:112
+msgid "Black and white"
+msgstr "モノクロ"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:109
+#: pcbnew/dialogs/dialog_pns_settings_base.cpp:21
+msgid "Mode"
+msgstr "モード"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:111
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:77
+#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:38
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:116
+msgid ""
+"Choose if you want to draw the sheet like it appears on screen,\n"
+"or in black and white mode, better to print it when using  black and white "
+"printers"
+msgstr ""
+"スクリーン表示のような作画や、モノクロモードで\n"
+"モノクロのプリンター使用時に良い印刷をしたい場合に選択"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:115
+msgid "Plot border and title block"
+msgstr "シートの図枠を印刷"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:117
+#: eeschema/dialogs/dialog_print_using_printer_base.cpp:30
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:96
+msgid "Print (or not) the Frame references."
+msgstr "図枠 リファレンスの印刷設定"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:126
+msgid "Plot Current Page"
+msgstr "現在のページをプロット"
+
+#: eeschema/dialogs/dialog_plot_schematic_base.cpp:130
+msgid "Plot All Pages"
+msgstr "全てのページをプロット"
+
+#: eeschema/dialogs/dialog_print_using_printer.cpp:263
+#: eeschema/dialogs/dialog_print_using_printer_base.cpp:47
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:102
+#: pagelayout_editor/dialogs/dialogs_for_printing.cpp:237
+#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:51
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:138
+msgid "Preview"
+msgstr "プレビュー"
+
+#: eeschema/dialogs/dialog_print_using_printer.cpp:304
+msgid "Print Schematic"
+msgstr "回路図の印刷"
+
+#: eeschema/dialogs/dialog_print_using_printer.cpp:309
+msgid "An error occurred attempting to print the schematic."
+msgstr "回路図の印刷中にエラーが発生しました。"
+
+#: eeschema/dialogs/dialog_print_using_printer.cpp:310
+#: pagelayout_editor/dialogs/dialogs_for_printing.cpp:225
+msgid "Printing"
+msgstr "印刷中"
+
+#: eeschema/dialogs/dialog_print_using_printer.cpp:323
+#, c-format
+msgid "Print page %d"
+msgstr "印刷 (ページ:%d)"
+
+#: eeschema/dialogs/dialog_print_using_printer_base.cpp:22
+msgid "Print options:"
+msgstr "印刷設定:"
+
+#: eeschema/dialogs/dialog_print_using_printer_base.cpp:28
+msgid "Print sheet &reference and title block"
+msgstr "シートのリファレンスと図枠の印刷(&R)"
+
+#: eeschema/dialogs/dialog_print_using_printer_base.cpp:34
+msgid "Print in &black and white only"
+msgstr "モノクロ印刷(&B)"
+
+#: eeschema/dialogs/dialog_print_using_printer_base.cpp:44
+msgid "Page Setup"
+msgstr "用紙設定"
+
+#: eeschema/dialogs/dialog_print_using_printer_base.cpp:50
+#: gerbview/dialogs/dialog_print_using_printer.cpp:390
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:105
+#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:54
+#: pcbnew/dialogs/dialog_print_using_printer.cpp:490
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:141
+#: eeschema/dialogs/dialog_print_using_printer_base.h:56
+#: gerbview/dialogs/dialog_print_using_printer_base.h:73
+#: pcbnew/dialogs/dialog_print_for_modedit_base.h:61
+#: pcbnew/dialogs/dialog_print_using_printer_base.h:81
+msgid "Print"
+msgstr "印刷"
+
+#: eeschema/dialogs/dialog_rescue_each.cpp:85
+msgid ""
+"It looks like this project was made using older schematic component "
+"libraries.\n"
+"Some parts may need to be relinked to a different symbol name, and some "
+"symbols\n"
+"may need to be \"rescued\" (cloned and renamed) into a new library.\n"
+"\n"
+"The following changes are recommended to update the project."
+msgstr ""
+"このプロジェクトは古い回路図用のコンポーネントライブラリを使って作られている"
+"ようです。\n"
+"いくつかの部品は別のシンボル名へ再リンクする必要があると思われ, またいくつか"
+"のシンボルは\n"
+"新しいライブラリへ \"レスキュー\" (クローン化とリネーム) が必要と思われま"
+"す。\n"
+"\n"
+"次の変更はプロジェクトをアップデートするために推奨されるものです。"
+
+#: eeschema/dialogs/dialog_rescue_each.cpp:104
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:192
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:609
+msgid "Accept"
+msgstr "適用"
+
+#: eeschema/dialogs/dialog_rescue_each.cpp:105
+msgid "Symbol"
+msgstr "シンボル"
+
+#: eeschema/dialogs/dialog_rescue_each.cpp:106
+msgid "Action"
+msgstr "アクション"
+
+#: eeschema/dialogs/dialog_rescue_each.cpp:280
+msgid ""
+"Stop showing this tool?\n"
+"No changes will be made.\n"
+"\n"
+"This setting can be changed from the \"Component Libraries\" dialog,\n"
+"and the tool can be activated manually from the \"Tools\" menu."
+msgstr ""
+"このツールを終了しますか？\n"
+"何も変更されません. \n"
+"\n"
+"この設定は \"コンポーネント ライブラリ\" ダイアログから変更でき, \n"
+"ツールは \"ツール\" メニューから実行できます."
+
+#: eeschema/dialogs/dialog_rescue_each.cpp:284
+msgid "Rescue Components"
+msgstr "レスキュー コンポーネント"
+
+#: eeschema/dialogs/dialog_rescue_each_base.cpp:23
+msgid "Symbols to update:"
+msgstr "シンボルの更新"
+
+#: eeschema/dialogs/dialog_rescue_each_base.cpp:32
+msgid "Instances of this symbol:"
+msgstr "このシンボルのインスタンス"
+
+#: eeschema/dialogs/dialog_rescue_each_base.cpp:47
+msgid "Cached Part:"
+msgstr "キャッシュされた部品:"
+
+#: eeschema/dialogs/dialog_rescue_each_base.cpp:64
+msgid "Library Part:"
+msgstr "ライブラリの部品:"
+
+#: eeschema/dialogs/dialog_rescue_each_base.cpp:84
+msgid "Never Show Again"
+msgstr "再表示しない"
+
+#: eeschema/dialogs/dialog_sch_edit_sheet_pin.cpp:33 eeschema/lib_pin.cpp:186
+msgid "Tri-state"
+msgstr "トライステート"
+
+#: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.cpp:39
+#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:49
+#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:87
+msgid "Text height:"
+msgstr "テキスト高さ:"
+
+#: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.cpp:51
+#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:57
+#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:95
+msgid "Text width:"
+msgstr "テキスト幅:"
+
+#: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.cpp:63
+msgid "Connection type:"
+msgstr "接続のタイプ:"
+
+#: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:28
+msgid "&File name:"
+msgstr "ファイル名(&F):"
+
+#: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:41
+msgid "Si&ze:"
+msgstr "サイズ(&Z):"
+
+#: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:53
+msgid "&Sheet name:"
+msgstr "シート名(&S):"
+
+#: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:94
+msgid "Unique timestamp:"
+msgstr "固有のタイムスタンプ:"
+
+#: eeschema/dialogs/dialog_schematic_find.cpp:39
+#: eeschema/dialogs/dialog_schematic_find_base.h:76
+#: pcbnew/dialogs/dialog_find_base.h:54
+msgid "Find"
+msgstr "検索"
+
+#: eeschema/dialogs/dialog_schematic_find.cpp:48
+msgid "Find and Replace"
+msgstr "検索と置換"
+
+#: eeschema/dialogs/dialog_schematic_find_base.cpp:28
+msgid "&Search for:"
+msgstr "検索(&S):"
+
+#: eeschema/dialogs/dialog_schematic_find_base.cpp:33
+msgid "Text with optional wildcards"
+msgstr "検索文字列"
+
+# 置換か
+#: eeschema/dialogs/dialog_schematic_find_base.cpp:38
+msgid "Replace &with:"
+msgstr "交換(&W):"
+
+#: eeschema/dialogs/dialog_schematic_find_base.cpp:49
+msgid "Direction:"
+msgstr "向き:"
+
+#: eeschema/dialogs/dialog_schematic_find_base.cpp:58
+msgid "F&orward"
+msgstr "前へ(&O)"
+
+#: eeschema/dialogs/dialog_schematic_find_base.cpp:63
+msgid "&Backward"
+msgstr "後へ(&B)"
+
+#: eeschema/dialogs/dialog_schematic_find_base.cpp:74
+msgid "Match whole wor&d"
+msgstr "全体一致のみ(&D)"
+
+#: eeschema/dialogs/dialog_schematic_find_base.cpp:78
+msgid "&Match case"
+msgstr "大文字/小文字を区別(&M)"
+
+#: eeschema/dialogs/dialog_schematic_find_base.cpp:81
+msgid "Search &using simple wildcard matching"
+msgstr "ワイルドカードを使用(&U)"
+
+#: eeschema/dialogs/dialog_schematic_find_base.cpp:84
+msgid "Wrap around &end of search list"
+msgstr "先頭から検索(&E)"
+
+#: eeschema/dialogs/dialog_schematic_find_base.cpp:88
+msgid "Search all com&ponent fields"
+msgstr "全てのコンポーネントフィールドを検索(&P)"
+
+#: eeschema/dialogs/dialog_schematic_find_base.cpp:91
+msgid "Search all pin &names and numbers"
+msgstr "全てのピン名と番号を検索(&N)"
+
+#: eeschema/dialogs/dialog_schematic_find_base.cpp:94
+msgid "Search the current &sheet onl&y"
+msgstr "現在のシートのみを検索(&S)"
+
+#: eeschema/dialogs/dialog_schematic_find_base.cpp:97
+msgid "Replace componen&t reference designators"
+msgstr "コンポーネントのリファレンス記号の置換(&t)"
+
+#: eeschema/dialogs/dialog_schematic_find_base.cpp:102
+msgid "D&o not warp cursor to found item"
+msgstr "検索したアイテムにカーソルを移動しない(&O)"
+
+#: eeschema/dialogs/dialog_schematic_find_base.cpp:111
+#: eeschema/menubar.cpp:195 pcbnew/menubar_pcbframe.cpp:289
+msgid "&Find"
+msgstr "検索(&F)"
+
+# 置換か
+#: eeschema/dialogs/dialog_schematic_find_base.cpp:115
+msgid "&Replace"
+msgstr "入れ替え(&R)"
+
+#: eeschema/dialogs/dialog_schematic_find_base.cpp:120
+msgid "Replace &All"
+msgstr "全て置換(&A)"
+
+#: eeschema/edit_bitmap.cpp:115 eeschema/edit_bitmap.cpp:125
+#: pagelayout_editor/pl_editor_frame.cpp:646
+#: pagelayout_editor/pl_editor_frame.cpp:653
+#, c-format
+msgid "Couldn't load image from <%s>"
+msgstr "<%s> からイメージを読み込むことが出来ません。"
+
+#: eeschema/edit_component_in_schematic.cpp:73
+#, c-format
+msgid "Edit %s Field"
+msgstr "フィールド %s の編集"
+
+#: eeschema/edit_component_in_schematic.cpp:108
+msgid "Illegal reference string!  No change"
+msgstr "無効なリファレンス文字です! 変更されません"
+
+#: eeschema/edit_component_in_schematic.cpp:117
+msgid "The reference field cannot be empty!  No change"
+msgstr "リファレンス フィールドは空にできません! 変更されません"
+
+#: eeschema/edit_component_in_schematic.cpp:127
+msgid "The value field cannot be empty!  No change"
+msgstr "定数のフィールドは空にできません。"
+
+#: eeschema/eeschema_config.cpp:262 pcbnew/pcbnew_config.cpp:217
+msgid "Read Project File"
+msgstr "プロジェクトファイルの読込み"
+
+#: eeschema/eeschema_config.cpp:493 pcbnew/pcbnew_config.cpp:300
+msgid "Save Project File"
+msgstr "プロジェクト ファイルの保存"
+
+#: eeschema/erc.cpp:89
+msgid "Input Pin.........."
+msgstr "入力ピン.........."
+
+#: eeschema/erc.cpp:90
+msgid "Output Pin........."
+msgstr "出力ピン........."
+
+#: eeschema/erc.cpp:91
+msgid "Bidirectional Pin.."
+msgstr "双方向ピン.."
+
+#: eeschema/erc.cpp:92
+msgid "Tri-State Pin......"
+msgstr "トライステートピン......"
+
+#: eeschema/erc.cpp:93
+msgid "Passive Pin........"
+msgstr "受動ピン........"
+
+#: eeschema/erc.cpp:94
+msgid "Unspecified Pin...."
+msgstr "指定なしピン...."
+
+#: eeschema/erc.cpp:95
+msgid "Power Input Pin...."
+msgstr "電源入力ピン...."
+
+#: eeschema/erc.cpp:96
+msgid "Power Output Pin..."
+msgstr "電源出力ピン..."
+
+#: eeschema/erc.cpp:97
+msgid "Open Collector....."
+msgstr "オープンコレクタ....."
+
+#: eeschema/erc.cpp:98
+msgid "Open Emitter......."
+msgstr "オープンエミッタ....."
+
+#: eeschema/erc.cpp:99
+msgid "No Connection......"
+msgstr "未接続....."
+
+#: eeschema/erc.cpp:105
+msgid "Input Pin"
+msgstr "入力ピン"
+
+#: eeschema/erc.cpp:106
+msgid "Output Pin"
+msgstr "出力ピン"
+
+#: eeschema/erc.cpp:107
+msgid "Bidirectional Pin"
+msgstr "双方向ピン"
+
+#: eeschema/erc.cpp:108
+msgid "Tri-State Pin"
+msgstr "トライステートピン"
+
+#: eeschema/erc.cpp:109
+msgid "Passive Pin"
+msgstr "受動ピン"
+
+#: eeschema/erc.cpp:110
+msgid "Unspecified Pin"
+msgstr "指定なしピン"
+
+#: eeschema/erc.cpp:111
+msgid "Power Input Pin"
+msgstr "電源入力ピン"
+
+#: eeschema/erc.cpp:112
+msgid "Power Output Pin"
+msgstr "電源出力ピン"
+
+#: eeschema/erc.cpp:113
+msgid "Open Collector"
+msgstr "オープンコレクタ"
+
+#: eeschema/erc.cpp:114
+msgid "Open Emitter"
+msgstr "オープンエミッタ"
+
+#: eeschema/erc.cpp:115
+msgid "No Connection"
+msgstr "未接続"
+
+#: eeschema/erc.cpp:209
+msgid "Duplicate sheet name"
+msgstr "シート名の重複"
+
+#: eeschema/erc.cpp:252
+#, c-format
+msgid "Hierarchical label %s is not connected to a sheet label."
+msgstr "階層ラベル %s がシートラベルに接続されていません"
+
+#: eeschema/erc.cpp:261
+#, c-format
+msgid "Global label %s is not connected to any other global label."
+msgstr ""
+
+#: eeschema/erc.cpp:270
+#, c-format
+msgid "Sheet label %s is not connected to a hierarchical label."
+msgstr "シートラベル %s が階層ラベルに接続されていません。"
+
+#: eeschema/erc.cpp:297
+#, c-format
+msgid "Pin %s (%s) of component %s is unconnected."
+msgstr "ピン %s (%s) (コンポーネント %s) が接続されていません。"
+
+#: eeschema/erc.cpp:314
+#, c-format
+msgid "Pin %s (%s) of component %s is not driven (Net %d)."
+msgstr "ピン %s (%s) (コンポーネント %s) は駆動されていません。(Net %d)"
+
+#: eeschema/erc.cpp:328
+msgid "More than 1 pin connected to an UnConnect symbol."
+msgstr "1つ以上のピンが空き端子フラグに接続しています"
+
+#: eeschema/erc.cpp:356
+#, c-format
+msgid "Pin %s (%s) of component %s is connected to "
+msgstr "ピン %s (%s) (コンポーネント %s) が次に接続されています。"
+
+#: eeschema/erc.cpp:361
+#, c-format
+msgid "pin %s (%s) of component %s (net %d)."
+msgstr "ピン %s (%s) コンポーネント %s (ネット %d)."
+
+#: eeschema/erc.cpp:534
+msgid "ERC report"
+msgstr "ERC レポート"
+
+#: eeschema/erc.cpp:536
+msgid "Encoding UTF8"
+msgstr "UTF8 でエンコード"
+
+#: eeschema/erc.cpp:546
+#, c-format
+msgid ""
+"\n"
+"***** Sheet %s\n"
+msgstr ""
+"\n"
+"***** シート %s\n"
+
+#: eeschema/erc.cpp:571
+#, c-format
+msgid ""
+"\n"
+" ** ERC messages: %d  Errors %d  Warnings %d\n"
+msgstr ""
+"\n"
+" ** ERC メッセージ: %d  エラー %d  警告 %d\n"
+
+#: eeschema/files-io.cpp:68
+msgid "Schematic Files"
+msgstr "回路図ファイル"
+
+#: eeschema/files-io.cpp:98
+#, c-format
+msgid "Could not save backup of file '%s'"
+msgstr "ファイル '%s' のバックアップを保存できません"
+
+#: eeschema/files-io.cpp:112
+#: eeschema/netlist_exporters/netlist_exporter_cadstar.cpp:48
+#: eeschema/netlist_exporters/netlist_exporter_orcadpcb2.cpp:51
+#: eeschema/netlist_exporters/netlist_exporter_pspice.cpp:61
+#, c-format
+msgid "Failed to create file '%s'"
+msgstr "ファイルの作成に失敗しました '%s'"
+
+#: eeschema/files-io.cpp:141
+#, c-format
+msgid "File %s saved"
+msgstr "ファイル %s を保存しました"
+
+#: eeschema/files-io.cpp:146
+msgid "File write operation failed."
+msgstr "ファイルの書き込みに失敗しました。"
+
+#: eeschema/files-io.cpp:200
+#, c-format
+msgid "Schematic file '%s' is already open."
+msgstr "この回路図ファイル '%s' は既に開かれています。"
+
+#: eeschema/files-io.cpp:213
+msgid ""
+"The current schematic has been modified.  Do you wish to save the changes?"
+msgstr "現在の回路図は変更されています。変更を保存しますか？"
+
+#: eeschema/files-io.cpp:215 pcbnew/files.cpp:422
+msgid "Save and Load"
+msgstr "保存と読み込み"
+
+#: eeschema/files-io.cpp:216 pcbnew/files.cpp:423
+msgid "Load Without Saving"
+msgstr "保存しないで読み込み"
+
+#: eeschema/files-io.cpp:246
+#, c-format
+msgid "Schematic '%s' does not exist.  Do you wish to create it?"
+msgstr "回路図 '%s' は存在しません。新規作成しますか?"
+
+#: eeschema/files-io.cpp:268
+#, c-format
+msgid ""
+"Ready\n"
+"Project dir: '%s'\n"
+msgstr ""
+"準備完了\n"
+"作業中のディレクトリ: '%s'\n"
+
+#: eeschema/files-io.cpp:353
+msgid "Import Schematic"
+msgstr "回路図のインポート"
+
+#: eeschema/files-io.cpp:463
+msgid ""
+"This operation cannot be undone. Besides, take into account that "
+"hierarchical sheets will not be appended.\n"
+"\n"
+"Do you want to save the current document before proceeding?"
+msgstr ""
+"この操作はやり直しができません．しかも，階層化された回路図は追加できないこと"
+"に注意してください．\n"
+"\n"
+"操作を続行する前に現在の作業内容を保存しますか？"
+
+#: eeschema/files-io.cpp:487
+#, c-format
+msgid "Directory '%s' is not writable"
+msgstr "ディレクトリ '%s' は書き込み禁止されています"
+
+#: eeschema/find.cpp:100
+#, c-format
+msgid "Design rule check marker found in sheet %s at %0.3f%s, %0.3f%s"
+msgstr ""
+"シート %s の %0.3f%s, %0.3f%s にデザイン ルール チェック マーカーが見つかりま"
+"した。"
+
+#: eeschema/find.cpp:106
+msgid "No more markers were found."
+msgstr "これ以上マーカーは見つかりませんでした。"
+
+#: eeschema/find.cpp:243
+msgid "component"
+msgstr "コンポーネント"
+
+#: eeschema/find.cpp:247
+#, c-format
+msgid "pin %s"
+msgstr "ピン %s"
+
+#: eeschema/find.cpp:251
+#, c-format
+msgid "reference %s"
+msgstr "リファレンス %s"
+
+#: eeschema/find.cpp:255
+msgid "value"
+msgstr "定数"
+
+#: eeschema/find.cpp:259
+msgid "field"
+msgstr "フィールド"
+
+#: eeschema/find.cpp:267
+#, c-format
+msgid "%s %s found"
+msgstr "%s  %s が見つかりました"
+
+#: eeschema/find.cpp:272
+#, c-format
+msgid "%s found but %s not found"
+msgstr "%s が見つかりましたが %s が見つかりません"
+
+#: eeschema/find.cpp:278
+#, c-format
+msgid "Component %s not found"
+msgstr "コンポーネント %s が見つかりません"
+
+#: eeschema/find.cpp:492
+#, c-format
+msgid "No item found matching %s."
+msgstr "%s にマッチするアイテムは見つかりませんでした。"
+
+#: eeschema/getpart.cpp:152
+msgid "History"
+msgstr "履歴"
+
+#: eeschema/getpart.cpp:158
+#, c-format
+msgid "Choose Component (%d items loaded)"
+msgstr "コンポーネントの選択 (%d アイテムが読込まれています)"
+
+#: eeschema/getpart.cpp:216
+#, c-format
+msgid "Failed to find part '%s' in library"
+msgstr "ライブラリ中にコンポーネント '%s' が見つかりませんでした"
+
+#: eeschema/hierarch.cpp:147
+msgid "Navigator"
+msgstr "ナビゲータ"
+
+#: eeschema/hierarch.cpp:157
+msgid "Root"
+msgstr "ルート"
+
+#: eeschema/hotkeys.cpp:735
+msgid "Add Pin"
+msgstr "ピンの追加"
+
+#: eeschema/lib_arc.cpp:95 gerbview/class_gerber_draw_item.cpp:186
+#: pcbnew/class_board_item.cpp:44 pcbnew/class_drawsegment.cpp:377
+msgid "Arc"
+msgstr "円弧"
+
+#: eeschema/lib_arc.cpp:136
+#, c-format
+msgid "Arc only had %d parameters of the required 8"
+msgstr "円弧は8個のパラメータが必要ですが、%d個しか定義されていません。"
+
+#: eeschema/lib_arc.cpp:565 eeschema/lib_bezier.cpp:417
+#: eeschema/lib_circle.cpp:279 eeschema/lib_polyline.cpp:409
+#: eeschema/lib_rectangle.cpp:256 eeschema/lib_text.cpp:424
+#: pcb_calculator/transline_ident.cpp:186
+#: pcb_calculator/transline_ident.cpp:216
+#: pcb_calculator/transline_ident.cpp:248
+#: pcb_calculator/transline_ident.cpp:353
+#: pcb_calculator/transline_ident.cpp:388
+msgid "Line Width"
+msgstr "線幅"
+
+#: eeschema/lib_arc.cpp:570 eeschema/lib_bezier.cpp:422
+#: eeschema/lib_circle.cpp:287 eeschema/lib_polyline.cpp:414
+msgid "Bounding Box"
+msgstr "バウンディング ボックス"
+
+#: eeschema/lib_arc.cpp:576
+#, c-format
+msgid "Arc center (%s, %s), radius %s"
+msgstr "円弧 中心 (%s, %s) 半径 %s"
+
+#: eeschema/lib_bezier.cpp:51
+msgid "Bezier"
+msgstr "ベジェ曲線"
+
+#: eeschema/lib_bezier.cpp:83
+#, c-format
+msgid "Bezier only had %d parameters of the required 4"
+msgstr "ベジェ曲線には4つのパラメータが必要ですが %d しかありません"
+
+#: eeschema/lib_bezier.cpp:89
+#, c-format
+msgid "Bezier count parameter %d is invalid"
+msgstr "ベジェ曲線の %d 番目のパラメータが不正です"
+
+#: eeschema/lib_bezier.cpp:105
+#, c-format
+msgid "Bezier point %d X position not defined"
+msgstr "ベジェ曲線の %d ポイントのX座標が定義されていません"
+
+#: eeschema/lib_bezier.cpp:113
+#, c-format
+msgid "Bezier point %d Y position not defined"
+msgstr "ベジェ曲線の %d ポイントのY座標が定義されていません"
+
+#: eeschema/lib_circle.cpp:53 gerbview/class_gerber_draw_item.cpp:189
+#: pcbnew/class_board_item.cpp:45 pcbnew/class_drawsegment.cpp:373
+#: pcbnew/class_pad.cpp:861
+msgid "Circle"
+msgstr "円"
+
+#: eeschema/lib_circle.cpp:76
+#, c-format
+msgid "Circle only had %d parameters of the required 6"
+msgstr "円は6個のパラメータが必要ですが、%d個しか定義されていません。"
+
+#: eeschema/lib_circle.cpp:282
+msgid "Radius"
+msgstr "半径"
+
+#: eeschema/lib_circle.cpp:293
+#, c-format
+msgid "Circle center (%s, %s), radius %s"
+msgstr "円 中心 (%s, %s) 半径 %s"
+
+#: eeschema/lib_draw_item.cpp:55
+msgid "Undefined"
+msgstr "未定義"
+
+#: eeschema/lib_draw_item.cpp:68 eeschema/lib_draw_item.cpp:75
+msgid "All"
+msgstr "全て"
+
+#: eeschema/lib_draw_item.cpp:77
+msgid "no"
+msgstr "いいえ"
+
+#: eeschema/lib_draw_item.cpp:79
+msgid "yes"
+msgstr "はい"
+
+#: eeschema/lib_draw_item.cpp:83 eeschema/libedit.cpp:496
+#: eeschema/onrightclick.cpp:440
+msgid "Convert"
+msgstr "シンボル変換"
+
+#: eeschema/lib_export.cpp:51
+msgid "Import Component"
+msgstr "コンポーネントのインポート"
+
+#: eeschema/lib_export.cpp:72
+#, c-format
+msgid ""
+"Unable to import library '%s'.  Error:\n"
+"%s"
+msgstr ""
+"ライブラリ '%s' の読込みに失敗しました。\n"
+"エラー: %s"
+
+#: eeschema/lib_export.cpp:86
+#, c-format
+msgid "Part library file '%s' is empty."
+msgstr "コンポーネント ライブラリ ファイル '%s' は空です。"
+
+#: eeschema/lib_export.cpp:113
+msgid "There is no component selected to save."
+msgstr "保存するコンポーネントが選択されていません。"
+
+#: eeschema/lib_export.cpp:121
+msgid "New Library"
+msgstr "新規ライブラリ"
+
+#: eeschema/lib_export.cpp:121
+msgid "Export Component"
+msgstr "コンポーネントのエクスポート"
+
+#: eeschema/lib_export.cpp:176
+#, c-format
+msgid "'%s' - OK"
+msgstr "'%s' - OK"
+
+#: eeschema/lib_export.cpp:178
+msgid ""
+"This library will not be available until it is loaded by Eeschema.\n"
+"\n"
+"Modify the Eeschema library configuration if you want to include it as part "
+"of this project."
+msgstr ""
+"このライブラリは Eeschema に読込まれるまで使用できません。\n"
+"\n"
+"このプロジェクトのパーツとして取り込む場合は Eeschema のライブラリ設定を変更"
+"してください。"
+
+#: eeschema/lib_export.cpp:184
+#, c-format
+msgid "'%s' - Export OK"
+msgstr "'%s' - エクスポートOK"
+
+#: eeschema/lib_export.cpp:189
+#, c-format
+msgid "Error creating '%s'"
+msgstr "ファイル '%s' 生成時エラー"
+
+#: eeschema/lib_field.cpp:72 eeschema/lib_field.cpp:756
+#: eeschema/template_fieldnames.cpp:55
+msgid "Field"
+msgstr "フィールド"
+
+#: eeschema/lib_field.cpp:588 eeschema/onrightclick.cpp:433
+#: eeschema/sch_component.cpp:1536 eeschema/template_fieldnames.cpp:45
+#: pcbnew/class_edge_mod.cpp:260 pcbnew/class_module.cpp:616
+#: pcbnew/class_pad.cpp:628 pcbnew/class_text_mod.cpp:369
+#: pcbnew/loadcmp.cpp:436
+msgid "Footprint"
+msgstr "フットプリント"
+
+#: eeschema/lib_field.cpp:595 eeschema/libedit.cpp:510
+#: eeschema/template_fieldnames.cpp:48
+msgid "Datasheet"
+msgstr "データシート"
+
+#: eeschema/lib_field.cpp:604
+#, c-format
+msgid "Field%d"
+msgstr "フィールド%d"
+
+#: eeschema/lib_field.cpp:667
+#, c-format
+msgid "Field %s %s"
+msgstr "フィールド %s %s"
+
+#: eeschema/lib_field.cpp:749 pcbnew/class_drawsegment.cpp:410
+#: pcbnew/class_pad.cpp:650 pcbnew/class_pcb_text.cpp:154
+#: pcbnew/class_text_mod.cpp:401 pcbnew/class_track.cpp:1157
+#: pcbnew/class_track.cpp:1184 pcbnew/dialogs/dialog_design_rules_base.cpp:327
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:48
+msgid "Width"
+msgstr "幅"
+
+#: eeschema/lib_field.cpp:752 pcbnew/class_pad.cpp:653
+#: pcbnew/class_pcb_text.cpp:157 pcbnew/class_text_mod.cpp:404
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:56
+msgid "Height"
+msgstr "高さ"
+
+#: eeschema/lib_pin.cpp:188
+msgid "Unspecified"
+msgstr "不特定"
+
+#: eeschema/lib_pin.cpp:189
+msgid "Power input"
+msgstr "電源入力"
+
+#: eeschema/lib_pin.cpp:190
+msgid "Power output"
+msgstr "電源出力"
+
+#: eeschema/lib_pin.cpp:191
+msgid "Open collector"
+msgstr "オープンコレクタ"
+
+#: eeschema/lib_pin.cpp:192
+msgid "Open emitter"
+msgstr "オープンエミッタ"
+
+#: eeschema/lib_pin.cpp:193
+msgid "Not connected"
+msgstr "未接続"
+
+#: eeschema/lib_pin.cpp:207 gerbview/class_gerber_draw_item.cpp:183
+#: pcbnew/class_board_item.cpp:42
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:241
+#: pcbnew/dialogs/dialog_keepout_area_properties_base.cpp:53
+#: pcbnew/dialogs/dialog_non_copper_zones_properties_base.cpp:52
+msgid "Line"
+msgstr "ライン"
+
+#: eeschema/lib_pin.cpp:208
+msgid "Inverted"
+msgstr "反転"
+
+#: eeschema/lib_pin.cpp:209
+msgid "Clock"
+msgstr "クロック"
+
+# 8973～8988要確認
+#: eeschema/lib_pin.cpp:210
+msgid "Inverted clock"
+msgstr "反転クロック"
+
+#: eeschema/lib_pin.cpp:211
+msgid "Input low"
+msgstr "負論理入力"
+
+#: eeschema/lib_pin.cpp:212
+msgid "Clock low"
+msgstr "負論理クロック"
+
+#: eeschema/lib_pin.cpp:213
+msgid "Output low"
+msgstr "負論理出力"
+
+#: eeschema/lib_pin.cpp:214
+msgid "Falling edge clock"
+msgstr "ネガティブエッジ クロック"
+
+#: eeschema/lib_pin.cpp:215
+msgid "NonLogic"
+msgstr "非ロジック"
+
+#: eeschema/lib_pin.cpp:2008 pcbnew/class_drawsegment.cpp:391
+#: pcbnew/class_track.cpp:1045
+msgid "Length"
+msgstr "長さ"
+
+#: eeschema/lib_pin.cpp:2011 eeschema/sch_text.cpp:756
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:112
+msgid "Orientation"
+msgstr "角度"
+
+#: eeschema/lib_pin.cpp:2269
+#, c-format
+msgid "Pin %s, %s, %s"
+msgstr "ピン %s, %s, %s"
+
+#: eeschema/lib_polyline.cpp:53
+msgid "PolyLine"
+msgstr "ポリライン"
+
+#: eeschema/lib_polyline.cpp:88
+#, c-format
+msgid "Polyline only had %d parameters of the required 4"
+msgstr "ポリラインは4個のパラメータが必要ですが、%d個しか定義されていません。"
+
+#: eeschema/lib_polyline.cpp:94
+#, c-format
+msgid "Polyline count parameter %d is invalid"
+msgstr "ポリラインのカウントパラメータ %d が不正です"
+
+#: eeschema/lib_polyline.cpp:110
+#, c-format
+msgid "Polyline point %d X position not defined"
+msgstr "ポリラインの座標点%dのX座標は定義されていません"
+
+#: eeschema/lib_polyline.cpp:118
+#, c-format
+msgid "Polyline point %d Y position not defined"
+msgstr "ポリラインの座標点%dのY座標は定義されていません"
+
+#: eeschema/lib_polyline.cpp:420
+#, c-format
+msgid "Polyline at (%s, %s) with %d points"
+msgstr ""
+
+#: eeschema/lib_rectangle.cpp:51
+msgid "Rectangle"
+msgstr "矩形"
+
+#: eeschema/lib_rectangle.cpp:78
+#, c-format
+msgid "Rectangle only had %d parameters of the required 7"
+msgstr "矩形には7つのパラメータが必要ですが %d しかありません"
+
+#: eeschema/lib_rectangle.cpp:332
+#, c-format
+msgid "Rectangle from (%s, %s) to (%s, %s)"
+msgstr "矩形 始点 (%s, %s) 終点 (%s, %s)"
+
+#: eeschema/lib_text.cpp:132
+#, c-format
+msgid "Text only had %d parameters of the required 8"
+msgstr "テキストには8個のパラメータが必要ですが、%d個しか定義されていません。"
+
+#: eeschema/lib_text.cpp:485 eeschema/sch_text.cpp:603
+#, c-format
+msgid "Graphic Text %s"
+msgstr "図形テキスト %s"
+
+#: eeschema/libarch.cpp:101 eeschema/project_rescue.cpp:61
+#, c-format
+msgid "An error occurred attempting to save component library '%s'."
+msgstr ""
+"コンポーネント ライブラリ '%s' を保存しようとしたところエラーが発生しました。"
+
+#: eeschema/libarch.cpp:111 eeschema/libedit.cpp:406
+#: eeschema/project_rescue.cpp:71
+#, c-format
+msgid "Failed to create component library file '%s'"
+msgstr "コンポーネントライブラリファイル '%s' が作成できませんでした。"
+
+#: eeschema/libedit.cpp:53
+msgid "Part Library Editor: "
+msgstr "コンポーネントライブラリエディタ:"
+
+#: eeschema/libedit.cpp:65 eeschema/viewlibs.cpp:141
+#: pcbnew/modview_frame.cpp:708
+msgid "no library selected"
+msgstr "ライブラリが選択されていません"
+
+#: eeschema/libedit.cpp:89 eeschema/libedit.cpp:120
+msgid ""
+"The current component is not saved.\n"
+"\n"
+"Discard current changes?"
+msgstr ""
+"現在のパーツは保存されていません。\n"
+"\n"
+"現在の変更を破棄しますか？"
+
+#: eeschema/libedit.cpp:168
+msgid "The selected component is not in the active library."
+msgstr "選択されたコンポーネントは、アクティブなライブラリ中にありません."
+
+#: eeschema/libedit.cpp:170
+msgid "Do you want to change the active library?"
+msgstr "アクティブなライブラリを変更して宜しいですか？"
+
+#: eeschema/libedit.cpp:180
+#, c-format
+msgid "Part name '%s' not found in library '%s'"
+msgstr "コンポーネント名 \"%s\" はライブラリ \"%s\" 中に見つかりませんでした。"
+
+#: eeschema/libedit.cpp:315 eeschema/libeditframe.cpp:731
+msgid "No library specified."
+msgstr "指定されたライブラリがありません。"
+
+#: eeschema/libedit.cpp:321
+msgid "Include last component changes?"
+msgstr "最後のコンポーネントの変更を含めますか？"
+
+#: eeschema/libedit.cpp:336
+msgid "Part Library Name:"
+msgstr "コンポーネントライブラリ名:"
+
+#: eeschema/libedit.cpp:356
+#, c-format
+msgid "Modify library file '%s' ?"
+msgstr "ライブラリファイル '%s' を変更しますか?"
+
+#: eeschema/libedit.cpp:396
+#, c-format
+msgid "Error occurred while saving library file '%s'"
+msgstr "ライブラリファイル '%s' の保存中にエラーが発生しました"
+
+#: eeschema/libedit.cpp:398 eeschema/libedit.cpp:440
+msgid "*** ERROR: ***"
+msgstr "***エラー: ***"
+
+#: eeschema/libedit.cpp:438
+#, c-format
+msgid "Error occurred while saving library documentation file <%s>"
+msgstr "ライブラリドキュメントファイル <%s> の保存中にエラーが発生しました"
+
+#: eeschema/libedit.cpp:448
+#, c-format
+msgid "Failed to create component document library file <%s>"
+msgstr ""
+"コンポーネントのドキュメントライブラリファイル <%s> が作成できませんでした"
+
+#: eeschema/libedit.cpp:454
+#, c-format
+msgid "Library file '%s' OK"
+msgstr "ライブラリファイル '%s' : OK"
+
+#: eeschema/libedit.cpp:457
+#, c-format
+msgid "Documentation file '%s' OK"
+msgstr "ドキュメントファイル '%s' OK"
+
+#: eeschema/libedit.cpp:480 eeschema/viewlibs.cpp:295
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:50
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:130
+#: pcbnew/dialogs/dialog_copper_zones_base.cpp:154
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:200
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:324
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:474
+#: pcbnew/dialogs/dialog_plot_base.cpp:144
+msgid "None"
+msgstr "なし"
+
+#: eeschema/libedit.cpp:503
+msgid "Power Symbol"
+msgstr "電源シンボル"
+
+#: eeschema/libedit.cpp:505 eeschema/viewlibs.cpp:306
+msgid "Part"
+msgstr "パーツ"
+
+#: eeschema/libedit.cpp:509 eeschema/viewlibs.cpp:309
+msgid "Key words"
+msgstr "キーワード"
+
+#: eeschema/libedit.cpp:535
+msgid "Please select a component library."
+msgstr "コンポーネント ライブラリを選択してください"
+
+#: eeschema/libedit.cpp:544
+#, c-format
+msgid "Part library '%s' is empty."
+msgstr "コンポーネント ライブラリ '%s' は空です。"
+
+#: eeschema/libedit.cpp:545
+msgid "Delete Entry Error"
+msgstr "Delete Entry エラー"
+
+#: eeschema/libedit.cpp:549
+#, c-format
+msgid ""
+"Select one of %d components to delete\n"
+"from library '%s'."
+msgstr ""
+
+#: eeschema/libedit.cpp:553
+msgid "Delete Part"
+msgstr "コンポーネントの削除"
+
+#: eeschema/libedit.cpp:562
+#, c-format
+msgid "Entry '%s' not found in library '%s'."
+msgstr "エントリー '%s' が ライブラリ '%s' 中に存在しません。"
+
+#: eeschema/libedit.cpp:569
+#, c-format
+msgid "Delete component '%s' from library '%s' ?"
+msgstr "コンポーネント '%s' をライブラリ '%s' から削除して宜しいですか？"
+
+#: eeschema/libedit.cpp:588
+msgid ""
+"The component being deleted has been modified. All changes will be lost. "
+"Discard changes?"
+msgstr ""
+"削除しようとしているコンポーネントは編集されています。全ての変更が失われま"
+"す。変更を取りやめますか？"
+
+#: eeschema/libedit.cpp:617
+msgid ""
+"All changes to the current component will be lost!\n"
+"\n"
+"Clear the current component from the screen?"
+msgstr ""
+"現在のコンポーネントの全ての変更が失われます!\n"
+"\n"
+"スクリーンから現在のコンポーネントをクリアしますか？"
+
+#: eeschema/libedit.cpp:636
+msgid "This new component has no name and cannot be created. Aborted"
+msgstr "この新しいコンポーネントは名前がなく、作成できませんでした。中止"
+
+#: eeschema/libedit.cpp:649
+#, c-format
+msgid "Part '%s' already exists in library '%s'"
+msgstr "コンポーネント '%s' は既にライブラリ '%s' 内に既に存在します。"
+
+#: eeschema/libedit.cpp:721
+#, c-format
+msgid "Part '%s' already exists. Change it?"
+msgstr "コンポーネント '%s' は既に存在します。変更して宜しいですか？"
+
+#: eeschema/libedit.cpp:735
+#, c-format
+msgid "Part '%s' saved in library '%s'"
+msgstr "コンポーネント '%s' がライブラリ '%s' 内に保存されました"
+
+#: eeschema/libedit_onrightclick.cpp:88 eeschema/onrightclick.cpp:158
+#: gerbview/onrightclick.cpp:62 pcbnew/modedit_onclick.cpp:232
+#: pcbnew/onrightclick.cpp:87
+msgid "End Tool"
+msgstr "ツールの終了"
+
+#: eeschema/libedit_onrightclick.cpp:118
+msgid "Move Arc"
+msgstr "円弧の移動"
+
+#: eeschema/libedit_onrightclick.cpp:122
+msgid "Drag Arc Size"
+msgstr "円弧サイズのドラッグ"
+
+#: eeschema/libedit_onrightclick.cpp:126
+msgid "Edit Arc Options"
+msgstr "円弧オプションの編集"
+
+#: eeschema/libedit_onrightclick.cpp:131
+msgid "Delete Arc"
+msgstr "円弧の削除"
+
+#: eeschema/libedit_onrightclick.cpp:139
+msgid "Move Circle"
+msgstr "円の移動"
+
+#: eeschema/libedit_onrightclick.cpp:143
+msgid "Drag Circle Outline"
+msgstr "円のアウトラインをドラッグ"
+
+#: eeschema/libedit_onrightclick.cpp:148
+msgid "Edit Circle Options"
+msgstr "円のオプションを編集"
+
+#: eeschema/libedit_onrightclick.cpp:154
+msgid "Delete Circle"
+msgstr "円の削除"
+
+#: eeschema/libedit_onrightclick.cpp:163
+msgid "Move Rectangle"
+msgstr "矩形の移動"
+
+#: eeschema/libedit_onrightclick.cpp:169
+msgid "Edit Rectangle Options"
+msgstr "矩形オプションの編集"
+
+#: eeschema/libedit_onrightclick.cpp:175
+msgid "Drag Rectangle Edge"
+msgstr "矩形の端をドラッグ"
+
+#: eeschema/libedit_onrightclick.cpp:178
+msgid "Delete Rectangle"
+msgstr "矩形の削除"
+
+#: eeschema/libedit_onrightclick.cpp:188 eeschema/onrightclick.cpp:597
+#: pcbnew/modedit_onclick.cpp:343 pcbnew/onrightclick.cpp:882
+msgid "Move Text"
+msgstr "テキストの移動"
+
+#: eeschema/libedit_onrightclick.cpp:194 eeschema/onrightclick.cpp:96
+#: eeschema/onrightclick.cpp:607 pcbnew/modedit_onclick.cpp:379
+#: pcbnew/onrightclick.cpp:898
+msgid "Edit Text"
+msgstr "テキストの編集"
+
+#: eeschema/libedit_onrightclick.cpp:197 eeschema/onrightclick.cpp:605
+#: pcbnew/modedit_onclick.cpp:349 pcbnew/onrightclick.cpp:892
+msgid "Rotate Text"
+msgstr "テキストの回転"
+
+#: eeschema/libedit_onrightclick.cpp:202 eeschema/onrightclick.cpp:609
+#: pcbnew/modedit_onclick.cpp:385 pcbnew/onrightclick.cpp:909
+msgid "Delete Text"
+msgstr "テキストの削除"
+
+#: eeschema/libedit_onrightclick.cpp:210
+msgid "Move Line"
+msgstr "線の移動"
+
+#: eeschema/libedit_onrightclick.cpp:214
+msgid "Drag Edge Point"
+msgstr "端点のドラッグ"
+
+#: eeschema/libedit_onrightclick.cpp:220
+msgid "Line End"
+msgstr "線の終端"
+
+#: eeschema/libedit_onrightclick.cpp:224
+msgid "Edit Line Options"
+msgstr "線オプションの編集"
+
+#: eeschema/libedit_onrightclick.cpp:230
+msgid "Delete Line "
+msgstr "線の削除"
+
+#: eeschema/libedit_onrightclick.cpp:239 pcbnew/onrightclick.cpp:654
+msgid "Delete Segment"
+msgstr "セグメント削除"
+
+#: eeschema/libedit_onrightclick.cpp:250 eeschema/onrightclick.cpp:306
+msgid "Move Field"
+msgstr "フィールドの移動"
+
+#: eeschema/libedit_onrightclick.cpp:256
+msgid "Field Rotate"
+msgstr "フィールドの回転"
+
+#: eeschema/libedit_onrightclick.cpp:258
+msgid "Field Edit"
+msgstr "フィールドの編集"
+
+#: eeschema/libedit_onrightclick.cpp:283
+msgid "Move Pin "
+msgstr "ピンの移動"
+
+#: eeschema/libedit_onrightclick.cpp:288
+msgid "Edit Pin "
+msgstr "ピンの編集"
+
+#: eeschema/libedit_onrightclick.cpp:291
+msgid "Rotate Pin "
+msgstr "ピンの回転"
+
+#: eeschema/libedit_onrightclick.cpp:296
+msgid "Delete Pin "
+msgstr "ピンの削除"
+
+#: eeschema/libedit_onrightclick.cpp:303
+msgid "Global"
+msgstr "グローバル"
+
+#: eeschema/libedit_onrightclick.cpp:306
+msgid "Pin Size to selected pins"
+msgstr "選択したピンのピンサイズ"
+
+#: eeschema/libedit_onrightclick.cpp:307
+msgid "Pin Size to Others"
+msgstr "他のピンサイズ"
+
+#: eeschema/libedit_onrightclick.cpp:310
+msgid "Pin Name Size to selected pin"
+msgstr "選択したピンのピン名サイズ"
+
+#: eeschema/libedit_onrightclick.cpp:311
+msgid "Pin Name Size to Others"
+msgstr "他のピン名サイズ"
+
+#: eeschema/libedit_onrightclick.cpp:314
+msgid "Pin Num Size to selected pin"
+msgstr "選択したピンのピン番号サイズ"
+
+#: eeschema/libedit_onrightclick.cpp:315
+msgid "Pin Num Size to Others"
+msgstr "他のピンのピン番号サイズ"
+
+#: eeschema/libedit_onrightclick.cpp:323 eeschema/onrightclick.cpp:827
+#: gerbview/onrightclick.cpp:73 pcbnew/modedit_onclick.cpp:244
+#: pcbnew/onrightclick.cpp:495
+msgid "Cancel Block"
+msgstr "ブロックのキャンセル"
+
+#: eeschema/libedit_onrightclick.cpp:328 pcbnew/modedit_onclick.cpp:246
+msgid "Zoom Block (drag middle mouse)"
+msgstr "ブロック ズーム(マウスの中ボタンでドラッグ)"
+
+#: eeschema/libedit_onrightclick.cpp:333 eeschema/onrightclick.cpp:835
+#: gerbview/onrightclick.cpp:76 pcbnew/modedit_onclick.cpp:250
+#: pcbnew/onrightclick.cpp:499
+msgid "Place Block"
+msgstr "ブロックの配置"
+
+#: eeschema/libedit_onrightclick.cpp:337
+msgid "Select Items"
+msgstr "アイテム選択"
+
+#: eeschema/libedit_onrightclick.cpp:339 eeschema/onrightclick.cpp:844
+#: pcbnew/onrightclick.cpp:500
+msgid "Copy Block"
+msgstr "ブロックのコピー"
+
+#: eeschema/libedit_onrightclick.cpp:340 eeschema/onrightclick.cpp:849
+msgid "Mirror Block ||"
+msgstr "ブロックの縦軸ミラー"
+
+#: eeschema/libedit_onrightclick.cpp:342 eeschema/onrightclick.cpp:852
+msgid "Mirror Block --"
+msgstr "ブロックの横軸ミラー"
+
+#: eeschema/libedit_onrightclick.cpp:344
+msgid "Rotate Block ccw"
+msgstr "ブロックを反時計周り"
+
+#: eeschema/libedit_onrightclick.cpp:346 eeschema/onrightclick.cpp:848
+#: pcbnew/onrightclick.cpp:503
+msgid "Delete Block"
+msgstr "ブロックの削除"
+
+#: eeschema/libedit_plot_component.cpp:57
+msgid "No component"
+msgstr "コンポーネントがありません"
+
+#: eeschema/libedit_plot_component.cpp:74
+#: eeschema/libedit_plot_component.cpp:97
+msgid "Filename:"
+msgstr "ファイル名:"
+
+#: eeschema/libedit_plot_component.cpp:139
+#, c-format
+msgid "Can't save file <%s>"
+msgstr "ファイル <%s> が保存できません"
+
+#: eeschema/libeditframe.cpp:181
+msgid "Library Editor"
+msgstr "コンポーネント ライブラリ エディタ"
+
+#: eeschema/libeditframe.cpp:317
+msgid "Save the changes in the library before closing?"
+msgstr "終了前にライブラリの変更を保存しますか？"
+
+#: eeschema/libeditframe.cpp:344
+#, c-format
+msgid ""
+"Library '%s' was modified!\n"
+"Discard changes?"
+msgstr ""
+"ライブラリ '%s'は編集されています! \n"
+"変更を破棄しますか？"
+
+#: eeschema/libeditframe.cpp:450 eeschema/onrightclick.cpp:451
+#, c-format
+msgid "Unit %s"
+msgstr "ユニット %s"
+
+#: eeschema/libeditframe.cpp:718
+msgid "No part to save."
+msgstr "保存するコンポーネントがありません。"
+
+#: eeschema/libeditframe.cpp:1110
+msgid "Add pin"
+msgstr "ピンの追加"
+
+#: eeschema/libeditframe.cpp:1114
+msgid "Set pin options"
+msgstr "ピンのオプションをセット"
+
+#: eeschema/libeditframe.cpp:1125 eeschema/schedit.cpp:559
+#: pcbnew/edit.cpp:1488 pcbnew/modedit.cpp:951
+#: pcbnew/tools/drawing_tool.cpp:1230 pcbnew/tools/drawing_tool.cpp:1354
+msgid "Add text"
+msgstr "テキストの追加"
+
+#: eeschema/libeditframe.cpp:1129
+msgid "Add rectangle"
+msgstr "矩形を追加"
+
+#: eeschema/libeditframe.cpp:1133 pcbnew/modedit.cpp:947
+msgid "Add circle"
+msgstr "円を追加"
+
+#: eeschema/libeditframe.cpp:1137 pcbnew/modedit.cpp:943
+msgid "Add arc"
+msgstr "円弧の追加"
+
+#: eeschema/libeditframe.cpp:1141 pcbnew/modedit.cpp:939
+msgid "Add line"
+msgstr "線の追加"
+
+#: eeschema/libeditframe.cpp:1145
+msgid "Set anchor position"
+msgstr "アンカー位置の設定"
+
+#: eeschema/libeditframe.cpp:1149
+msgid "Import"
+msgstr "インポート"
+
+#: eeschema/libeditframe.cpp:1167 eeschema/schedit.cpp:595
+#: pcbnew/edit.cpp:1500 pcbnew/modedit.cpp:976
+#: pcbnew/tools/pcbnew_control.cpp:752 eeschema/help_common_strings.h:48
+msgid "Delete item"
+msgstr "アイテム削除"
+
+#: eeschema/libfield.cpp:57
+msgid "Component Name"
+msgstr "コンポーネント名"
+
+#: eeschema/libfield.cpp:58
+msgid "Enter a name to create a new component based on this one."
+msgstr ""
+"このパーツをベースとして新しいコンポーネントを作成するための名前を入力してく"
+"ださい。"
+
+#: eeschema/libfield.cpp:62
+#, c-format
+msgid "Edit Field %s"
+msgstr "フィールドの編集 %s"
+
+#: eeschema/libfield.cpp:63
+#, c-format
+msgid "Enter a new value for the %s field."
+msgstr "%s フィールドの新しい値を入力してください。"
+
+#: eeschema/libfield.cpp:79
+#, c-format
+msgid "A %s field cannot be empty."
+msgstr "%s フィールドは空にできません。"
+
+#: eeschema/libfield.cpp:88
+msgid "Illegal reference. A reference must start by a letter"
+msgstr ""
+"無効なリファレンスです。リファレンスはアルファベット文字で始まる必要がありま"
+"す。"
+
+#: eeschema/libfield.cpp:108
+#, c-format
+msgid ""
+"The name '%s' conflicts with an existing entry in the component library "
+"'%s'.\n"
+"\n"
+"Do you wish to replace the current component in library with this one?"
+msgstr ""
+" '%s' という名前はコンポーネント ライブラリ '%s' 内の既存エントリと衝突しま"
+"す。\n"
+"\n"
+"現在のコンポーネントをライブラリ内のコンポーネントと交換しますか？"
+
+#: eeschema/libfield.cpp:114 eeschema/libfield.cpp:130
+#: eeschema/libfield.cpp:149
+msgid "Confirm"
+msgstr "確認"
+
+#: eeschema/libfield.cpp:125
+#, c-format
+msgid ""
+"The current component already has an alias named '%s'.\n"
+"\n"
+"Do you wish to remove this alias from the component?"
+msgstr ""
+"現在のコンポーネントは既にエイリアス名 '%s' を持っています。\n"
+"\n"
+"このエイリアスをコンポーネントから削除しますか？"
+
+#: eeschema/libfield.cpp:144
+#, c-format
+msgid ""
+"The new component contains alias names that conflict with entries in the "
+"component library '%s'.\n"
+"\n"
+"Do you wish to remove all of the conflicting aliases from this component?"
+msgstr ""
+"新しいコンポーネントに含まれているエイリアス名はコンポーネント ライブラリ "
+"'%s' 内の既存エントリと衝突します。\n"
+"\n"
+"このコンポーネント内の衝突するエイリアスを削除しますか？"
+
+#: eeschema/load_one_schematic_file.cpp:94
+#, c-format
+msgid "Failed to open '%s'"
+msgstr "ファイル '%s' が開けませんでした"
+
+#: eeschema/load_one_schematic_file.cpp:102
+#, c-format
+msgid "Loading '%s'"
+msgstr "読込み中 '%s'"
+
+#: eeschema/load_one_schematic_file.cpp:109
+#, c-format
+msgid "'%s' is NOT an Eeschema file!"
+msgstr "'%s' は Eeschema のファイルではありません！"
+
+#: eeschema/load_one_schematic_file.cpp:128
+#, c-format
+msgid ""
+"'%s' was created by a more recent version of Eeschema and may not load "
+"correctly. Please consider updating!"
+msgstr ""
+"'%s' は新しいバージョンの Eeschema で作成されており、正しく読み込めない可能性"
+"があります。ソフトウェアの更新を検討してください！"
+
+#: eeschema/load_one_schematic_file.cpp:139
+msgid ""
+" was created by an older version of Eeschema. It will be stored in the new "
+"file format when you save this file again."
+msgstr ""
+"　は古いバージョンの Eeschema で作成されています。このファイルは保存する際に"
+"新しいフォーマットで保存されます。"
+
+#: eeschema/load_one_schematic_file.cpp:225
+#, c-format
+msgid "Eeschema file text load error at line %d"
+msgstr "%d 行で Eeschema のファイル読み込みエラー"
+
+#: eeschema/load_one_schematic_file.cpp:241
+#, c-format
+msgid "Eeschema file undefined object at line %d, aborted"
+msgstr ""
+"Eeschema ファイルの %d 行目に未定義のオブジェクトがありました、中止します。"
+
+#: eeschema/load_one_schematic_file.cpp:264
+#, c-format
+msgid "Eeschema file object not loaded at line %d, aborted"
+msgstr ""
+"Eeschema ファイルの %d 行目に読み込まれていないオブジェクトがありました、中止"
+"します。"
+
+#: eeschema/load_one_schematic_file.cpp:281
+#, c-format
+msgid "Done Loading <%s>"
+msgstr "読み込み完了 <%s>"
+
+#: eeschema/load_one_schematic_file.cpp:310
+#, c-format
+msgid ""
+"Eeschema file dimension definition error line %d,\n"
+"Abort reading file.\n"
+msgstr ""
+"Eeschema ファイルの単位系定義でエラー (行番号: %d)\n"
+"ファイルの読み込みを中断しました。\n"
+
+#: eeschema/menubar.cpp:69
+msgid "&New Schematic Project"
+msgstr "新規回路図プロジェクト(&N)"
+
+#: eeschema/menubar.cpp:70
+msgid "Clear current schematic hierarchy and start a new schematic root sheet"
+msgstr "現在の回路図階層をクリアし、新しい回路図ルートシートを開始する"
+
+#: eeschema/menubar.cpp:73
+msgid "&Open Schematic Project"
+msgstr "既存の回路図プロジェクトを開く(&O)"
+
+#: eeschema/menubar.cpp:76
+msgid "Open an existing schematic hierarchy"
+msgstr "既存の回路図階層を開く"
+
+#: eeschema/menubar.cpp:97 kicad/menubar.cpp:224
+#: pcbnew/menubar_pcbframe.cpp:94
+msgid "Open &Recent"
+msgstr "最近開いたファイル(&R)"
+
+#: eeschema/menubar.cpp:98
+msgid "Open a recent opened schematic project"
+msgstr "最近開いた回路図を開く"
+
+#: eeschema/menubar.cpp:103
+msgid "App&end Schematic Sheet"
+msgstr "回路図シートを追加(&e)"
+
+#: eeschema/menubar.cpp:104
+msgid "Append schematic sheet to current project"
+msgstr "現在読み込まれている回路図へ、他の回路図プロジェクトを追加する"
+
+#: eeschema/menubar.cpp:109
+msgid "&Save Schematic Project"
+msgstr "回路図プロジェクトの保存(&S)"
+
+#: eeschema/menubar.cpp:113
+msgid "Save all sheets in schematic project"
+msgstr "回路図プロジェクト内の全てのシートを保存"
+
+#: eeschema/menubar.cpp:118
+msgid "Save &Current Sheet Only"
+msgstr "現在のシートのみ保存(&C)"
+
+#: eeschema/menubar.cpp:119
+msgid "Save only current schematic sheet"
+msgstr "現在の回路図シートのみ保存"
+
+#: eeschema/menubar.cpp:126
+msgid "Save C&urrent Sheet As"
+msgstr "現在のシートを名前をつけて保存(&u)"
+
+#: eeschema/menubar.cpp:127
+msgid "Save current schematic sheet as..."
+msgstr "現在の回路図シートを名前をつけて保存"
+
+#: eeschema/menubar.cpp:135
+msgid "Pa&ge Settings"
+msgstr "ページ設定(&G)"
+
+#: eeschema/menubar.cpp:136
+msgid "Setting for sheet size and frame references"
+msgstr "ページサイズと図枠情報の設定"
+
+#: eeschema/menubar.cpp:141
+msgid "Pri&nt"
+msgstr "印刷(&N)"
+
+#: eeschema/menubar.cpp:142
+msgid "Print schematic sheet"
+msgstr "回路図の印刷"
+
+#: eeschema/menubar.cpp:148 eeschema/menubar.cpp:160
+msgid "&Plot"
+msgstr "出図(&P)"
+
+#: eeschema/menubar.cpp:149
+msgid "Plot schematic sheet in PostScript, PDF, SVG, DXF or HPGL format"
+msgstr ""
+"回路図シートをPostScript, PDF, SVG, DXF, HPGLフォーマット等でプロットする"
+
+#: eeschema/menubar.cpp:154
+msgid "Plot to C&lipboard"
+msgstr "クリップボードにプロット(&l)"
+
+#: eeschema/menubar.cpp:155
+msgid "Export drawings to clipboard"
+msgstr "クリップボードに図をエクスポート"
+
+#: eeschema/menubar.cpp:161
+msgid "Plot schematic sheet in HPGL, PostScript or SVG format"
+msgstr "HPGL, PostScript, SVGフォーマットのいづれかで回路図シートをプロット"
+
+#: eeschema/menubar.cpp:171
+msgid "Close Eeschema"
+msgstr "Eeschema の終了"
+
+#: eeschema/menubar.cpp:178 eeschema/menubar_libedit.cpp:118
+#: pcbnew/menubar_modedit.cpp:158 pcbnew/menubar_pcbframe.cpp:277
+msgid "&Undo"
+msgstr "元に戻す(&U)"
+
+#: eeschema/menubar.cpp:183 eeschema/menubar_libedit.cpp:127
+#: pcbnew/menubar_modedit.cpp:164 pcbnew/menubar_pcbframe.cpp:280
+msgid "&Redo"
+msgstr "やり直し(&R)"
+
+#: eeschema/menubar.cpp:199
+msgid "Find and Re&place"
+msgstr "検索と置換(&P)"
+
+#: eeschema/menubar.cpp:207
+msgid "Import Footprint Selection"
+msgstr "フットプリントの関連付けをインポート"
+
+#: eeschema/menubar.cpp:229 eeschema/menubar_libedit.cpp:161
+#: eeschema/tool_viewlib.cpp:225 pcbnew/menubar_modedit.cpp:216
+#: pcbnew/menubar_pcbframe.cpp:328 pcbnew/tool_modview.cpp:157
+msgid "Zoom &In"
+msgstr "ズーム イン(&I)"
+
+#: eeschema/menubar.cpp:233 eeschema/menubar_libedit.cpp:165
+#: eeschema/tool_viewlib.cpp:229 pcbnew/menubar_modedit.cpp:220
+#: pcbnew/menubar_pcbframe.cpp:332 pcbnew/tool_modview.cpp:161
+msgid "Zoom &Out"
+msgstr "ズーム アウト(&O)"
+
+#: eeschema/menubar.cpp:237 eeschema/menubar_libedit.cpp:169
+#: eeschema/tool_viewlib.cpp:233 pcbnew/menubar_modedit.cpp:224
+#: pcbnew/menubar_pcbframe.cpp:336 pcbnew/tool_modview.cpp:165
+msgid "&Fit on Screen"
+msgstr "スクリーンにフィット(&F)"
+
+#: eeschema/menubar.cpp:241 eeschema/menubar_libedit.cpp:176
+#: eeschema/tool_viewlib.cpp:238 pcbnew/menubar_modedit.cpp:229
+#: pcbnew/menubar_pcbframe.cpp:341 pcbnew/tool_modview.cpp:170
+msgid "&Redraw"
+msgstr "再描画(&R)"
+
+#: eeschema/menubar.cpp:249
+msgid "Show &Hierarchical Navigator"
+msgstr "階層ナビゲータの表示(&H)"
+
+#: eeschema/menubar.cpp:250
+msgid "Navigate hierarchical sheets"
+msgstr "階層シートのナビゲート"
+
+#: eeschema/menubar.cpp:253
+msgid "&Leave Sheet"
+msgstr "シートから抜ける(&L)"
+
+#: eeschema/menubar.cpp:258 eeschema/onrightclick.cpp:196
+msgid "Leave Sheet"
+msgstr "シートから抜ける"
+
+#: eeschema/menubar.cpp:264
+msgid "&Component"
+msgstr "コンポーネント(&C)"
+
+#: eeschema/menubar.cpp:270
+msgid "&Power Port"
+msgstr "電源ポート(&P)"
+
+#: eeschema/menubar.cpp:276
+msgid "&Wire"
+msgstr "配線(&W)"
+
+#: eeschema/menubar.cpp:282
+msgid "&Bus"
+msgstr "バス(&B)"
+
+#: eeschema/menubar.cpp:288
+msgid "Wire to Bus &Entry"
+msgstr "ワイヤ-バス・エントリの追加(&E)"
+
+#: eeschema/menubar.cpp:294
+msgid "Bus &to Bus Entry"
+msgstr "バス-バス・エントリの追加(&T)"
+
+#: eeschema/menubar.cpp:300
+msgid "&No Connect Flag"
+msgstr "空き端子フラグ(&N)"
+
+#: eeschema/menubar.cpp:304
+msgid "&Junction"
+msgstr "ジャンクション(&J)"
+
+#: eeschema/menubar.cpp:310
+msgid "&Label"
+msgstr "ラベル(&L)"
+
+#: eeschema/menubar.cpp:316
+msgid "Gl&obal Label"
+msgstr "グローバル ラベル(&O)"
+
+#: eeschema/menubar.cpp:324
+msgid "&Hierarchical Label"
+msgstr "階層ラベル(&H)"
+
+#: eeschema/menubar.cpp:331
+msgid "Hierarchical &Sheet"
+msgstr "階層シート(&S)"
+
+#: eeschema/menubar.cpp:339
+msgid "I&mport Hierarchical Label"
+msgstr "階層ラベルのインポート(&M)"
+
+#: eeschema/menubar.cpp:345
+msgid "Hierarchical Pi&n to Sheet"
+msgstr "階層ピンをシートに追加(&N)"
+
+#: eeschema/menubar.cpp:351
+msgid "Graphic Pol&yline"
+msgstr "図形ライン入力(&y)"
+
+#: eeschema/menubar.cpp:357
+msgid "&Graphic Text"
+msgstr "図形テキスト(&G)"
+
+#: eeschema/menubar.cpp:364
+msgid "&Image"
+msgstr "画像(&I)"
+
+#: eeschema/menubar.cpp:374 eeschema/menubar_libedit.cpp:230
+msgid "Component &Libraries"
+msgstr "コンポーネントライブラリ(&L)"
+
+#: eeschema/menubar.cpp:375 eeschema/menubar_libedit.cpp:231
+msgid "Configure component libraries and paths"
+msgstr "コンポーネント ライブラリとパスの設定"
+
+#: eeschema/menubar.cpp:381 eeschema/menubar_libedit.cpp:244
+msgid "Set &Colors Scheme"
+msgstr "色の設定(&C)"
+
+#: eeschema/menubar.cpp:382 eeschema/menubar_libedit.cpp:245
+msgid "Set color preferences"
+msgstr "色の設定"
+
+#: eeschema/menubar.cpp:392
+msgid "Schematic Editor &Options"
+msgstr "回路図エディタ オプション(&O)"
+
+#: eeschema/menubar.cpp:393
+msgid "Set Eeschema preferences"
+msgstr "Eeschema の設定"
+
+#: eeschema/menubar.cpp:409 pcbnew/menubar_pcbframe.cpp:594
+msgid "&Save Preferences"
+msgstr "設定の保存(&S)"
+
+#: eeschema/menubar.cpp:410 pcbnew/menubar_pcbframe.cpp:595
+msgid "Save application preferences"
+msgstr "アプリケーション設定の保存"
+
+#: eeschema/menubar.cpp:415 pcbnew/menubar_pcbframe.cpp:599
+msgid "Load Prefe&rences"
+msgstr "設定の読込み(&R)"
+
+#: eeschema/menubar.cpp:416 pcbnew/menubar_pcbframe.cpp:600
+msgid "Load application preferences"
+msgstr "アプリケーション設定の読込み"
+
+#: eeschema/menubar.cpp:424
+msgid "Library &Editor"
+msgstr "コンポーネント ライブラリ エディタ(&E)"
+
+#: eeschema/menubar.cpp:429
+msgid "Library &Browser"
+msgstr "ライブラリ ブラウザ(&B)"
+
+#: eeschema/menubar.cpp:434
+msgid "&Rescue Old Components"
+msgstr "キャッシュされたコンポーネントのレスキュー(&R)"
+
+#: eeschema/menubar.cpp:435
+msgid "Find old components in the project and rename/rescue them"
+msgstr "プロジェクトにある古いコンポーネントを探してリネーム/レスキューする"
+
+#: eeschema/menubar.cpp:442
+msgid "&Annotate Schematic"
+msgstr "回路図のアノテーション(&A)"
+
+#: eeschema/menubar.cpp:448
+msgid "Electrical Rules &Checker"
+msgstr "エレクトリックルール チェッカ(ERC) (&C)"
+
+#: eeschema/menubar.cpp:449 eeschema/tool_sch.cpp:148
+msgid "Perform electrical rules check"
+msgstr "エレクトリック ルール チェッカの実行"
+
+#: eeschema/menubar.cpp:454
+msgid "Generate &Netlist File"
+msgstr "ネットリストの生成(&N)"
+
+#: eeschema/menubar.cpp:455
+msgid "Generate the component netlist file"
+msgstr "コンポーネントネットリストの生成"
+
+#: eeschema/menubar.cpp:460
+msgid "Generate Bill of &Materials"
+msgstr "部品表の生成(&M)"
+
+#: eeschema/menubar.cpp:469
+msgid "A&ssign Component Footprint"
+msgstr "コンポーネントにフットプリントを割付け(&S)"
+
+#: eeschema/menubar.cpp:470
+msgid "Run CvPcb"
+msgstr "CVpcb起動"
+
+#: eeschema/menubar.cpp:476
+msgid "&Layout Printed Circuit Board"
+msgstr "プリント基板のレイアウト(&L)"
+
+#: eeschema/menubar.cpp:477 kicad/menubar.cpp:370
+msgid "Run Pcbnew"
+msgstr "プリント基板エディタ(Pcbnew)の起動"
+
+#: eeschema/menubar.cpp:488 eeschema/menubar_libedit.cpp:263
+#: eeschema/tool_viewlib.cpp:250
+msgid "Eeschema &Manual"
+msgstr ""
+
+#: eeschema/menubar.cpp:489
+msgid "Open Eeschema Manual"
+msgstr ""
+
+#: eeschema/menubar.cpp:507 eeschema/menubar_libedit.cpp:284
+#: pcbnew/menubar_modedit.cpp:359 pcbnew/menubar_pcbframe.cpp:663
+msgid "&Edit"
+msgstr "編集(&E)"
+
+#: eeschema/menubar.cpp:508 eeschema/menubar_libedit.cpp:285
+#: eeschema/tool_viewlib.cpp:269 pcbnew/menubar_modedit.cpp:360
+#: pcbnew/menubar_pcbframe.cpp:664 pcbnew/tool_modview.cpp:208
+msgid "&View"
+msgstr "表示(&V)"
+
+#: eeschema/menubar.cpp:509 eeschema/menubar_libedit.cpp:286
+#: pcbnew/menubar_modedit.cpp:361 pcbnew/menubar_pcbframe.cpp:665
+msgid "&Place"
+msgstr "配置(&P)"
+
+#: eeschema/menubar.cpp:510 eeschema/menubar_libedit.cpp:287
+#: pcbnew/menubar_modedit.cpp:362 pcbnew/menubar_pcbframe.cpp:667
+msgid "P&references"
+msgstr "設定(&R)"
+
+#: eeschema/menubar.cpp:511 kicad/menubar.cpp:429
+#: pcbnew/menubar_pcbframe.cpp:669
+msgid "&Tools"
+msgstr "ツール(&T)"
+
+#: eeschema/menubar_libedit.cpp:68
+msgid "&Current Library"
+msgstr "現在のライブラリ(&C)"
+
+#: eeschema/menubar_libedit.cpp:69 eeschema/tool_lib.cpp:115
+msgid "Select working library"
+msgstr "作業ライブラリの選択"
+
+#: eeschema/menubar_libedit.cpp:76
+msgid "&Save Current Library\tCtrl+S"
+msgstr "現在のライブラリを保存(&S)\tCtrl+S"
+
+#: eeschema/menubar_libedit.cpp:77
+msgid "Save the current active library"
+msgstr "現在のアクティブライブラリを保存"
+
+#: eeschema/menubar_libedit.cpp:83
+msgid "Save Current Library &As"
+msgstr "現在のライブラリを名前をつけて保存(&A)"
+
+#: eeschema/menubar_libedit.cpp:84
+msgid "Save current active library as..."
+msgstr "現在アクティブなライブラリを名前をつけて保存"
+
+#: eeschema/menubar_libedit.cpp:93
+msgid "Create &PNG File from Screen"
+msgstr "画面からPNGファイルを生成(&P)"
+
+#: eeschema/menubar_libedit.cpp:94
+msgid "Create a PNG file from the component displayed on screen"
+msgstr "スクリーン上に表示されたコンポーネントからPNGファイルを作成"
+
+#: eeschema/menubar_libedit.cpp:100
+msgid "Create S&VG File"
+msgstr "SVGファイル作成(&V)"
+
+#: eeschema/menubar_libedit.cpp:101
+msgid "Create a SVG file from the current loaded component"
+msgstr "現在読込まれているコンポーネントからSVGファイルを作成"
+
+#: eeschema/menubar_libedit.cpp:110
+msgid "&Quit"
+msgstr "終了(&Q)"
+
+#: eeschema/menubar_libedit.cpp:111
+msgid "Quit Library Editor"
+msgstr "コンポーネント ライブラリ エディタの終了"
+
+#: eeschema/menubar_libedit.cpp:123
+msgid "Undo last edit"
+msgstr "一つ前の編集を元に戻す"
+
+#: eeschema/menubar_libedit.cpp:131 pcbnew/tool_modedit.cpp:111
+#: pcbnew/help_common_strings.h:16
+msgid "Redo the last undo command"
+msgstr "一つ前のコマンドをやり直し"
+
+#: eeschema/menubar_libedit.cpp:185
+msgid "&Pin"
+msgstr "ピン(&P)"
+
+#: eeschema/menubar_libedit.cpp:192
+msgid "Graphic &Text"
+msgstr "図形テキスト(&T)"
+
+#: eeschema/menubar_libedit.cpp:199
+msgid "&Rectangle"
+msgstr "矩形(&R)"
+
+#: eeschema/menubar_libedit.cpp:206 pcbnew/menubar_modedit.cpp:276
+#: pcbnew/menubar_pcbframe.cpp:406
+msgid "&Circle"
+msgstr "円(&C)"
+
+#: eeschema/menubar_libedit.cpp:213 pcbnew/menubar_modedit.cpp:287
+#: pcbnew/menubar_pcbframe.cpp:403
+msgid "&Arc"
+msgstr "円弧(&A)"
+
+#: eeschema/menubar_libedit.cpp:220 pcbnew/menubar_modedit.cpp:281
+#: pcbnew/menubar_pcbframe.cpp:410
+msgid "&Line or Polygon"
+msgstr "線 (ポリゴン) (&L)"
+
+#: eeschema/menubar_libedit.cpp:237
+msgid "Component Editor &Options"
+msgstr "コンポーネントライブラリエディタ オプション(&O)"
+
+#: eeschema/menubar_libedit.cpp:238
+msgid "Set Component Editor default values and options"
+msgstr "コンポーネント エディタにデフォルトの値とオプションを設定する"
+
+#: eeschema/menubar_libedit.cpp:264
+msgid "Open the Eeschema Manual"
+msgstr ""
+
+#: eeschema/menubar_libedit.cpp:270 eeschema/tool_viewlib.cpp:256
+#: pcbnew/menubar_modedit.cpp:347 pcbnew/menubar_pcbframe.cpp:652
+#: pcbnew/tool_modview.cpp:195
+msgid "Open the \"Getting Started in KiCad\" guide for beginners"
+msgstr "チュートリアル\"KiCadを始めよう\"を開く"
+
+#: eeschema/netform.cpp:111
+msgid "Run command:"
+msgstr "コマンドラインで実行:"
+
+#: eeschema/netform.cpp:117
+#, c-format
+msgid "Command error. Return code %d"
+msgstr "コマンドエラー. リターンコード %d"
+
+#: eeschema/netform.cpp:120
+msgid "Success"
+msgstr "成功"
+
+#: eeschema/netform.cpp:127
+msgid "Info messages:"
+msgstr "Info メッセージ:"
+
+#: eeschema/netform.cpp:137
+msgid "Error messages:"
+msgstr "エラーメッセージ:"
+
+#: eeschema/netlist.cpp:68
+msgid ""
+"Exporting the netlist requires a completely\n"
+"annotated schematic."
+msgstr ""
+"ネットリストのエクスポートには回路図の完全な\n"
+"アノテーションが必要です."
+
+#: eeschema/netlist.cpp:78
+msgid "Error: duplicate sheet names. Continue?"
+msgstr "エラー: シート名の重複。続けますか？"
+
+#: eeschema/netlist.cpp:172
+msgid "No Objects"
+msgstr "オブジェクトがありまs年"
+
+#: eeschema/netlist.cpp:176
+#, c-format
+msgid "Net count = %d"
+msgstr ""
+
+#: eeschema/onrightclick.cpp:102 eeschema/onrightclick.cpp:573
+msgid "Edit Label"
+msgstr "ラベルの編集"
+
+#: eeschema/onrightclick.cpp:108 eeschema/onrightclick.cpp:501
+msgid "Edit Global Label"
+msgstr "グローバル ラベルの編集"
+
+#: eeschema/onrightclick.cpp:115 eeschema/onrightclick.cpp:537
+msgid "Edit Hierarchical Label"
+msgstr "階層ラベルの編集"
+
+#: eeschema/onrightclick.cpp:122 eeschema/onrightclick.cpp:895
+msgid "Edit Image"
+msgstr "イメージの編集"
+
+#: eeschema/onrightclick.cpp:209
+msgid "Delete No Connect"
+msgstr "接続の削除"
+
+#: eeschema/onrightclick.cpp:267 pcbnew/onrightclick.cpp:189
+msgid "End Drawing"
+msgstr "線ツールの終了"
+
+#: eeschema/onrightclick.cpp:270 pcbnew/onrightclick.cpp:220
+msgid "Delete Drawing"
+msgstr "図形の削除"
+
+#: eeschema/onrightclick.cpp:303
+msgid "Move Reference"
+msgstr "リファレンスの移動"
+
+#: eeschema/onrightclick.cpp:304
+msgid "Move Value"
+msgstr "ラベルの移動"
+
+#: eeschema/onrightclick.cpp:305
+msgid "Move Footprint Field"
+msgstr "フットプリントフィールドの移動"
+
+#: eeschema/onrightclick.cpp:316
+msgid "Rotate Reference"
+msgstr "リファレンスの回転"
+
+#: eeschema/onrightclick.cpp:317
+msgid "Rotate Value"
+msgstr "値の回転"
+
+#: eeschema/onrightclick.cpp:318
+msgid "Rotate Footprint Field"
+msgstr "フットプリントフィールドの回転"
+
+#: eeschema/onrightclick.cpp:319
+msgid "Rotate Field"
+msgstr "フィールドの回転"
+
+#: eeschema/onrightclick.cpp:331
+msgid "Edit Reference"
+msgstr "リファレンスの編集"
+
+#: eeschema/onrightclick.cpp:335
+msgid "Edit Value"
+msgstr "ラベルの編集"
+
+#: eeschema/onrightclick.cpp:339
+msgid "Edit Footprint Field"
+msgstr "フットプリントフィールドの編集"
+
+#: eeschema/onrightclick.cpp:343
+msgid "Edit Field"
+msgstr "フィールドの編集"
+
+#: eeschema/onrightclick.cpp:364
+#, c-format
+msgid "Move Component %s"
+msgstr "コンポーネント %s の移動"
+
+#: eeschema/onrightclick.cpp:368
+msgid "Drag Component"
+msgstr "コンポーネントのドラッグ"
+
+#: eeschema/onrightclick.cpp:373
+msgid "Rotate Clockwise"
+msgstr "右回転"
+
+#: eeschema/onrightclick.cpp:375
+msgid "Rotate Counterclockwise"
+msgstr "左回転"
+
+#: eeschema/onrightclick.cpp:377 eeschema/onrightclick.cpp:769
+#: eeschema/onrightclick.cpp:889
+msgid "Mirror --"
+msgstr "横軸でミラー"
+
+#: eeschema/onrightclick.cpp:379 eeschema/onrightclick.cpp:771
+#: eeschema/onrightclick.cpp:892
+msgid "Mirror ||"
+msgstr "縦軸でミラー"
+
+#: eeschema/onrightclick.cpp:384
+msgid "Orient Component"
+msgstr "コンポーネントの角度"
+
+#: eeschema/onrightclick.cpp:390
+msgid "Copy Component"
+msgstr "コンポーネントのコピー"
+
+#: eeschema/onrightclick.cpp:393
+msgid "Delete Component"
+msgstr "コンポーネントの削除"
+
+#: eeschema/onrightclick.cpp:398
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:26
+msgid "Doc"
+msgstr "ドキュメント"
+
+#: eeschema/onrightclick.cpp:470
+msgid "Edit with Library Editor"
+msgstr "コンポーネント ライブラリ エディタで編集"
+
+#: eeschema/onrightclick.cpp:477
+msgid "Edit Component"
+msgstr "コンポーネントの編集"
+
+#: eeschema/onrightclick.cpp:488
+msgid "Move Global Label"
+msgstr "グローバル ラベルの移動"
+
+#: eeschema/onrightclick.cpp:491
+msgid "Drag Global Label"
+msgstr "グローバル ラベルのドラッグ"
+
+#: eeschema/onrightclick.cpp:494
+msgid "Copy Global Label"
+msgstr "グローバル ラベルのコピー"
+
+#: eeschema/onrightclick.cpp:499
+msgid "Rotate Global Label"
+msgstr "グローバル ラベルの回転"
+
+#: eeschema/onrightclick.cpp:503
+msgid "Delete Global Label"
+msgstr "グローバル ラベルの削除"
+
+#: eeschema/onrightclick.cpp:508 eeschema/onrightclick.cpp:580
+#: eeschema/onrightclick.cpp:620
+msgid "Change to Hierarchical Label"
+msgstr "階層ラベルに変更"
+
+#: eeschema/onrightclick.cpp:510 eeschema/onrightclick.cpp:544
+#: eeschema/onrightclick.cpp:618
+msgid "Change to Label"
+msgstr "ラベルに変更"
+
+#: eeschema/onrightclick.cpp:512 eeschema/onrightclick.cpp:546
+#: eeschema/onrightclick.cpp:582
+msgid "Change to Text"
+msgstr "テキストに変更"
+
+#: eeschema/onrightclick.cpp:514 eeschema/onrightclick.cpp:550
+#: eeschema/onrightclick.cpp:586 eeschema/onrightclick.cpp:624
+msgid "Change Type"
+msgstr "タイプの変更"
+
+#: eeschema/onrightclick.cpp:525
+msgid "Move Hierarchical Label"
+msgstr "階層ラベルの移動"
+
+#: eeschema/onrightclick.cpp:528
+msgid "Drag Hierarchical Label"
+msgstr "階層ラベルのドラッグ"
+
+#: eeschema/onrightclick.cpp:530
+msgid "Copy Hierarchical Label"
+msgstr "階層ラベルのコピー"
+
+#: eeschema/onrightclick.cpp:535
+msgid "Rotate Hierarchical Label"
+msgstr "階層ラベルの回転"
+
+#: eeschema/onrightclick.cpp:539
+msgid "Delete Hierarchical Label"
+msgstr "階層ラベル削除"
+
+#: eeschema/onrightclick.cpp:548 eeschema/onrightclick.cpp:584
+#: eeschema/onrightclick.cpp:622
+msgid "Change to Global Label"
+msgstr "グローバルラベルに変更"
+
+#: eeschema/onrightclick.cpp:561
+msgid "Move Label"
+msgstr "ラベルの移動"
+
+#: eeschema/onrightclick.cpp:564
+msgid "Drag Label"
+msgstr "ラベルのドラッグ"
+
+#: eeschema/onrightclick.cpp:566
+msgid "Copy Label"
+msgstr "ラベルのコピー"
+
+#: eeschema/onrightclick.cpp:571
+msgid "Rotate Label"
+msgstr "ラベルの回転"
+
+#: eeschema/onrightclick.cpp:575
+msgid "Delete Label"
+msgstr "ラベルの削除"
+
+#: eeschema/onrightclick.cpp:600
+msgid "Copy Text"
+msgstr "テキストのコピー"
+
+#: eeschema/onrightclick.cpp:634
+msgid "Delete Junction"
+msgstr "ジャンクションの削除"
+
+#: eeschema/onrightclick.cpp:640
+msgid "Drag Junction"
+msgstr "ジャンクション (接続点) のドラッグ"
+
+#: eeschema/onrightclick.cpp:643 eeschema/onrightclick.cpp:691
+msgid "Break Wire"
+msgstr "配線の切断"
+
+#: eeschema/onrightclick.cpp:649 eeschema/onrightclick.cpp:683
+msgid "Delete Node"
+msgstr "ノードの削除"
+
+# コネクション→一連のネットの意であればそのまま用語として残す
+#: eeschema/onrightclick.cpp:651 eeschema/onrightclick.cpp:685
+msgid "Delete Connection"
+msgstr "コネクションの削除"
+
+#: eeschema/onrightclick.cpp:665
+msgid "Begin Wire"
+msgstr "配線の開始"
+
+#: eeschema/onrightclick.cpp:673
+msgid "Wire End"
+msgstr "ワイヤの終端"
+
+#: eeschema/onrightclick.cpp:678
+msgid "Drag Wire"
+msgstr "ワイヤのドラッグ"
+
+#: eeschema/onrightclick.cpp:681
+msgid "Delete Wire"
+msgstr "ワイヤの削除"
+
+#: eeschema/onrightclick.cpp:696 eeschema/onrightclick.cpp:734
+msgid "Add Junction"
+msgstr "ジャンクションの追加"
+
+#: eeschema/onrightclick.cpp:698 eeschema/onrightclick.cpp:736
+msgid "Add Label"
+msgstr "ラベルの追加"
+
+#: eeschema/onrightclick.cpp:703 eeschema/onrightclick.cpp:741
+msgid "Add Global Label"
+msgstr "グローバル ラベルの追加"
+
+#: eeschema/onrightclick.cpp:715
+msgid "Begin Bus"
+msgstr "バスの開始"
+
+#: eeschema/onrightclick.cpp:723
+msgid "Bus End"
+msgstr "バスの終端"
+
+#: eeschema/onrightclick.cpp:728
+msgid "Delete Bus"
+msgstr "バス削除"
+
+#: eeschema/onrightclick.cpp:731
+msgid "Break Bus"
+msgstr "バスの切断"
+
+#: eeschema/onrightclick.cpp:752
+msgid "Enter Sheet"
+msgstr "シートに入る"
+
+#: eeschema/onrightclick.cpp:755
+msgid "Move Sheet"
+msgstr "シートの移動"
+
+#: eeschema/onrightclick.cpp:759
+msgid "Drag Sheet"
+msgstr "シートのドラッグ"
+
+#: eeschema/onrightclick.cpp:763
+msgid "Rotate Sheet CW"
+msgstr "シートを時計方向に回転"
+
+#: eeschema/onrightclick.cpp:766
+msgid "Rotate Sheet CCW"
+msgstr "シートを反時計方向に回転"
+
+#: eeschema/onrightclick.cpp:775
+msgid "Orient Sheet"
+msgstr "シートの向きを合わせる."
+
+#: eeschema/onrightclick.cpp:780
+msgid "Place Sheet"
+msgstr "シートの配置"
+
+#: eeschema/onrightclick.cpp:784
+msgid "Edit Sheet"
+msgstr "シートの編集"
+
+#: eeschema/onrightclick.cpp:787
+msgid "Resize Sheet"
+msgstr "シートのリサイズ"
+
+#: eeschema/onrightclick.cpp:790
+msgid "Import Sheet Pins"
+msgstr "シートピンのインポート"
+
+#: eeschema/onrightclick.cpp:794
+msgid "Cleanup Sheet Pins"
+msgstr "シートピンのクリーンアップ"
+
+#: eeschema/onrightclick.cpp:798
+msgid "Delete Sheet"
+msgstr "シートの削除"
+
+#: eeschema/onrightclick.cpp:810
+msgid "Move Sheet Pin"
+msgstr "シートピンの移動"
+
+#: eeschema/onrightclick.cpp:815
+msgid "Edit Sheet Pin"
+msgstr "シートピンの編集"
+
+#: eeschema/onrightclick.cpp:818
+msgid "Delete Sheet Pin"
+msgstr "シートピンの削除"
+
+#: eeschema/onrightclick.cpp:833
+msgid "Window Zoom"
+msgstr "選択範囲ズーム"
+
+#: eeschema/onrightclick.cpp:841
+msgid "Save Block"
+msgstr "ブロックの保存"
+
+#: eeschema/onrightclick.cpp:845
+msgid "Drag Block"
+msgstr "ブロックのドラッグ"
+
+#: eeschema/onrightclick.cpp:855
+msgid "Rotate Block CCW"
+msgstr "ブロックの左回転"
+
+#: eeschema/onrightclick.cpp:861
+msgid "Copy to Clipboard"
+msgstr "クリップボードにコピー"
+
+#: eeschema/onrightclick.cpp:870 pcbnew/onrightclick.cpp:1027
+msgid "Delete Marker"
+msgstr "マーカー削除"
+
+#: eeschema/onrightclick.cpp:871 pcbnew/onrightclick.cpp:1029
+msgid "Marker Error Info"
+msgstr "マーカー エラー情報"
+
+#: eeschema/onrightclick.cpp:882
+msgid "Move Image"
+msgstr "イメージの移動"
+
+#: eeschema/onrightclick.cpp:887
+msgid "Rotate Image"
+msgstr "イメージの回転"
+
+#: eeschema/onrightclick.cpp:901
+msgid "Delete Image"
+msgstr "イメージの削除"
+
+#: eeschema/onrightclick.cpp:913
+msgid "Move Bus Entry"
+msgstr "バスエントリの移動"
+
+#: eeschema/onrightclick.cpp:920
+msgid "Set Bus Entry Shape /"
+msgstr "バスエントリ形状のセット /"
+
+#: eeschema/onrightclick.cpp:923
+msgid "Set Bus Entry Shape \\"
+msgstr "バスエントリ形状のセット \\"
+
+#: eeschema/onrightclick.cpp:925
+msgid "Delete Bus Entry"
+msgstr "バスエントリの削除"
+
+#: eeschema/pinedit.cpp:249
+msgid "This position is already occupied by another pin. Continue?"
+msgstr "この位置にはすでに他のピンがあります。続けますか？"
+
+#: eeschema/pinedit.cpp:665
+msgid "No pins!"
+msgstr "ピンがありません！"
+
+#: eeschema/pinedit.cpp:675
+msgid "Marker Information"
+msgstr "マーカー情報"
+
+#: eeschema/pinedit.cpp:701
+#, c-format
+msgid ""
+"<b>Duplicate pin %s</b> \"%s\" at location <b>(%.3f, %.3f)</b> conflicts "
+"with pin %s \"%s\" at location <b>(%.3f, %.3f)</b>"
+msgstr ""
+"<b>重複ピン %s</b> \"%s\" 位置 <b>(%.3f, %.3f)</b> 衝突ピン %s \"%s\" 位置 "
+"<b>(%.3f, %.3f)</b>"
+
+#: eeschema/pinedit.cpp:715 eeschema/pinedit.cpp:757
+#, c-format
+msgid " in part %c"
+msgstr "パーツ %c"
+
+#: eeschema/pinedit.cpp:721 eeschema/pinedit.cpp:763
+msgid "  of converted"
+msgstr " 変換シンボル"
+
+#: eeschema/pinedit.cpp:723 eeschema/pinedit.cpp:765
+msgid "  of normal"
+msgstr "標準"
+
+#: eeschema/pinedit.cpp:748
+#, c-format
+msgid "<b>Off grid pin %s</b> \"%s\" at location <b>(%.3f, %.3f)</b>"
+msgstr "<b>グリッドから外れたピン %s</b> \"%s\" 位置 <b>(%.3f, %.3f)</b>"
+
+#: eeschema/pinedit.cpp:774
+msgid "No off grid or duplicate pins were found."
+msgstr "グリッドから外れたり、重複したピンは見つかりませんでした。"
+
+#: eeschema/plot_schematic_DXF.cpp:94 eeschema/plot_schematic_HPGL.cpp:190
+#: eeschema/plot_schematic_PDF.cpp:140 eeschema/plot_schematic_PS.cpp:123
+#: eeschema/plot_schematic_SVG.cpp:100 eeschema/plot_schematic_SVG.cpp:137
+#, c-format
+msgid "Plot: '%s' OK.\n"
+msgstr "プロット: '%s' OK.\n"
+
+#: eeschema/plot_schematic_DXF.cpp:99 eeschema/plot_schematic_HPGL.cpp:195
+#: eeschema/plot_schematic_PDF.cpp:103 eeschema/plot_schematic_PS.cpp:129
+#: eeschema/plot_schematic_SVG.cpp:144
+#, c-format
+msgid "Unable to create file '%s'.\n"
+msgstr "ファイル '%s' を作成できません\n"
+
+#: eeschema/plot_schematic_SVG.cpp:94
+#, c-format
+msgid "Cannot create file '%s'.\n"
+msgstr "ファイル '%s' を作成できません\n"
+
+#: eeschema/project_rescue.cpp:295
+#, c-format
+msgid "Rename to %s"
+msgstr "ファイル名を %s へ変更"
+
+#: eeschema/project_rescue.cpp:389
+#, c-format
+msgid "Rescue %s as %s"
+msgstr "%s を %s としてレスキュー"
+
+#: eeschema/project_rescue.cpp:527
+msgid "This project has nothing to rescue."
+msgstr "このプロジェクトにレスキューは必要ありません."
+
+#: eeschema/project_rescue.cpp:541
+msgid "No symbols were rescued."
+msgstr "レスキューするシンボルがありません."
+
+#: eeschema/sch_bus_entry.cpp:335
+msgid "Bus to Wire Entry"
+msgstr "ワイヤ-バス・エントリ"
+
+#: eeschema/sch_bus_entry.cpp:341
+msgid "Bus to Bus Entry"
+msgstr "バス-バス・エントリ"
+
+#: eeschema/sch_collectors.cpp:432
+#, c-format
+msgid "Child item %s of parent item %s found in sheet %s"
+msgstr "子アイテム %s の親アイテム %s がシート %s 中にありません"
+
+#: eeschema/sch_collectors.cpp:439
+#, c-format
+msgid "Item %s found in sheet %s"
+msgstr "アイテム %s がシート%s 内に見つかりませんでした"
+
+#: eeschema/sch_component.cpp:1518
+msgid "Power symbol"
+msgstr "電源シンボル"
+
+#: eeschema/sch_component.cpp:1526
+msgid "Alias of"
+msgstr "エイリアス"
+
+#: eeschema/sch_component.cpp:1528
+#: pcbnew/dialogs/wizard_add_fplib_base.cpp:185 pcbnew/loadcmp.cpp:437
+msgid "Library"
+msgstr "ライブラリ"
+
+#: eeschema/sch_component.cpp:1534
+msgid "<Unknown>"
+msgstr "<不明>"
+
+#: eeschema/sch_component.cpp:1540
+msgid "Key Words"
+msgstr "キーワード"
+
+#: eeschema/sch_component.cpp:1784
+#, c-format
+msgid "Component %s, %s"
+msgstr "コンポーネント %s, %s"
+
+#: eeschema/sch_field.cpp:453
+#, c-format
+msgid "Field %s"
+msgstr "フィールド %s"
+
+#: eeschema/sch_line.cpp:469 pcbnew/dialogs/dialog_pad_properties_base.cpp:211
+msgid "Vert."
+msgstr "垂直"
+
+#: eeschema/sch_line.cpp:471 pcbnew/dialogs/dialog_pad_properties_base.cpp:211
+msgid "Horiz."
+msgstr "水平"
+
+#: eeschema/sch_line.cpp:476
+#, c-format
+msgid "%s Graphic Line from (%s,%s) to (%s,%s) "
+msgstr "%s 図形ライン 始点 (%s,%s) 終点 (%s,%s) "
+
+#: eeschema/sch_line.cpp:480
+#, c-format
+msgid "%s Wire from (%s,%s) to (%s,%s)"
+msgstr "%s ワイヤ 始点 (%s,%s) 終点 (%s,%s)"
+
+#: eeschema/sch_line.cpp:484
+#, c-format
+msgid "%s Bus from (%s,%s) to (%s,%s)"
+msgstr "%s バス 始点 (%s,%s) 終点 (%s,%s)"
+
+#: eeschema/sch_line.cpp:488
+#, c-format
+msgid "%s Line on Unknown Layer from (%s,%s) to (%s,%s)"
+msgstr "%s ライン 不明なレイヤ 始点 (%s,%s) 終点 (%s,%s)"
+
+#: eeschema/sch_marker.cpp:142
+msgid "Electronics Rule Check Error"
+msgstr "エレクトリックルール チェッカ (ERC) エラー"
+
+#: eeschema/sch_sheet.cpp:828
+msgid "Sheet Name"
+msgstr "シート名"
+
+#: eeschema/sch_sheet.cpp:829
+msgid "File Name"
+msgstr "ファイル名"
+
+#: eeschema/sch_sheet.cpp:834
+msgid "Time Stamp"
+msgstr "タイムスタンプ"
+
+#: eeschema/sch_sheet.cpp:1047
+#, c-format
+msgid "Hierarchical Sheet %s"
+msgstr "階層シート　%s"
+
+#: eeschema/sch_sheet_path.cpp:175
+#, c-format
+msgid "Schematic sheets can only be nested %d levels deep."
+msgstr "回路図シートは %d 層までしかネストできません。"
+
+#: eeschema/sch_sheet_path.cpp:206
+#, c-format
+msgid "%8.8lX/"
+msgstr "%8.8lX/"
+
+#: eeschema/sch_sheet_pin.cpp:500
+#, c-format
+msgid "Hierarchical Sheet Pin %s"
+msgstr "階層シートピン %s"
+
+#: eeschema/sch_text.cpp:708
+msgid "Graphic Text"
+msgstr "図形テキスト"
+
+#: eeschema/sch_text.cpp:716
+msgid "Global Label"
+msgstr "グローバル ラベル"
+
+#: eeschema/sch_text.cpp:720
+msgid "Hierarchical Label"
+msgstr "階層ラベル"
+
+#: eeschema/sch_text.cpp:724
+msgid "Hierarchical Sheet Pin"
+msgstr "階層シートピン"
+
+#: eeschema/sch_text.cpp:736
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:110
+msgid "Horizontal"
+msgstr "水平"
+
+#: eeschema/sch_text.cpp:740
+msgid "Vertical up"
+msgstr "下方向"
+
+#: eeschema/sch_text.cpp:744
+msgid "Horizontal invert"
+msgstr "水平反転"
+
+#: eeschema/sch_text.cpp:748
+msgid "Vertical down"
+msgstr "上方向"
+
+#: eeschema/sch_text.cpp:1009
+#, c-format
+msgid "Label %s"
+msgstr "ラベル %s"
+
+#: eeschema/sch_text.cpp:1434
+#, c-format
+msgid "Global Label %s"
+msgstr "グローバル ラベル %s"
+
+#: eeschema/sch_text.cpp:1775
+#, c-format
+msgid "Hierarchical Label %s"
+msgstr "階層ラベル %s"
+
+#: eeschema/schedit.cpp:258
+msgid "There are no undefined labels in this sheet to clean up."
+msgstr "このシート中に未定義のラベルはありません。"
+
+#: eeschema/schedit.cpp:262
+msgid "Do you wish to cleanup this sheet?"
+msgstr "このシートをクリーンアップしますか？"
+
+#: eeschema/schedit.cpp:519
+msgid "No tool selected"
+msgstr "ツールが選択されていません"
+
+#: eeschema/schedit.cpp:523
+msgid "Descend or ascend hierarchy"
+msgstr "階層の上下移動"
+
+#: eeschema/schedit.cpp:527
+msgid "Add no connect"
+msgstr "空き端子フラグの入力"
+
+#: eeschema/schedit.cpp:531
+msgid "Add wire"
+msgstr "ワイヤの追加"
+
+#: eeschema/schedit.cpp:535
+msgid "Add bus"
+msgstr "バスの追加"
+
+#: eeschema/schedit.cpp:539
+msgid "Add lines"
+msgstr "線の追加"
+
+#: eeschema/schedit.cpp:543
+msgid "Add junction"
+msgstr "ジャンクションの追加"
+
+#: eeschema/schedit.cpp:547
+msgid "Add label"
+msgstr "ラベルの追加"
+
+#: eeschema/schedit.cpp:551
+msgid "Add global label"
+msgstr "グローバル ラベルの追加"
+
+#: eeschema/schedit.cpp:555
+msgid "Add hierarchical label"
+msgstr "階層ラベルの追加"
+
+#: eeschema/schedit.cpp:563
+msgid "Add image"
+msgstr "イメージの追加"
+
+#: eeschema/schedit.cpp:567
+msgid "Add wire to bus entry"
+msgstr "配線にバスエントリを追加"
+
+#: eeschema/schedit.cpp:571
+msgid "Add bus to bus entry"
+msgstr "バスに バスエントリを追加"
+
+#: eeschema/schedit.cpp:575
+msgid "Add sheet"
+msgstr "シートの追加"
+
+#: eeschema/schedit.cpp:579
+msgid "Add sheet pins"
+msgstr "シートピンの追加"
+
+#: eeschema/schedit.cpp:583
+msgid "Import sheet pins"
+msgstr "シートピンのインポート"
+
+#: eeschema/schedit.cpp:587
+msgid "Add component"
+msgstr "コンポーネントの追加"
+
+#: eeschema/schedit.cpp:591
+msgid "Add power"
+msgstr "電源の追加"
+
+#: eeschema/schframe.cpp:169 pcbnew/class_zone.cpp:848
+msgid "Not Found"
+msgstr "見つかりませんでした"
+
+#: eeschema/schframe.cpp:171
+msgid "The following libraries were not found:"
+msgstr "ライブラリは見つかりませんでした:"
+
+#: eeschema/schframe.cpp:619 pcbnew/pcbframe.cpp:583
+#, c-format
+msgid ""
+"Save the changes in\n"
+"'%s'\n"
+"before closing?"
+msgstr ""
+"閉じる前に下記の変更を保存しますか？\n"
+"'%s'\n"
+" "
+
+#: eeschema/schframe.cpp:766
+msgid "Draw wires and buses in any direction"
+msgstr "配線、バスを自由角度で描画"
+
+#: eeschema/schframe.cpp:767
+msgid "Draw horizontal and vertical wires and buses only"
+msgstr "配線、バスを90度のみで描画"
+
+#: eeschema/schframe.cpp:776
+msgid "Do not show hidden pins"
+msgstr "非表示のピンを表示しない"
+
+#: eeschema/schframe.cpp:777 eeschema/tool_sch.cpp:290
+msgid "Show hidden pins"
+msgstr "非表示ピンを表示"
+
+#: eeschema/schframe.cpp:902
+msgid "Schematic"
+msgstr "回路図"
+
+#: eeschema/schframe.cpp:921
+msgid "New Schematic"
+msgstr "新規回路図"
+
+#: eeschema/schframe.cpp:934
+#, c-format
+msgid "Schematic file '%s' already exists, use Open instead"
+msgstr "回路図ファイル '%s' は既に存在します。"
+
+#: eeschema/schframe.cpp:955
+msgid "Open Schematic"
+msgstr "回路図を開く"
+
+#: eeschema/schframe.cpp:1085
+msgid "Error: not a component or no component"
+msgstr "Error: コンポーネントではありません、又はコンポーネントがありません"
+
+#: eeschema/schframe.cpp:1315
+msgid " [no file]"
+msgstr " [no file]"
+
+#: eeschema/selpart.cpp:65
+msgid "No component libraries are loaded."
+msgstr "コンポーネント ライブラリが読込まれていません"
+
+#: eeschema/selpart.cpp:89 pcbnew/librairi.cpp:81
+msgid "Select Library"
+msgstr "ライブラリの選択"
+
+#: eeschema/selpart.cpp:139
+msgid "Select Component"
+msgstr "コンポーネントの選択"
+
+#: eeschema/sheet.cpp:84
+msgid "File name is not valid!"
+msgstr "ファイル名が不正です! "
+
+#: eeschema/sheet.cpp:93
+#, c-format
+msgid "A sheet named \"%s\" already exists."
+msgstr "シート名 \"%s\" は既に存在します。"
+
+#: eeschema/sheet.cpp:126
+#, c-format
+msgid "A file named '%s' already exists in the current schematic hierarchy."
+msgstr "名前'%s'のファイルは既に回路図階層内に存在しています。"
+
+#: eeschema/sheet.cpp:131
+#, c-format
+msgid "A file named '%s' already exists."
+msgstr "ファイル名 '%s' は既に存在しています。"
+
+#: eeschema/sheet.cpp:134
+msgid ""
+"\n"
+"\n"
+"Do you want to create a sheet with the contents of this file?"
+msgstr ""
+"\n"
+"\n"
+"このファイルの内容でシートを作成しますか？"
+
+#: eeschema/sheet.cpp:161
+msgid "Changing the sheet file name cannot be undone.  "
+msgstr "シートファイル名を変更すると元に戻せません。"
+
+#: eeschema/sheet.cpp:169
+#, c-format
+msgid "A file named <%s> already exists in the current schematic hierarchy."
+msgstr "ファイル名 <%s> は既に回路図階層内に存在しています。"
+
+#: eeschema/sheet.cpp:174
+#, c-format
+msgid "A file named <%s> already exists."
+msgstr "ファイル名 <%s> は既に存在します。"
+
+#: eeschema/sheet.cpp:179
+msgid ""
+"\n"
+"\n"
+"Do you want to replace the sheet with the contents of this file?"
+msgstr ""
+"\n"
+"\n"
+"このファイルの内容でシートを置換しますか？"
+
+#: eeschema/sheet.cpp:191
+msgid ""
+"This sheet uses shared data in a complex hierarchy.\n"
+"\n"
+msgstr ""
+"このシートは複雑な階層の中で共有データを使用しています。\n"
+"\n"
+
+#: eeschema/sheet.cpp:192
+msgid "Do you wish to convert it to a simple hierarchical sheet?"
+msgstr "シンプルな階層シートに変換しますか？"
+
+#: eeschema/sheetlab.cpp:164
+msgid "No new hierarchical labels found."
+msgstr "新しい階層ラベルが見つかりません"
+
+#: eeschema/symbedit.cpp:65
+msgid "Import Symbol Drawings"
+msgstr "シンボル図形をインポート"
+
+#: eeschema/symbedit.cpp:87
+#, c-format
+msgid "Error '%s' occurred loading part file '%s'."
+msgstr "エラー '%s' がコンポーネントファイル '%s' の読み込み時に発生しました。"
+
+#: eeschema/symbedit.cpp:98
+#, c-format
+msgid "No parts found in part file '%s'."
+msgstr "シンボル ライブラリ '%s' 内にコンポーネントがありません。"
+
+#: eeschema/symbedit.cpp:108
+#, c-format
+msgid "More than one part in part file '%s'."
+msgstr "パーツファイル '%s' 内に1つ以上のパーツがあります。"
+
+#: eeschema/symbedit.cpp:158
+msgid "Export Symbol Drawings"
+msgstr "シンボル図形のエクスポート"
+
+#: eeschema/symbedit.cpp:174
+#, c-format
+msgid "Saving symbol in '%s'"
+msgstr "シンボルを \"%s\" へ保存中"
+
+#: eeschema/symbedit.cpp:240
+#, c-format
+msgid "An error occurred attempting to save symbol file '%s'"
+msgstr "シンボルファイル '%s' を保存しようとしたところエラーが発生しました。"
+
+#: eeschema/tool_lib.cpp:62
+msgid "Deselect current tool"
+msgstr "現在のツールの選択を外す"
+
+#: eeschema/tool_lib.cpp:83
+msgid "Move part anchor"
+msgstr "パーツのアンカーを移動"
+
+#: eeschema/tool_lib.cpp:86
+msgid "Import existing drawings"
+msgstr "既存の図形のインポート"
+
+#: eeschema/tool_lib.cpp:89
+msgid "Export current drawing"
+msgstr "現在の図形のエクスポート"
+
+#: eeschema/tool_lib.cpp:112
+msgid "Save current library to disk"
+msgstr "ディスクに現在のライブラリを保存"
+
+#: eeschema/tool_lib.cpp:118
+msgid "Delete component in current library"
+msgstr "現在のライブラリのコンポーネントを削除"
+
+#: eeschema/tool_lib.cpp:126
+msgid "Create a new component"
+msgstr "新規コンポーネントを作成"
+
+#: eeschema/tool_lib.cpp:130
+msgid "Load component to edit from the current library"
+msgstr "現在のライブラリから、エディタへコンポーネントを読み込む"
+
+#: eeschema/tool_lib.cpp:134
+msgid "Create a new component from the current one"
+msgstr "現在のものから新規コンポーネントを作成"
+
+#: eeschema/tool_lib.cpp:138
+msgid "Update current component in current library"
+msgstr "現在のライブラリ内の現在のコンポーネントを更新"
+
+#: eeschema/tool_lib.cpp:141
+msgid "Import component"
+msgstr "コンポーネントのインポート"
+
+#: eeschema/tool_lib.cpp:144
+msgid "Export component"
+msgstr "コンポーネントのエクスポート"
+
+#: eeschema/tool_lib.cpp:147
+msgid "Save current component to new library"
+msgstr "新しいライブラリへ現在のコンポーネントを保存"
+
+#: eeschema/tool_lib.cpp:150 eeschema/help_common_strings.h:40
+msgid "Undo last command"
+msgstr "一つ前のコマンドを元に戻す"
+
+#: eeschema/tool_lib.cpp:152
+msgid "Redo the last command"
+msgstr "一つ前のコマンドをやり直し"
+
+#: eeschema/tool_lib.cpp:158
+msgid "Edit component properties"
+msgstr "コンポーネント プロパティの編集"
+
+#: eeschema/tool_lib.cpp:162
+msgid "Add and remove fields and edit field properties"
+msgstr "フィールドの追加/削除とプロパティの編集"
+
+#: eeschema/tool_lib.cpp:166
+msgid "Test for duplicate and off grid pins"
+msgstr "重複ピンとグリッドから外れたピンのテスト"
+
+#: eeschema/tool_lib.cpp:183 eeschema/tool_viewlib.cpp:98
+msgid "Show as \"De Morgan\" normal part"
+msgstr "\"ド・モルガン\" 標準部品として表示"
+
+#: eeschema/tool_lib.cpp:185 eeschema/tool_viewlib.cpp:103
+msgid "Show as \"De Morgan\" convert part"
+msgstr "\"ド・モルガン\" 変換部品として表示"
+
+#: eeschema/tool_lib.cpp:189
+msgid "Show the associated datasheet or document"
+msgstr "関連するデータシートまたはドキュメントを表示する"
+
+#: eeschema/tool_lib.cpp:209
+msgid "Edit pins per part or body style (Use carefully!)"
+msgstr "パーツ/ボディ形状ごとのピンの編集 (気をつけて使うこと!)"
+
+#: eeschema/tool_lib.cpp:213
+msgid "Show pin table"
+msgstr "ピン テーブルの表示"
+
+#: eeschema/tool_lib.cpp:229 eeschema/tool_sch.cpp:273
+#: gerbview/toolbars_gerber.cpp:151
+msgid "Turn grid off"
+msgstr "グリッド非表示"
+
+#: eeschema/tool_sch.cpp:58
+msgid "New schematic project"
+msgstr "新規回路図作成"
+
+#: eeschema/tool_sch.cpp:61
+msgid "Open schematic project"
+msgstr "既存回路図を開く"
+
+#: eeschema/tool_sch.cpp:65
+msgid "Save schematic project"
+msgstr "回路図プロジェクトの保存"
+
+#: eeschema/tool_sch.cpp:70 pagelayout_editor/toolbars_pl_editor.cpp:61
+msgid "Page settings"
+msgstr "ページの設定"
+
+#: eeschema/tool_sch.cpp:75
+msgid "Print schematic"
+msgstr "回路図の印刷"
+
+#: eeschema/tool_sch.cpp:81
+msgid "Cut selected item"
+msgstr "選択したアイテムを切り取り"
+
+#: eeschema/tool_sch.cpp:84
+msgid "Copy selected item"
+msgstr "選択したアイテムをコピー"
+
+#: eeschema/tool_sch.cpp:87
+msgid "Paste"
+msgstr "貼り付け"
+
+#: eeschema/tool_sch.cpp:105
+msgid "Find and replace text"
+msgstr "テキストの検索と置換"
+
+#: eeschema/tool_sch.cpp:127
+msgid "Navigate schematic hierarchy"
+msgstr "回路図の階層ナビゲータを表示"
+
+#: eeschema/tool_sch.cpp:131
+msgid "Leave sheet"
+msgstr "シートから抜ける"
+
+#: eeschema/tool_sch.cpp:151
+msgid "Generate netlist"
+msgstr "ネットリストの生成"
+
+#: eeschema/tool_sch.cpp:162
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:134
+msgid "Footprint Editor"
+msgstr "フットプリント エディタ"
+
+#: eeschema/tool_sch.cpp:165
+msgid "Run CvPcb to associate components and footprints"
+msgstr "CvPcb (コンポーネントとフットプリントの関連付け) を実行"
+
+#: eeschema/tool_sch.cpp:168
+msgid "Run Pcbnew to layout printed circuit board"
+msgstr "Pcbnew (プリント基板のレイアウト) の実行"
+
+#: eeschema/tool_sch.cpp:195
+msgid "Ascend/descend hierarchy"
+msgstr "階層の上下移動"
+
+#: eeschema/tool_sch.cpp:251 eeschema/help_common_strings.h:90
+msgid "Add bitmap image"
+msgstr "ビットマップイメージの追加"
+
+#: eeschema/tool_sch.cpp:277
+msgid "Set unit to inch"
+msgstr "単位をインチ系に設定"
+
+#: eeschema/tool_sch.cpp:281
+msgid "Set unit to mm"
+msgstr "単位をmm系に設定"
+
+#: eeschema/tool_sch.cpp:295
+msgid "HV orientation for wires and bus"
+msgstr "配線、バスの90度入力"
+
+#: eeschema/tool_viewlib.cpp:59 pcbnew/tool_modview.cpp:58
+msgid "Select library to browse"
+msgstr "参照するライブラリの選択"
+
+#: eeschema/tool_viewlib.cpp:63
+msgid "Select component to browse"
+msgstr "参照するパーツの選択"
+
+#: eeschema/tool_viewlib.cpp:68
+msgid "Display previous component"
+msgstr "前のコンポーネントの表示"
+
+#: eeschema/tool_viewlib.cpp:72
+msgid "Display next component"
+msgstr "次のコンポーネントを表示"
+
+#: eeschema/tool_viewlib.cpp:116
+msgid "View component documents"
+msgstr "コンポーネントのドキュメントを見る "
+
+#: eeschema/tool_viewlib.cpp:124
+msgid "Insert component in schematic"
+msgstr "回路図にコンポーネントを挿入"
+
+#: eeschema/tool_viewlib.cpp:170
+#, c-format
+msgid "Unit %c"
+msgstr "ユニット %c"
+
+#: eeschema/tool_viewlib.cpp:211 pcbnew/tool_modview.cpp:144
+msgid "Set Current Library"
+msgstr "現在のライブラリ"
+
+#: eeschema/tool_viewlib.cpp:212 pcbnew/tool_modview.cpp:145
+msgid "Select library to be displayed"
+msgstr "参照するライブラリの選択"
+
+#: eeschema/tool_viewlib.cpp:218 pcbnew/menubar_modedit.cpp:150
+#: pcbnew/tool_modview.cpp:150
+msgid "Cl&ose"
+msgstr "閉じる(&O)"
+
+#: eeschema/tool_viewlib.cpp:219
+msgid "Close schematic component viewer"
+msgstr "回路図 コンポーネント ビューアを閉じる"
+
+#: eeschema/tool_viewlib.cpp:251
+msgid "Open Eeschema manual"
+msgstr "Eeschema のマニュアルを開く"
+
+#: eeschema/tool_viewlib.cpp:262
+msgid "&About Eeschema"
+msgstr "Eeschema について(&A)"
+
+#: eeschema/tool_viewlib.cpp:263
+msgid "About Eeschema schematic designer"
+msgstr "Eeschema 回路図デザイナについて"
+
+#: eeschema/viewlib_frame.cpp:99 eeschema/viewlibs.cpp:134
+#: pcbnew/modview_frame.cpp:702
+msgid "Library Browser"
+msgstr "ライブラリ ブラウザ"
+
+#: gerbview/class_GERBER.cpp:347
+msgid "Image name"
+msgstr "画像名"
+
+#: gerbview/class_GERBER.cpp:352
+msgid "Graphic layer"
+msgstr "図形レイヤ"
+
+#: gerbview/class_GERBER.cpp:356
+msgid "Img Rot."
+msgstr "イメージの回転"
+
+#: gerbview/class_GERBER.cpp:360 gerbview/class_gerber_draw_item.cpp:568
+msgid "Polarity"
+msgstr "極性"
+
+#: gerbview/class_GERBER.cpp:364
+msgid "X Justify"
+msgstr "X位置調整"
+
+#: gerbview/class_GERBER.cpp:367
+msgid "Y Justify"
+msgstr "Y位置調整"
+
+#: gerbview/class_GERBER.cpp:375
+msgid "Image Justify Offset"
+msgstr "イメージのオフセット"
+
+#: gerbview/class_GERBER.cpp:469
+#, c-format
+msgid "Layer %d (%s, %s, %s)"
+msgstr "レイヤ %d (%s, %s, %s)"
+
+#: gerbview/class_GERBER.cpp:476
+#, c-format
+msgid "Layer %d (%s, %s)"
+msgstr "レイヤ %d (%s, %s)"
+
+#: gerbview/class_GERBER.cpp:482
+#, c-format
+msgid "Layer %d *"
+msgstr "レイヤ %d *"
+
+#: gerbview/class_GERBER.cpp:485 gerbview/select_layers_to_pcb.cpp:183
+#, c-format
+msgid "Layer %d"
+msgstr "レイヤ %d"
+
+#: gerbview/class_gerber_draw_item.cpp:553
+msgid "D Code"
+msgstr "D コード"
+
+#: gerbview/class_gerber_draw_item.cpp:557
+msgid "Graphic Layer"
+msgstr "図形レイヤ"
+
+#: gerbview/class_gerber_draw_item.cpp:564
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:350
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:68
+msgid "Rotation"
+msgstr "回転"
+
+#: gerbview/class_gerber_draw_item.cpp:567
+msgid "Clear"
+msgstr "クリア"
+
+#: gerbview/class_gerber_draw_item.cpp:567
+msgid "Dark"
+msgstr "ダーク"
+
+#: gerbview/class_gerber_draw_item.cpp:578
+msgid "AB axis"
+msgstr "AB軸"
+
+#: gerbview/class_gerbview_layer_widget.cpp:89
+#: gerbview/dialogs/dialog_print_using_printer.cpp:163
+#: gerbview/dialogs/dialog_select_one_pcb_layer.cpp:163
+#: pcbnew/class_drawsegment.cpp:408 pcbnew/class_module.cpp:568
+#: pcbnew/class_pad.cpp:644 pcbnew/class_pcb_layer_widget.cpp:242
+#: pcbnew/class_pcb_text.cpp:140 pcbnew/class_text_mod.cpp:385
+#: pcbnew/class_track.cpp:1152 pcbnew/class_track.cpp:1179
+#: pcbnew/class_zone.cpp:630
+#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:89
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:115
+#: pcbnew/dialogs/dialog_modedit_options_base.cpp:144
+#: pcbnew/layer_widget.cpp:540
+msgid "Layer"
+msgstr "レイヤ"
+
+#: gerbview/class_gerbview_layer_widget.cpp:90
+#: pcbnew/class_pcb_layer_widget.cpp:243 pcbnew/layer_widget.cpp:560
+msgid "Render"
+msgstr "表示"
+
+#: gerbview/class_gerbview_layer_widget.cpp:110
+#: pcbnew/class_pcb_layer_widget.cpp:74
+msgid "Show the (x,y) grid dots"
+msgstr "(x,y) グリッドのドットを表示"
+
+#: gerbview/class_gerbview_layer_widget.cpp:111
+msgid "DCodes"
+msgstr "Dコード"
+
+#: gerbview/class_gerbview_layer_widget.cpp:111
+msgid "Show DCodes identification"
+msgstr "Dコード表の表示"
+
+#: gerbview/class_gerbview_layer_widget.cpp:112
+msgid "Neg. Obj."
+msgstr "ネガのオブジェクト"
+
+#: gerbview/class_gerbview_layer_widget.cpp:113
+msgid "Show negative objects in this color"
+msgstr "ネガのオブジェクトをこの色で表示します"
+
+#: gerbview/class_gerbview_layer_widget.cpp:152
+msgid "Show All Layers"
+msgstr "全てのレイヤを表示"
+
+#: gerbview/class_gerbview_layer_widget.cpp:155
+msgid "Hide All Layers But Active"
+msgstr "アクティブでない全てのレイヤを隠す"
+
+#: gerbview/class_gerbview_layer_widget.cpp:158
+msgid "Always Hide All Layers But Active"
+msgstr "アクティブでない全てのレイヤを隠す"
+
+#: gerbview/class_gerbview_layer_widget.cpp:161
+msgid "Hide All Layers"
+msgstr "全てのレイヤを非表示"
+
+#: gerbview/class_gerbview_layer_widget.cpp:165
+msgid "Sort Layers if X2 Mode"
+msgstr "X2 モードならレイヤをソートする"
+
+#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:31
+msgid "Layers selection:"
+msgstr "レイヤの選択:"
+
+#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:56
+msgid "Copper layers count:"
+msgstr "導体レイヤ数:"
+
+#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:60
+#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:61
+msgid "2 Layers"
+msgstr "２層"
+
+#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:62
+msgid "4 Layers"
+msgstr "４層"
+
+#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:63
+msgid "6 Layers"
+msgstr "６層"
+
+#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:64
+msgid "8 Layers"
+msgstr "８層"
+
+#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:65
+msgid "10 Layers"
+msgstr "１０層"
+
+#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:66
+msgid "12 Layers"
+msgstr "１２層"
+
+#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:67
+msgid "14 Layers"
+msgstr "１４層"
+
+#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:68
+msgid "16 Layers"
+msgstr "１６層"
+
+#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:80
+msgid "Store Choice"
+msgstr "選択内容の保存"
+
+#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:83
+msgid "Get Stored Choice"
+msgstr "保存された選択を取得する"
+
+#: gerbview/dialogs/dialog_print_using_printer.cpp:107
+#: pagelayout_editor/events_functions.cpp:517
+#: pcbnew/dialogs/dialog_print_for_modedit.cpp:87
+#: pcbnew/dialogs/dialog_print_using_printer.cpp:114
+msgid "Error Init Printer info"
+msgstr "プリンタ情報の初期化エラー"
+
+#: gerbview/dialogs/dialog_print_using_printer.cpp:297
+#: pcbnew/dialogs/dialog_plot.cpp:776
+#: pcbnew/dialogs/dialog_print_using_printer.cpp:367
+msgid "Warning: Scale option set to a very large value"
+msgstr "警告: 拡大率が非常に大きく設定されています"
+
+#: gerbview/dialogs/dialog_print_using_printer.cpp:305
+#: pcbnew/dialogs/dialog_plot.cpp:772
+#: pcbnew/dialogs/dialog_print_using_printer.cpp:375
+msgid "Warning: Scale option set to a very small value"
+msgstr "警告: 拡大率が非常に小さく設定されています"
+
+#: gerbview/dialogs/dialog_print_using_printer.cpp:340
+#: pcbnew/dialogs/dialog_plot.cpp:827
+#: pcbnew/dialogs/dialog_print_using_printer.cpp:441
+#: pcbnew/dialogs/dialog_print_using_printer.cpp:482
+msgid "No layer selected"
+msgstr "レイヤが選択されていません"
+
+#: gerbview/dialogs/dialog_print_using_printer.cpp:354
+#: pcbnew/dialogs/dialog_print_for_modedit.cpp:173
+#: pcbnew/dialogs/dialog_print_using_printer.cpp:446
+msgid "Print Preview"
+msgstr "印刷プレビュー"
+
+#: gerbview/dialogs/dialog_print_using_printer.cpp:401
+#: pcbnew/dialogs/dialog_print_for_modedit.cpp:221
+#: pcbnew/dialogs/dialog_print_using_printer.cpp:496
+msgid "There was a problem printing"
+msgstr "印刷中に問題が発生しました"
+
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:20
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:25
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:30
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:45
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:20
+msgid "Layers:"
+msgstr "レイヤ:"
+
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
+#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:22
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:49
+msgid "fit in page"
+msgstr "ページに合わせる"
+
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
+#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:22
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:49
+msgid "Scale 0.5"
+msgstr "0.5倍"
+
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
+#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:22
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:49
+msgid "Scale 0.7"
+msgstr "0.7倍"
+
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:49
+msgid "Approx. Scale 1"
+msgstr "大まかな原寸"
+
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:49
+msgid "Accurate Scale 1"
+msgstr "正確な原寸"
+
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
+#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:22
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:49
+msgid "Scale 1.4"
+msgstr "1.4倍"
+
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
+#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:22
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:49
+msgid "Scale 2"
+msgstr "2倍"
+
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
+#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:22
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:49
+msgid "Scale 3"
+msgstr "3倍"
+
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
+#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:22
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:49
+msgid "Scale 4"
+msgstr "4倍"
+
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:46
+#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:24
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:51
+msgid "Approx. Scale:"
+msgstr "概略スケール値:"
+
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:50
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:55
+msgid "X Scale Adjust"
+msgstr "Xスケール値の調整"
+
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:56
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:61
+msgid "Set X scale adjust for exact scale plotting"
+msgstr "実際の作画倍率にXスケールを調整"
+
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:60
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:65
+msgid "Y Scale Adjust"
+msgstr "Yスケールの調整"
+
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:66
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:71
+msgid "Set Y scale adjust for exact scale plotting"
+msgstr "実際に作画倍率にYスケールを調整"
+
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:87
+#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:36
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:114
+msgid "Print Mode"
+msgstr "印刷モード"
+
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:89
+msgid ""
+"Choose if you want to print sheets in color, or force the black and white "
+"mode."
+msgstr "シートをカラーまたは強制的にモノクロで印刷したい場合に選択"
+
+#: gerbview/dialogs/dialog_print_using_printer_base.cpp:99
+#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:48
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:135
+msgid "Page Options"
+msgstr "ページ オプション"
+
+#: gerbview/dialogs/dialog_select_one_pcb_layer.cpp:113
+#: pcbnew/dialogs/dialog_layer_selection_base.h:50
+msgid "Select Layer:"
+msgstr "レイヤの選択: "
+
+#: gerbview/dialogs/dialog_select_one_pcb_layer.cpp:154
+#: gerbview/select_layers_to_pcb.cpp:222 gerbview/select_layers_to_pcb.cpp:338
+#: gerbview/select_layers_to_pcb.cpp:377
+msgid "Do not export"
+msgstr "エクスポートできません。"
+
+#: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
+msgid "Full size. Do not show page limits"
+msgstr "フルサイズ、ページ区切り/非表示"
+
+#: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:77
+msgid "Full size"
+msgstr "フルサイズ"
+
+#: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:77
+msgid "Size A4"
+msgstr "A4サイズ"
+
+#: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:77
+msgid "Size A3"
+msgstr "A3サイズ"
+
+#: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:77
+msgid "Size A2"
+msgstr "A2サイズ"
+
+#: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:77
+msgid "Size A"
+msgstr "Aサイズ"
+
+#: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:77
+msgid "Size B"
+msgstr "Bサイズ"
+
+#: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:77
+msgid "Size C"
+msgstr "Cサイズ"
+
+#: gerbview/dialogs/dialog_show_page_borders_base.cpp:27
+msgid "Show Page Limits:"
+msgstr "ページの境界を表示:"
+
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:25
+#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:25
+msgid "Cartesian coordinates"
+msgstr "直交座標"
+
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:25
+#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:25
+msgid "Polar coordinates"
+msgstr "極座標"
+
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:27
+#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:27
+msgid "Coordinates"
+msgstr "座標"
+
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:31
+#: pcbnew/dialogs/dialog_export_idf_base.cpp:86
+#: pcbnew/dialogs/dialog_gendrill_base.cpp:44
+#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:33
+#: pcbnew/dialogs/dialog_set_grid_base.cpp:25
+msgid "Millimeters"
+msgstr "mm"
+
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:37
+#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:41
+msgid "Small cross"
+msgstr "小十字"
+
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:37
+#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:41
+msgid "Full screen cursor"
+msgstr "フルスクリーンカーソルに変更"
+
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:39
+#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:43
+msgid "Cursor"
+msgstr "カーソル"
+
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:43
+msgid "Show D codes"
+msgstr "Dコードの表示"
+
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:53
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:59
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:65
+#: pcbnew/dialogs/dialog_plot_base.cpp:164
+msgid "Sketch"
+msgstr "スケッチ"
+
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:53
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:59
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:65
+#: pcbnew/dialogs/dialog_plot_base.cpp:164
+msgid "Filled"
+msgstr "塗りつぶし"
+
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:55
+#: pcbnew/autorouter/auto_place_footprints.cpp:477
+msgid "Lines"
+msgstr "行"
+
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:61
+#: pcbnew/class_board.cpp:951 pcbnew/class_module.cpp:580
+#: pcbnew/class_netinfo_item.cpp:113 pcbnew/pcb_draw_panel_gal.cpp:347
+msgid "Pads"
+msgstr "パッド"
+
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:67
+#: pcbnew/class_zone.cpp:638
+msgid "Polygons"
+msgstr "ポリゴン"
+
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:77
+msgid "Full size without limits"
+msgstr "フルサイズ、ページ区切り/非表示"
+
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:79
+msgid "Page"
+msgstr "ページ"
+
+#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:86
+msgid "Do not center and warp cursor on zoom"
+msgstr "拡大縮小時にカーソルを中心へ移動させない"
+
+#: gerbview/events_called_functions.cpp:269
+msgid "No editor defined. Please select one"
+msgstr "エディタが定義されていません。一つ選択してください。"
+
+#: gerbview/events_called_functions.cpp:275
+#, c-format
+msgid "No file loaded on the active layer %d"
+msgstr "アクティブなレイヤ%d上にファイルが読み込まれていません"
+
+#: gerbview/events_called_functions.cpp:319 gerbview/gerbview_frame.cpp:143
+#: pcbnew/moduleframe.cpp:289 pcbnew/pcbframe.cpp:401 pcbnew/pcbframe.cpp:907
+msgid "Visibles"
+msgstr "表示"
+
+#: gerbview/events_called_functions.cpp:382 gerbview/menubar.cpp:155
+#: gerbview/menubar.cpp:157 gerbview/options.cpp:89
+#: pcbnew/dialogs/dialog_general_options.cpp:243 pcbnew/pcbnew_config.cpp:80
+msgid "Hide &Layers Manager"
+msgstr "レイヤマネージャを非表示(&L)"
+
+#: gerbview/events_called_functions.cpp:382 gerbview/menubar.cpp:157
+#: gerbview/options.cpp:89 pcbnew/dialogs/dialog_general_options.cpp:243
+#: pcbnew/pcbnew_config.cpp:80
+msgid "Show &Layers Manager"
+msgstr "レイヤマネージャを表示(&L)"
+
+#: gerbview/excellon_read_drill_file.cpp:189
+msgid "No room to load file"
+msgstr "ファイルをロードできません"
+
+#: gerbview/excellon_read_drill_file.cpp:199 pcbnew/pcbnew_config.cpp:227
+#: pcbnew/pcbnew_config.cpp:504
+#, c-format
+msgid "File %s not found"
+msgstr "ファイル %s が見つかりません"
+
+#: gerbview/excellon_read_drill_file.cpp:214
+msgid "Files not found"
+msgstr "ファイルが見つかりません"
+
+#: gerbview/excellon_read_drill_file.cpp:388
+msgid "METRIC command has no parameter"
+msgstr "METRIC コマンドはパラメータを持ちません"
+
+#: gerbview/excellon_read_drill_file.cpp:406
+msgid "INCH command has no parameter"
+msgstr "INCH コマンドはパラメータを持ちません"
+
+#: gerbview/excellon_read_drill_file.cpp:434
+msgid "ICI command has no parameter"
+msgstr "ICIコメントはパラメータを持っていません"
+
+#: gerbview/excellon_read_drill_file.cpp:444
+msgid "ICI command has incorrect parameter"
+msgstr "ICIコメントは不正なパラメータを持っています"
+
+#: gerbview/excellon_read_drill_file.cpp:482
+#, c-format
+msgid "Tool definition <%c> not supported"
+msgstr "ツール定義 <%c> はサポートされていません。"
+
+#: gerbview/excellon_read_drill_file.cpp:534
+#, c-format
+msgid "Tool <%d> not defined"
+msgstr "ツール <%d> は定義されていません"
+
+#: gerbview/excellon_read_drill_file.cpp:661
+#, c-format
+msgid "Unknown Excellon G Code: &lt;%s&gt;"
+msgstr "不明な Excellon G Code です : &lt;%s&gt;"
+
+#: gerbview/export_to_pcbnew.cpp:173
+msgid "None of the Gerber layers contain any data"
+msgstr "ガーバーレイヤにデータが含まれていません。"
+
+#: gerbview/export_to_pcbnew.cpp:180
+msgid "Board file name:"
+msgstr "ボード ファイル名:"
+
+#: gerbview/export_to_pcbnew.cpp:216
+#, c-format
+msgid "Cannot create file '%s'"
+msgstr "ファイル '%s' を作成できません"
+
+#: gerbview/files.cpp:46
+msgid "Gerber files"
+msgstr "ガーバー ファイル"
+
+#: gerbview/files.cpp:60
+msgid "Drill files"
+msgstr "ドリル ファイル"
+
+#: gerbview/files.cpp:121
+msgid "Gerber files (.g* .lgr .pho)"
+msgstr "ガーバーファイル (.g*, .lgr, .pho)"
+
+#: gerbview/files.cpp:127
+msgid "Top layer (*.GTL)|*.GTL;*.gtl|"
+msgstr "表面レイヤ (*.GTL)|*.GTL;*.gtl|"
+
+#: gerbview/files.cpp:128
+msgid "Bottom layer (*.GBL)|*.GBL;*.gbl|"
+msgstr "裏面レイヤ (*.GBL)|*.GBL;*.gbl|"
+
+#: gerbview/files.cpp:129
+msgid "Bottom solder resist (*.GBS)|*.GBS;*.gbs|"
+msgstr "裏面ハンダレジスト (*.GBS)|*.GBS;*.gbs|"
+
+#: gerbview/files.cpp:130
+msgid "Top solder resist (*.GTS)|*.GTS;*.gts|"
+msgstr "表面ハンダレジスト (*.GTS)|*.GTS;*.gts|"
+
+#: gerbview/files.cpp:131
+msgid "Bottom overlay (*.GBO)|*.GBO;*.gbo|"
+msgstr "裏面オーバーレイ (*.GBO)|*.GBO;*.gbo|"
+
+#: gerbview/files.cpp:132
+msgid "Top overlay (*.GTO)|*.GTO;*.gto|"
+msgstr "表面オーバーレイ (*.GTO)|*.GTO;*.gto|"
+
+#: gerbview/files.cpp:133
+msgid "Bottom paste (*.GBP)|*.GBP;*.gbp|"
+msgstr "裏面ペースト (*.GBP)|*.GBP;*.gbp|"
+
+#: gerbview/files.cpp:134
+msgid "Top paste (*.GTP)|*.GTP;*.gtp|"
+msgstr "表面ペースト (*.GTP)|*.GTP;*.gtp|"
+
+#: gerbview/files.cpp:135
+msgid "Keep-out layer (*.GKO)|*.GKO;*.gko|"
+msgstr "キープアウト レイヤ (*.GKO)|*.GKO;*.gko|"
+
+#: gerbview/files.cpp:136
+msgid "Mechanical layers (*.GMx)|*.GM1;*.gm1;*.GM2;*.gm2;*.GM3;*.gm3|"
+msgstr "メカニカル レイヤ (*.GMx)|*.GM1;*.gm1;*.GM2;*.gm2;*.GM3;*.gm3|"
+
+#: gerbview/files.cpp:137
+msgid "Top Pad Master (*.GPT)|*.GPT;*.gpt|"
+msgstr "表面パッド マスター (*.GPT)|*.GPT;*.gpt|"
+
+#: gerbview/files.cpp:138
+msgid "Bottom Pad Master (*.GPB)|*.GPB;*.gpb|"
+msgstr "裏面パッド マスター (*.GPB)|*.GPB;*.gpb|"
+
+#: gerbview/files.cpp:150
+msgid "Open Gerber File"
+msgstr "ガーバー ファイルを開く"
+
+#: gerbview/files.cpp:240
+msgid "Open Drill File"
+msgstr "ドリルファイルを開く"
+
+#: gerbview/gerbview_frame.cpp:465
+msgid "D Codes"
+msgstr "D コード"
+
+#: gerbview/gerbview_frame.cpp:484
+#, c-format
+msgid "Layer %d not in use"
+msgstr "レイヤ %d は未使用です"
+
+#: gerbview/gerbview_frame.cpp:490
+#: pcbnew/import_dxf/dialog_dxf_import_base.cpp:24
+msgid "File:"
+msgstr "ファイル:"
+
+#: gerbview/gerbview_frame.cpp:494
+msgid "(with X2 Attributes)"
+msgstr "(X2属性)"
+
+#: gerbview/gerbview_frame.cpp:501
+#, c-format
+msgid "Image name: '%s'  Layer name: '%s'"
+msgstr "イメージ名: '%s', レイヤ: '%s'"
+
+#: gerbview/gerbview_frame.cpp:514
+msgid "X2 attr"
+msgstr "X2 属性"
+
+#: gerbview/init_gbr_drawlayers.cpp:48
+msgid "Current data will be lost?"
+msgstr "現在のデータが失われます、宜しいですか？"
+
+#: gerbview/init_gbr_drawlayers.cpp:72
+#, c-format
+msgid "Clear layer %d?"
+msgstr "レイヤ %d をクリアしますか？"
+
+#: gerbview/menubar.cpp:64
+msgid "Load &Gerber File"
+msgstr "ガーバー ファイルを読み込む(&G)"
+
+#: gerbview/menubar.cpp:65 gerbview/toolbars_gerber.cpp:62
+msgid ""
+"Load a new Gerber file on the current layer. Previous data will be deleted"
+msgstr "現在のレイヤに新規ガーバーファイルを読込み。前のデータが削除されます"
+
+#: gerbview/menubar.cpp:71
+msgid "Load &EXCELLON Drill File"
+msgstr "EXCELLON ドリルファイルの読み込み(&E)"
+
+#: gerbview/menubar.cpp:72
+msgid "Load excellon drill file"
+msgstr "excellon ドリルファイルの読込み"
+
+#: gerbview/menubar.cpp:90
+msgid "Open &Recent Gerber File"
+msgstr "最近のガーバー ファイルを開く(&R)"
+
+#: gerbview/menubar.cpp:91
+msgid "Open a recent opened Gerber file"
+msgstr "最近開いたガーバーファイルを開く"
+
+#: gerbview/menubar.cpp:105
+msgid "Open Recent Dri&ll File"
+msgstr "最近のドリルファイルを開く(&L)"
+
+#: gerbview/menubar.cpp:106
+msgid "Open a recent opened drill file"
+msgstr "最近開いたドリルファイルを開く"
+
+#: gerbview/menubar.cpp:115
+msgid "Clear &All"
+msgstr "全てクリア(&A)"
+
+#: gerbview/menubar.cpp:116
+msgid "Clear all layers. All data will be deleted"
+msgstr "全てのレイヤをクリア。全てのデータが削除されます"
+
+#: gerbview/menubar.cpp:125
+msgid "E&xport to Pcbnew"
+msgstr "Pcbnew へエクスポート(&X)"
+
+#: gerbview/menubar.cpp:126
+msgid "Export data in Pcbnew format"
+msgstr "Pcbnew フォーマットでデータのエクスポート"
+
+#: gerbview/menubar.cpp:135 pagelayout_editor/menubar.cpp:101
+#: pcbnew/menubar_modedit.cpp:141 pcbnew/menubar_pcbframe.cpp:237
+msgid "&Print"
+msgstr "印刷(&P)"
+
+#: gerbview/menubar.cpp:136
+msgid "Print gerber"
+msgstr "ガーバー印刷"
+
+#: gerbview/menubar.cpp:146
+msgid "Close GerbView"
+msgstr "GerbViewの終了"
+
+#: gerbview/menubar.cpp:167
+msgid "&Options"
+msgstr "オプション(&O)"
+
+#: gerbview/menubar.cpp:168
+msgid "Set options to draw items"
+msgstr "アイテム描画オプションの設定"
+
+#: gerbview/menubar.cpp:184
+msgid "&List DCodes"
+msgstr "Dコードのリスト(&L)"
+
+#: gerbview/menubar.cpp:185
+msgid "List and edit D-codes"
+msgstr "D-codesリスト表示、編集"
+
+#: gerbview/menubar.cpp:191
+msgid "&Show Source"
+msgstr "ソースの表示(&S)"
+
+#: gerbview/menubar.cpp:192
+msgid "Show source file for the current layer"
+msgstr "現在のレイヤのソースファイルを表示"
+
+#: gerbview/menubar.cpp:201
+msgid "&Clear Layer"
+msgstr "レイヤのクリア(&C)"
+
+#: gerbview/menubar.cpp:202
+msgid "Clear current layer"
+msgstr "現在のレイヤをクリアする"
+
+#: gerbview/menubar.cpp:211 pagelayout_editor/menubar.cpp:132
+msgid "&Text Editor"
+msgstr "テキストエディタ(&T)"
+
+#: gerbview/menubar.cpp:212 pagelayout_editor/menubar.cpp:133
+msgid "Select your preferred text editor"
+msgstr "使用するテキストエディタを指定"
+
+#: gerbview/menubar.cpp:224
+msgid "Gerbview &Manual"
+msgstr ""
+
+#: gerbview/menubar.cpp:225
+msgid "Open the GerbView Manual"
+msgstr ""
+
+#: gerbview/menubar.cpp:244
+msgid "&Miscellaneous"
+msgstr "その他(&M)"
+
+#: gerbview/readgerb.cpp:69
+#, c-format
+msgid "File <%s> not found"
+msgstr "ファイル <%s> が見つかりません。"
+
+#: gerbview/readgerb.cpp:182
+msgid "Errors"
+msgstr "エラー"
+
+#: gerbview/readgerb.cpp:192
+msgid ""
+"Warning: this file has no D-Code definition\n"
+"It is perhaps an old RS274D file\n"
+"Therefore the size of items is undefined"
+msgstr ""
+"警告！ このファイルは D-Code 定義を持っていません\n"
+"古い RS274D ファイルだと思われます\n"
+"そのため、アイテムのサイズは未定義です"
+
+#: gerbview/rs274x.cpp:444
+msgid "RS274X: Command \"IR\" rotation value not allowed"
+msgstr "RS274X: コマンド \"IR\" 回転値は許可されていません。"
+
+#: gerbview/rs274x.cpp:535
+msgid "RS274X: Command KNOCKOUT ignored by GerbView"
+msgstr "RS274X: コマンド「KNOCKOUT」は GerbViewで無視されます。"
+
+#: gerbview/rs274x.cpp:597
+msgid "Too many include files!!"
+msgstr "含まれるファイル数が多過ぎます!!"
+
+#: gerbview/select_layers_to_pcb.cpp:424
+msgid ""
+"The exported board has not enough copper layers to handle selected inner "
+"layers"
+msgstr ""
+"エクスポートされた基板は選択された内層を操作するための導体層が不足していま"
+"す。"
+
+#: gerbview/toolbars_gerber.cpp:59
+msgid "Erase all layers"
+msgstr "全レイヤを消去"
+
+#: gerbview/toolbars_gerber.cpp:66
+msgid ""
+"Load an excellon drill file on the current layer. Previous data will be "
+"deleted"
+msgstr ""
+"現在のレイヤにexcellonドリルファイルを読込みます。以前のデータは削除されま"
+"す。"
+
+#: gerbview/toolbars_gerber.cpp:70
+msgid "Show/hide frame reference and select paper size for printing"
+msgstr "フレームリファレンスの表示/非表示 及び 印刷用紙サイズ"
+
+#: gerbview/toolbars_gerber.cpp:74
+msgid "Print layers"
+msgstr "レイヤを印刷"
+
+#: gerbview/toolbars_gerber.cpp:101
+msgid "No tool"
+msgstr "ツールなし"
+
+#: gerbview/toolbars_gerber.cpp:105
+msgid "Tool "
+msgstr "ツール"
+
+#: gerbview/toolbars_gerber.cpp:155
+msgid "Turn polar coordinate on"
+msgstr "極座標表示に切り替え"
+
+#: gerbview/toolbars_gerber.cpp:159
+msgid "Set units to inches"
+msgstr "単位をインチ系に設定"
+
+#: gerbview/toolbars_gerber.cpp:163
+msgid "Set units to millimeters"
+msgstr "単位をmm系に設定"
+
+#: gerbview/toolbars_gerber.cpp:172
+msgid "Show spots in sketch mode"
+msgstr "スポットをスケッチモード表示"
+
+#: gerbview/toolbars_gerber.cpp:176
+msgid "Show lines in sketch mode"
+msgstr "ラインをスケッチモード表示"
+
+#: gerbview/toolbars_gerber.cpp:180
+msgid "Show polygons in sketch mode"
+msgstr "ポリゴンをスケッチモード表示"
+
+#: gerbview/toolbars_gerber.cpp:185
+msgid "Show negatives objects in ghost color"
+msgstr "ネガのオブジェクトをこの反転色で表示します"
+
+#: gerbview/toolbars_gerber.cpp:190
+msgid "Show dcode number"
+msgstr "Dコード番号を表示"
+
+# pls translate more better.
+#: gerbview/toolbars_gerber.cpp:196
+msgid ""
+"Show layers in raw mode (could have problems with negative items when more "
+"than one gerber file is shown)"
+msgstr ""
+"レイヤを実 (raw) モードで表示 (複数のガーバーファイルを表示する際にネガのアイ"
+"テムで問題が発生します)"
+
+#: gerbview/toolbars_gerber.cpp:201
+msgid ""
+"Show layers in stacked mode (show negative items without artifacts, "
+"sometimes slow)"
+msgstr ""
+"レイヤをスタックモードで表示(加工なしでネガのアイテムを表示、時々遅くなりま"
+"す)"
+
+# pls translate more better.
+#: gerbview/toolbars_gerber.cpp:206
+msgid ""
+"Show layers in transparency mode (show negative items without artifacts, "
+"sometimes slow)"
+msgstr ""
+"レイヤを透過 (transparency) モードで表示 (加工なしでネガのアイテムを表示、"
+"時々遅くなります)"
+
+#: gerbview/toolbars_gerber.cpp:215 pcbnew/help_common_strings.h:24
+msgid "Show/hide the layers manager toolbar"
+msgstr "レイヤ マネージャー ツールバーの表示/非表示"
+
+#: gerbview/toolbars_gerber.cpp:287
+msgid "Hide layers manager"
+msgstr "レイヤマネージャを非表示"
+
+#: gerbview/toolbars_gerber.cpp:289
+msgid "Show layers manager"
+msgstr "レイヤマネージャを表示"
 
 #: kicad/class_treeproject_item.cpp:111
 msgid ""
@@ -91,6 +9338,30 @@ msgstr "Pcb calculator - コンポーネント、配線幅などの計算"
 msgid "Pl editor - Worksheet layout editor"
 msgstr "Pl editor - 図枠エディタ"
 
+#: kicad/dialogs/dialog_template_selector.cpp:120
+msgid "<html><h1>Template Selector</h1></html>"
+msgstr "<html><h1>テンプレート選択</h1></html>"
+
+#: kicad/dialogs/dialog_template_selector.cpp:211
+msgid "Select Templates Directory"
+msgstr "テンプレートディレクトリの選択"
+
+#: kicad/dialogs/dialog_template_selector_base.cpp:26
+msgid "Templates path"
+msgstr "テンプレートのパス"
+
+#: kicad/dialogs/dialog_template_selector_base.cpp:39
+msgid "Validate"
+msgstr "有効にする"
+
+#: kicad/dialogs/dialog_template_selector_base.cpp:114
+msgid "Project Template Title"
+msgstr "プロジェクト・テンプレート・タイトル"
+
+#: kicad/files-io.cpp:46
+msgid "Zip file (*.zip)|*.zip"
+msgstr ""
+
 #: kicad/files-io.cpp:52
 msgid "KiCad project file"
 msgstr "Kicad プロジェクト ファイル"
@@ -112,43 +9383,43 @@ msgstr ""
 msgid "Target Directory"
 msgstr "ターゲット ディレクトリ"
 
-#: kicad/files-io.cpp:94
+#: kicad/files-io.cpp:95
 #, c-format
 msgid "Unzipping project in '%s'\n"
 msgstr "プロジェクトを \"%s\" 以下に展開\n"
 
-#: kicad/files-io.cpp:116
+#: kicad/files-io.cpp:119
 #, c-format
 msgid "Extract file '%s'"
 msgstr "ファイル '%s' の抽出"
 
-#: kicad/files-io.cpp:126
+#: kicad/files-io.cpp:128
 msgid " OK\n"
 msgstr " OK\n"
 
-#: kicad/files-io.cpp:129
+#: kicad/files-io.cpp:131
 msgid " *ERROR*\n"
 msgstr "*エラー*\n"
 
-#: kicad/files-io.cpp:157
+#: kicad/files-io.cpp:159
 msgid "Archive Project Files"
 msgstr "プロジェクトファイルをアーカイブする"
 
-#: kicad/files-io.cpp:200
+#: kicad/files-io.cpp:202
 #, c-format
 msgid "Archive file <%s>"
 msgstr "ファイル <%s> をアーカイブ"
 
-#: kicad/files-io.cpp:214
+#: kicad/files-io.cpp:216
 #, c-format
-msgid "(%d bytes, compressed %d bytes)\n"
-msgstr "(%d bytes, %d bytes 圧縮)\n"
+msgid "(%lu bytes, compressed %d bytes)\n"
+msgstr ""
 
-#: kicad/files-io.cpp:220
+#: kicad/files-io.cpp:222
 msgid " >>Error\n"
 msgstr ">>エラー\n"
 
-#: kicad/files-io.cpp:227
+#: kicad/files-io.cpp:229
 #, c-format
 msgid ""
 "\n"
@@ -157,25 +9428,25 @@ msgstr ""
 "\n"
 "Zip アーカイブ <%s> が作成されました (%d bytes)"
 
-#: kicad/mainframe.cpp:247
+#: kicad/mainframe.cpp:249
 #, c-format
 msgid "%s closed [pid=%d]\n"
 msgstr "%s の終了 [pid=%d]\n"
 
-#: kicad/mainframe.cpp:268
+#: kicad/mainframe.cpp:270
 #, c-format
-msgid "%s opened [pid=%ld]\n"
-msgstr "%s の起動 [pid=%ld]\n"
+msgid "%s %s opened [pid=%ld]\n"
+msgstr ""
 
-#: kicad/mainframe.cpp:467
+#: kicad/mainframe.cpp:441
 msgid "Text file ("
 msgstr "テキスト ファイル ("
 
-#: kicad/mainframe.cpp:470
+#: kicad/mainframe.cpp:444
 msgid "Load File to Edit"
 msgstr "編集するファイルを読み込む"
 
-#: kicad/mainframe.cpp:524
+#: kicad/mainframe.cpp:498
 #, c-format
 msgid ""
 "Project name:\n"
@@ -191,10 +9462,6 @@ msgstr "プロジェクトを開く(&O)"
 #: kicad/menubar.cpp:215 kicad/menubar.cpp:476
 msgid "Open existing project"
 msgstr "既存のプロジェクトを開く"
-
-#: kicad/menubar.cpp:224 pcbnew/menubar_pcbframe.cpp:94 eeschema/menubar.cpp:97
-msgid "Open &Recent"
-msgstr "最近開いたファイル(&R)"
 
 #: kicad/menubar.cpp:225
 msgid "Open recent schematic project"
@@ -249,13 +9516,6 @@ msgstr "アーカイブの展開(&U)"
 msgid "Unarchive project files from zip file"
 msgstr "Zipファイルからプロジェクトファイルを解凍"
 
-#: kicad/menubar.cpp:279 pcbnew/menubar_pcbframe.cpp:272
-#: eeschema/menubar.cpp:170 eeschema/dialogs/dialog_erc_base.cpp:110
-#: cvpcb/menubar.cpp:76 gerbview/menubar.cpp:145
-#: pagelayout_editor/menubar.cpp:111
-msgid "&Close"
-msgstr "閉じる(&C)"
-
 #: kicad/menubar.cpp:280
 msgid "Close KiCad"
 msgstr "KiCadの終了"
@@ -275,16 +9535,6 @@ msgstr "ファイルを開く(&O)"
 #: kicad/menubar.cpp:297
 msgid "Edit local file"
 msgstr "ローカルファイルの編集"
-
-#: kicad/menubar.cpp:306 pcbnew/menubar_modedit.cpp:318
-#: pcbnew/menubar_pcbframe.cpp:493 cvpcb/menubar.cpp:89
-msgid "Configure Pa&ths"
-msgstr "環境変数の設定(&T)"
-
-#: kicad/menubar.cpp:307 pcbnew/menubar_modedit.cpp:319
-#: pcbnew/menubar_pcbframe.cpp:494 cvpcb/menubar.cpp:90
-msgid "Edit path configuration environment variables"
-msgstr "環境変数の設定"
 
 #: kicad/menubar.cpp:313
 msgid "&Set Text Editor"
@@ -334,10 +9584,6 @@ msgstr "回路図エディタ(EESchema)の起動"
 msgid "Run Library Editor"
 msgstr "コンポーネントライブラリエディタの起動"
 
-#: kicad/menubar.cpp:370 eeschema/menubar.cpp:480
-msgid "Run Pcbnew"
-msgstr "プリント基板エディタ(Pcbnew)の起動"
-
 #: kicad/menubar.cpp:374
 msgid "Run Footprint Editor"
 msgstr "フットプリントエディタの起動"
@@ -366,17 +9612,6 @@ msgstr "KiCadマニュアル(&M)"
 msgid "Open KiCad user manual"
 msgstr "KiCadユーザーズマニュアルを開く"
 
-#: kicad/menubar.cpp:412 pcbnew/menubar_modedit.cpp:346
-#: pcbnew/menubar_pcbframe.cpp:651 pcbnew/tool_modview.cpp:194
-#: eeschema/menubar.cpp:497 eeschema/menubar_libedit.cpp:269
-#: eeschema/tool_viewlib.cpp:255
-msgid "&Getting Started in KiCad"
-msgstr "KiCadを始めよう(&G)"
-
-#: kicad/menubar.cpp:413 eeschema/menubar.cpp:498
-msgid "Open \"Getting Started in KiCad\" guide for beginners"
-msgstr "チュートリアル\"KiCadを始めよう\"を開く"
-
 #: kicad/menubar.cpp:421
 msgid "&About KiCad"
 msgstr "KiCadについて(&A)"
@@ -385,35 +9620,9 @@ msgstr "KiCadについて(&A)"
 msgid "About KiCad project manager"
 msgstr "KiCadプロジェクト マネージャーについて"
 
-#: kicad/menubar.cpp:426 pcbnew/menubar_modedit.cpp:358
-#: pcbnew/menubar_pcbframe.cpp:662 pcbnew/tool_modview.cpp:206
-#: eeschema/menubar.cpp:509 eeschema/menubar_libedit.cpp:283
-#: eeschema/tool_viewlib.cpp:267 cvpcb/menubar.cpp:135 gerbview/menubar.cpp:236
-#: 3d-viewer/3d_toolbar.cpp:135 pagelayout_editor/menubar.cpp:163
-msgid "&File"
-msgstr "ファイル(&F)"
-
 #: kicad/menubar.cpp:427
 msgid "&Browse"
 msgstr "ブラウズ(&B)"
-
-#: kicad/menubar.cpp:428 cvpcb/menubar.cpp:136 gerbview/menubar.cpp:237
-#: 3d-viewer/3d_toolbar.cpp:154 pagelayout_editor/menubar.cpp:164
-msgid "&Preferences"
-msgstr "設定(&P)"
-
-#: kicad/menubar.cpp:429 pcbnew/menubar_pcbframe.cpp:669
-#: eeschema/menubar.cpp:514
-msgid "&Tools"
-msgstr "ツール(&T)"
-
-#: kicad/menubar.cpp:430 pcbnew/menubar_modedit.cpp:364
-#: pcbnew/menubar_pcbframe.cpp:671 pcbnew/tool_modview.cpp:209
-#: eeschema/menubar.cpp:515 eeschema/menubar_libedit.cpp:288
-#: eeschema/tool_viewlib.cpp:270 cvpcb/menubar.cpp:137 gerbview/menubar.cpp:239
-#: pagelayout_editor/menubar.cpp:165
-msgid "&Help"
-msgstr "ヘルプ(&H)"
 
 #: kicad/menubar.cpp:471
 msgid "Create new project from template"
@@ -457,11 +9666,6 @@ msgstr ""
 "プロジェクトテンプレートが選択されていません。新規プロジェクトを生成すること"
 "ができませんでした。"
 
-#: kicad/prjconfig.cpp:143 pcbnew/router/length_tuner_tool.cpp:171
-#: pcbnew/router/router_tool.cpp:466 common/confirm.cpp:80
-msgid "Error"
-msgstr "エラー"
-
 #: kicad/prjconfig.cpp:154
 msgid "Problem whilst creating new project from template!"
 msgstr "テンプレートから新規プロジェクトを作成中に問題が発生しました！"
@@ -501,16 +9705,11 @@ msgstr ""
 "続行するには、新規プロジェクトを開始するためのファイルメニューを使用して下さ"
 "い。"
 
-#: kicad/prjconfig.cpp:335 pcbnew/moduleframe.cpp:762 pcbnew/pcbframe.cpp:965
-#: eeschema/libedit.cpp:61 eeschema/schframe.cpp:1338 cvpcb/cvframe.cpp:716
-msgid " [Read Only]"
-msgstr " [読み取り専用]"
-
-#: kicad/prjconfig.cpp:361
+#: kicad/prjconfig.cpp:363
 msgid "New Project Folder"
 msgstr "新規プロジェクトフォルダ"
 
-#: kicad/tree_project_frame.cpp:214
+#: kicad/tree_project_frame.cpp:215
 #, c-format
 msgid ""
 "Current project directory:\n"
@@ -519,88 +9718,1835 @@ msgstr ""
 "現在の作業ディレクトリ:\n"
 "%s"
 
-#: kicad/tree_project_frame.cpp:215
+#: kicad/tree_project_frame.cpp:216
 msgid "Create New Directory"
 msgstr "新規ディレクトリ作成"
 
-#: kicad/tree_project_frame.cpp:676 kicad/tree_project_frame.cpp:683
+#: kicad/tree_project_frame.cpp:677 kicad/tree_project_frame.cpp:684
 msgid "New D&irectory"
 msgstr "新規ディレクトリ(&I)"
 
-#: kicad/tree_project_frame.cpp:677 kicad/tree_project_frame.cpp:684
+#: kicad/tree_project_frame.cpp:678 kicad/tree_project_frame.cpp:685
 msgid "Create a New Directory"
 msgstr "新規ディレクトリの作成"
 
-#: kicad/tree_project_frame.cpp:687
+#: kicad/tree_project_frame.cpp:688
 msgid "&Delete Directory"
 msgstr "ディレクトリ削除(&D)"
 
-#: kicad/tree_project_frame.cpp:688 kicad/tree_project_frame.cpp:703
+#: kicad/tree_project_frame.cpp:689 kicad/tree_project_frame.cpp:704
 msgid "Delete the Directory and its content"
 msgstr "ディレクトリを中身ごと削除"
 
-#: kicad/tree_project_frame.cpp:694
+#: kicad/tree_project_frame.cpp:695
 msgid "&Edit in a text editor"
 msgstr "テキストエディタで開く(&E)"
 
-#: kicad/tree_project_frame.cpp:695
+#: kicad/tree_project_frame.cpp:696
 msgid "Open the file in a Text Editor"
 msgstr "テキストエディタで開く"
 
-#: kicad/tree_project_frame.cpp:698
+#: kicad/tree_project_frame.cpp:699
 msgid "&Rename file"
 msgstr "ファイル名変更(&R)"
 
-#: kicad/tree_project_frame.cpp:699
+#: kicad/tree_project_frame.cpp:700
 msgid "Rename file"
 msgstr "ファイル名変更"
 
-#: kicad/tree_project_frame.cpp:702
+#: kicad/tree_project_frame.cpp:703
 msgid "&Delete File"
 msgstr "ファイル削除(&D)"
 
-#: kicad/tree_project_frame.cpp:752
+#: kicad/tree_project_frame.cpp:753
 #, c-format
 msgid "Change filename: '%s'"
 msgstr "ファイル名変更: '%s'"
 
-#: kicad/tree_project_frame.cpp:755
+#: kicad/tree_project_frame.cpp:756
 msgid "Change filename"
 msgstr "ファイル名変更"
 
-#: kicad/dialogs/dialog_template_selector.cpp:120
-msgid "<html><h1>Template Selector</h1></html>"
-msgstr "<html><h1>テンプレート選択</h1></html>"
+#: new/sch_lib.cpp:237
+#, c-format
+msgid "part '%s' not found in lib %s"
+msgstr "パーツ '%s' はライブラリ %s 中に見つかりませんでした"
 
-#: kicad/dialogs/dialog_template_selector.cpp:211
-msgid "Select Templates Directory"
-msgstr "テンプレートディレクトリの選択"
+#: new/sch_lpid.cpp:208
+msgid "Illegal character found in LPID string"
+msgstr "FPID文字列中に不正な文字があります"
 
-#: kicad/dialogs/dialog_template_selector_base.cpp:26
-msgid "Templates path"
-msgstr "テンプレートのパス"
+#: new/sch_lpid.cpp:375
+msgid "Illegal character found in logical lib name"
+msgstr "論理的なライブラリ名の中に不正な文字があります"
 
-#: kicad/dialogs/dialog_template_selector_base.cpp:36
-#: pcbnew/dialogs/dialog_gendrill_base.cpp:29
-#: pcbnew/dialogs/dialog_netlist_fbp.cpp:152
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:66
-#: pcbnew/dialogs/wizard_add_fplib_base.cpp:73
-#: pcbnew/import_dxf/dialog_dxf_import_base.cpp:33
-#: common/dialogs/dialog_page_settings_base.cpp:356
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:210
-msgid "Browse"
-msgstr "参照"
+#: new/sch_lpid.cpp:406
+msgid "Illegal character found in category"
+msgstr "カテゴリに不正な文字があります"
 
-#: kicad/dialogs/dialog_template_selector_base.cpp:39
-msgid "Validate"
-msgstr "有効にする"
+#: new/sch_lpid.cpp:417
+msgid "Illegal character found in base name"
+msgstr "ベース名に不正な文字があります"
 
-#: kicad/dialogs/dialog_template_selector_base.cpp:114
-msgid "Project Template Title"
-msgstr "プロジェクト・テンプレート・タイトル"
+#: new/sch_sweet_parser.cpp:338
+msgid "invalid extends LPID"
+msgstr "不正な拡張 LPID"
 
-#: pcbnew/append_board_to_current.cpp:91 pcbnew/files.cpp:508
-#: pcbnew/tools/pcbnew_control.cpp:814
+#: new/sch_sweet_parser.cpp:354
+msgid "'extends' may not have self as any ancestor"
+msgstr "'extends' はいかなる先祖も持っていないようです"
+
+#: new/sch_sweet_parser.cpp:364
+msgid "max allowed extends depth exceeded"
+msgstr "深度が超過しています"
+
+#: new/sch_sweet_parser.cpp:392
+msgid "invalid alternates LPID"
+msgstr "不正な代替 LPID"
+
+#: new/sch_sweet_parser.cpp:709 new/sch_sweet_parser.cpp:748
+#: new/sch_sweet_parser.cpp:761 new/sch_sweet_parser.cpp:790
+#: new/sch_sweet_parser.cpp:821
+msgid "undefined pin"
+msgstr "未定義のピン"
+
+#: new/sch_sweet_parser.cpp:852 new/sch_sweet_parser.cpp:949
+#, c-format
+msgid "undefined pin %s"
+msgstr "未定義のピン %s"
+
+#: new/sch_sweet_parser.cpp:862 new/sch_sweet_parser.cpp:959
+#, c-format
+msgid "pin %s already in pin_merge group %s"
+msgstr "ピン %s は既にピングループ %s に存在します。"
+
+#: new/sch_sweet_parser.cpp:903
+#, c-format
+msgid "no pins with signal %s"
+msgstr "信号 %s のピンがありません"
+
+#: new/sch_sweet_parser.cpp:915
+#, c-format
+msgid "signal pin %s already in pin_merge group %s"
+msgstr "信号ピン %s は既にピングループ %s に存在します"
+
+#: new/sch_sweet_parser.cpp:998
+#, c-format
+msgid "Unable to find property: %s"
+msgstr "プロパティが見つかりませんでした: %s"
+
+#: new/sweet_editor_panel.cpp:31
+msgid "Sweet"
+msgstr "甘い"
+
+#: new/sweet_editor_panel.cpp:42
+msgid "Visual Part"
+msgstr "可視部分"
+
+#: new/sweet_editor_panel.cpp:59
+msgid "Parsing Errors"
+msgstr "構文エラー"
+
+#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:28
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:218
+msgid "Pos X (mm)"
+msgstr "X位置(mm)"
+
+#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:35
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:231
+msgid "Pos Y (mm)"
+msgstr "Y位置(mm)"
+
+#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:52
+#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:96
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:252
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:307
+msgid "Upper Right"
+msgstr "左上"
+
+#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:52
+#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:96
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:253
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:308
+msgid "Upper Left"
+msgstr "右上"
+
+#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:52
+#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:96
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:251
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:254
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:306
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:309
+msgid "Lower Right"
+msgstr "左下"
+
+#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:52
+#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:96
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:255
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:310
+msgid "Lower Left"
+msgstr "左下"
+
+#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:72
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:273
+msgid "End X (mm)"
+msgstr "終点X位置(mm)"
+
+#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:79
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:286
+msgid "End Y (mm)"
+msgstr "終点Y位置(mm)"
+
+#: pagelayout_editor/dialogs/dialogs_for_printing.cpp:219
+msgid "Print Page Layout"
+msgstr "図枠の印刷"
+
+#: pagelayout_editor/dialogs/dialogs_for_printing.cpp:224
+msgid "An error occurred attempting to print the page layout."
+msgstr "図枠の印刷中にエラーが発生しました。"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:44
+msgid "Page 1 option"
+msgstr "1ページ目の設定"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:50
+msgid "Page 1 only"
+msgstr "1ページ目のみ"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:50
+msgid "Not on page 1"
+msgstr "1ページ目には適用しない"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:80
+msgid "H justification"
+msgstr "水平位置合わせ"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:99
+msgid "V justification"
+msgstr "垂直位置合わせ"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:124
+msgid "Text Width (mm)"
+msgstr "テキスト幅(mm)"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:137
+msgid "Text Height (mm)"
+msgstr "テキスト高さ(mm)"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:150
+msgid "Constraints:"
+msgstr "制約:"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:160
+msgid "Max Size X (mm)"
+msgstr "最大Xサイズ(mm)"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:173
+msgid "Max Size Y (mm)"
+msgstr "最大Yサイズ(mm)"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:199
+msgid "Comment"
+msgstr "コメント"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:325
+#: pcbnew/class_pcb_text.cpp:151 pcbnew/class_text_mod.cpp:398
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:64
+#: pcbnew/dialogs/dialog_target_properties_base.cpp:39
+msgid "Thickness"
+msgstr "太さ"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:335
+msgid "Set to 0 to use default"
+msgstr "0を指定すると、デフォルト値が使用されます"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:365
+msgid "Bitmap PPI"
+msgstr "ビットマップPixel/Inch"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:378
+msgid "Repeat parameters:"
+msgstr "パラメータの繰り返し:"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:388
+msgid "Repeat count"
+msgstr "繰り返し数"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:400
+msgid "Text Increment"
+msgstr "テキストの増分"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:419
+msgid "Step X (mm)"
+msgstr "Xステップ(mm)"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:432
+msgid "Step Y (mm)"
+msgstr "Yステップ(mm)"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:449
+msgid "Item Properties"
+msgstr "アイテムのプロパティ"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:458
+msgid "Default Values:"
+msgstr "デフォルト値:"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:468
+msgid "Text Size X (mm)"
+msgstr "テキストサイズ X(mm)"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:481
+msgid "Text Size Y (mm)"
+msgstr "テキストサイズ Y(mm)"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:500
+msgid "Line Thickness (mm)"
+msgstr "線幅(mm)"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:513
+#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:53
+msgid "Text Thickness"
+msgstr "テキストの太さ"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:529
+msgid "Set to Default"
+msgstr "デフォルトに設定"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:538
+msgid "Page Margins"
+msgstr "ページ余白"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:548
+msgid "Left Margin (mm)"
+msgstr "左余白(mm)"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:561
+msgid "Right Margin (mm)"
+msgstr "右余白(mm)"
+
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:580
+msgid "Top Margin (mm)"
+msgstr "上余白(mm)"
+
+# orペア下層
+#: pagelayout_editor/dialogs/properties_frame_base.cpp:593
+msgid "Bottom Margin (mm)"
+msgstr "下余白"
+
+#: pagelayout_editor/files.cpp:46
+msgid "Page Layout Description File"
+msgstr "図枠ファイル"
+
+#: pagelayout_editor/files.cpp:51 pagelayout_editor/files.cpp:85
+msgid ""
+"The current page layout has been modified.\n"
+"Do you wish to discard the changes?"
+msgstr ""
+"現在の図枠レイアウトは変更されています。\n"
+"変更を破棄しますか？"
+
+#: pagelayout_editor/files.cpp:60 pagelayout_editor/files.cpp:154
+#, c-format
+msgid "File <%s> loaded"
+msgstr "ファイル <%s> を読み込みました"
+
+#: pagelayout_editor/files.cpp:111 pagelayout_editor/onrightclick.cpp:52
+msgid "Append Page Layout Descr File"
+msgstr "図枠ファイルを追加"
+
+#: pagelayout_editor/files.cpp:122 pagelayout_editor/files.cpp:148
+#, c-format
+msgid "Unable to load %s file"
+msgstr "ファイル %s が読み込めませんでした"
+
+#: pagelayout_editor/files.cpp:130
+#, c-format
+msgid "File <%s> inserted"
+msgstr "ファイル %s を挿入しました"
+
+#: pagelayout_editor/files.cpp:138
+msgid "Open file"
+msgstr "ファイルを開く"
+
+#: pagelayout_editor/files.cpp:163
+#, c-format
+msgid "Unable to write <%s>"
+msgstr "<%s> を作成できません"
+
+#: pagelayout_editor/files.cpp:168 pagelayout_editor/files.cpp:200
+#, c-format
+msgid "File <%s> written"
+msgstr "ファイル <%s> に書き込みました"
+
+#: pagelayout_editor/files.cpp:175 pagelayout_editor/pl_editor_frame.cpp:243
+msgid "Create file"
+msgstr "ファイルの作成"
+
+#: pagelayout_editor/files.cpp:194 pagelayout_editor/pl_editor_frame.cpp:255
+#: pcbnew/exporters/export_gencad.cpp:267
+#, c-format
+msgid "Unable to create <%s>"
+msgstr "<%s> を作成できません"
+
+#: pagelayout_editor/menubar.cpp:62
+msgid "&New Page Layout Design"
+msgstr "新規図枠(&N)"
+
+#: pagelayout_editor/menubar.cpp:65
+msgid "Load Page Layout &File"
+msgstr "図枠ファイルを読み込む(&F)"
+
+#: pagelayout_editor/menubar.cpp:68
+msgid "Load &Default Page Layout"
+msgstr "デフォルト図枠の読み込み(&D)"
+
+#: pagelayout_editor/menubar.cpp:85
+msgid "Open &Recent Page Layout File"
+msgstr "最近の図枠ファイルを開く(&R)"
+
+#: pagelayout_editor/menubar.cpp:91
+msgid "&Save Page Layout Design"
+msgstr "図枠の保存(&S)"
+
+#: pagelayout_editor/menubar.cpp:96
+msgid "Save Page Layout Design &As"
+msgstr "名前をつけて図枠を保存(&A)"
+
+#: pagelayout_editor/menubar.cpp:103
+msgid "Print Pre&view"
+msgstr "印刷プレビュー(&V)"
+
+#: pagelayout_editor/menubar.cpp:112
+msgid "&Close Page Layout Editor"
+msgstr "図枠エディタの終了(&C)"
+
+#: pagelayout_editor/menubar.cpp:121 pagelayout_editor/pl_editor_config.cpp:58
+msgid "&BackGround Black"
+msgstr "背景を黒色にする(&B)"
+
+#: pagelayout_editor/menubar.cpp:121 pagelayout_editor/pl_editor_config.cpp:59
+msgid "&BackGround White"
+msgstr "背景を白色にする(&B)"
+
+#: pagelayout_editor/menubar.cpp:126 pagelayout_editor/pl_editor_config.cpp:66
+msgid "Hide &Grid"
+msgstr "グリッドを非表示"
+
+#: pagelayout_editor/menubar.cpp:126 pagelayout_editor/pl_editor_config.cpp:67
+msgid "Show &Grid"
+msgstr "グリッドの表示"
+
+#: pagelayout_editor/menubar.cpp:151
+msgid "Page Layout Editor &Manual"
+msgstr ""
+
+#: pagelayout_editor/menubar.cpp:152
+msgid "Open the Page Layout Editor Manual"
+msgstr ""
+
+#: pagelayout_editor/onrightclick.cpp:45 pcbnew/muwave_command.cpp:60
+msgid "Add Line"
+msgstr "線の追加"
+
+#: pagelayout_editor/onrightclick.cpp:47
+msgid "Add Rectangle"
+msgstr "矩形を追加"
+
+#: pagelayout_editor/onrightclick.cpp:49 pcbnew/tool_modedit.cpp:179
+msgid "Add Text"
+msgstr "テキスト入力"
+
+#: pagelayout_editor/onrightclick.cpp:55
+msgid "Add Bitmap"
+msgstr "ビットマップを追加"
+
+#: pagelayout_editor/onrightclick.cpp:83
+msgid "Move Start Point"
+msgstr "始点を移動"
+
+#: pagelayout_editor/onrightclick.cpp:91
+msgid "Move End Point"
+msgstr "終点を移動"
+
+#: pagelayout_editor/onrightclick.cpp:97
+#: pcbnew/dialogs/dialog_move_exact_base.h:74
+msgid "Move Item"
+msgstr "アイテムの移動"
+
+#: pagelayout_editor/onrightclick.cpp:111
+msgid "Place Item"
+msgstr "アイテムの配置"
+
+#: pagelayout_editor/page_layout_writer.cpp:103
+#: pagelayout_editor/page_layout_writer.cpp:130
+msgid "Error writing page layout descr file"
+msgstr "図枠ファイル書き込み中のエラー"
+
+#: pagelayout_editor/pl_editor.cpp:149
+msgid "pl_editor is already running. Continue?"
+msgstr "図枠エディタは既に起動しています。続けますか？"
+
+#: pagelayout_editor/pl_editor.cpp:186
+#, c-format
+msgid "Error when loading file <%s>"
+msgstr "<%s> ファイルの読み込み中エラー"
+
+#: pagelayout_editor/pl_editor_frame.cpp:114
+msgid "coord origin: Right Bottom page corner"
+msgstr "原点位置: 用紙の左下角"
+
+#: pagelayout_editor/pl_editor_frame.cpp:139
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:302
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:236
+msgid "Properties"
+msgstr "プロパティ"
+
+#: pagelayout_editor/pl_editor_frame.cpp:146
+msgid "Design"
+msgstr "デザイン"
+
+#: pagelayout_editor/pl_editor_frame.cpp:200
+#, c-format
+msgid "Error when loading file '%s'"
+msgstr "'%s' ファイルの読み込み中のエラー"
+
+#: pagelayout_editor/pl_editor_frame.cpp:222
+msgid "Save changes in a new file before closing?"
+msgstr "終了前に、変更を新規ファイルに保存しますか？"
+
+#: pagelayout_editor/pl_editor_frame.cpp:224
+#, c-format
+msgid ""
+"Save the changes in\n"
+"<%s>\n"
+"before closing?"
+msgstr ""
+"閉じる前に変更を保存しますか？\n"
+"<%s>"
+
+#: pagelayout_editor/pl_editor_frame.cpp:456
+#, c-format
+msgid "Page size: width %.4g height %.4g"
+msgstr "ページサイズ: 幅 %.4g 高さ %.4g"
+
+#: pagelayout_editor/pl_editor_frame.cpp:501
+#, c-format
+msgid "coord origin: %s"
+msgstr "原点位置: %s"
+
+#: pagelayout_editor/pl_editor_frame.cpp:731
+msgid "(start or end point)"
+msgstr "(始点または終点)"
+
+#: pagelayout_editor/pl_editor_frame.cpp:735
+msgid "(start point)"
+msgstr "(始点)"
+
+#: pagelayout_editor/pl_editor_frame.cpp:738
+msgid "(end point)"
+msgstr "(終点)"
+
+#: pagelayout_editor/pl_editor_frame.cpp:747 pcbnew/controle.cpp:231
+#: pcbnew/modedit.cpp:130
+msgid "Selection Clarification"
+msgstr "明示的な選択"
+
+#: pagelayout_editor/toolbars_pl_editor.cpp:51
+msgid "New page layout design"
+msgstr "新規図枠"
+
+#: pagelayout_editor/toolbars_pl_editor.cpp:54
+msgid "Load a page layout file. Previous data will be deleted"
+msgstr "図枠ファイルを読み込みます。以前の図枠は削除されます。"
+
+#: pagelayout_editor/toolbars_pl_editor.cpp:57
+msgid "Save page layout design"
+msgstr "図枠の保存"
+
+#: pagelayout_editor/toolbars_pl_editor.cpp:64
+msgid "Print page layout"
+msgstr "図枠の印刷"
+
+#: pagelayout_editor/toolbars_pl_editor.cpp:68
+msgid "Delete selected item"
+msgstr "選択したアイテムを削除"
+
+#: pagelayout_editor/toolbars_pl_editor.cpp:94
+msgid ""
+"Show title block like it will be displayed in applications\n"
+"texts with format are replaced by the full text"
+msgstr ""
+"アプリケーションで表示されるようにタイトルブロック内文字列が表示されます。\n"
+"テキストはページ設定で指定された内容で表示されます。"
+
+#: pagelayout_editor/toolbars_pl_editor.cpp:99
+msgid ""
+"Show title block in edit mode: texts are shown as is:\n"
+"texts with format are displayed with no change"
+msgstr ""
+"編集モードでタイトルブロックを表示: テキスト部は記号で表示されます。\n"
+"フォーマット付きの変数記号で表示され、実際の表示内容は変更されません。"
+
+#: pagelayout_editor/toolbars_pl_editor.cpp:107
+msgid "Left Top paper corner"
+msgstr "用紙の左上角"
+
+# orペア下層
+#: pagelayout_editor/toolbars_pl_editor.cpp:108
+msgid "Right Bottom page corner"
+msgstr "ページの右下角"
+
+# orペア下層
+#: pagelayout_editor/toolbars_pl_editor.cpp:109
+msgid "Left Bottom page corner"
+msgstr "ページの左下角"
+
+#: pagelayout_editor/toolbars_pl_editor.cpp:110
+msgid "Right Top page corner"
+msgstr "ページの右上角"
+
+#: pagelayout_editor/toolbars_pl_editor.cpp:111
+msgid "Left Top page corner"
+msgstr "ページの左上角"
+
+#: pagelayout_editor/toolbars_pl_editor.cpp:118
+msgid " Origin of coordinates displayed to the status bar"
+msgstr "ステータスバーに現在の原点設定が表示されています"
+
+#: pagelayout_editor/toolbars_pl_editor.cpp:131
+msgid "Page 1"
+msgstr "ページ1"
+
+#: pagelayout_editor/toolbars_pl_editor.cpp:132
+msgid "Other pages"
+msgstr "その他のページ"
+
+#: pagelayout_editor/toolbars_pl_editor.cpp:139
+msgid ""
+"Simulate page 1 or other pages to show how items\n"
+"which are not on all page are displayed"
+msgstr ""
+"アイテム表示を、1ページ目、またはそれ以降のページ用に表示させます。\n"
+"これらは全てのページは表示されません。"
+
+#: pcb_calculator/UnitSelector.cpp:39
+msgid "um"
+msgstr "um"
+
+#: pcb_calculator/UnitSelector.cpp:40
+msgid "cm"
+msgstr "cm"
+
+#: pcb_calculator/UnitSelector.cpp:41
+msgid "mil"
+msgstr "mils"
+
+#: pcb_calculator/UnitSelector.cpp:42
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:191
+#: pcbnew/dialogs/dialog_export_idf_base.cpp:46
+#: pcbnew/dialogs/dialog_export_vrml_base.cpp:64
+#: pcbnew/import_dxf/dialog_dxf_import_base.cpp:90
+msgid "inch"
+msgstr "インチ"
+
+#: pcb_calculator/UnitSelector.cpp:70
+msgid "GHz"
+msgstr "GHz"
+
+#: pcb_calculator/UnitSelector.cpp:71
+msgid "MHz"
+msgstr "MHz"
+
+#: pcb_calculator/UnitSelector.cpp:72
+msgid "KHz"
+msgstr "KHz"
+
+#: pcb_calculator/UnitSelector.cpp:73
+msgid "Hz"
+msgstr "Hz"
+
+#: pcb_calculator/UnitSelector.cpp:99
+msgid "Radian"
+msgstr "ラジアン"
+
+#: pcb_calculator/UnitSelector.cpp:100
+msgid "Degree"
+msgstr "度"
+
+#: pcb_calculator/UnitSelector.cpp:124
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:389
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:478
+msgid "Ohm"
+msgstr "Ω"
+
+#: pcb_calculator/UnitSelector.cpp:125
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:97
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:112
+msgid "KOhm"
+msgstr "kΩ"
+
+#: pcb_calculator/attenuators.cpp:107
+#, c-format
+msgid "Attenuation more than %f dB"
+msgstr "減衰量は %f dB 以上に設定してください"
+
+#: pcb_calculator/datafile_read_write.cpp:76
+msgid "Data file error."
+msgstr "データファイルエラー"
+
+#: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:36
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:134
+msgid "Vref"
+msgstr "Vref"
+
+#: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:43
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:401
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:490
+msgid "Volt"
+msgstr "V"
+
+#: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:51
+msgid "Separate sense pin"
+msgstr "Vref検出端子が独立(4端子)"
+
+#: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:51
+msgid "3 terminals regulator"
+msgstr "三端子レギュレータ"
+
+#: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:60
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:151
+msgid "Iadj"
+msgstr "Iadj"
+
+#: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:67
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:161
+msgid "uA"
+msgstr "μA"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:62
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1183
+msgid "Formula"
+msgstr "計算式"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:64
+msgid "Vout = Vref * (R1 + R2) / R2"
+msgstr "Vout = Vref * (R1 + R2) / R2"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:89
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1130
+msgid "R1"
+msgstr "R1"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:104
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1142
+msgid "R2"
+msgstr "R2"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:119
+msgid "Vout"
+msgstr "Vout"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:127
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:144
+msgid "V"
+msgstr "V"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:136
+msgid ""
+"The internal reference voltage of the regulator.\n"
+"Should not be 0."
+msgstr ""
+"レギュレータ内部での基準電圧です。\n"
+"0を設定することはできません。"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:153
+msgid "For 3 terminal regulators only, the  Adjust pin current."
+msgstr "3端子レギュレータのみ、Adjustピンの電流。"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:170
+msgid ""
+"Type of the regulator.\n"
+"There are 2 types:\n"
+"- regulators which have a dedicated sense pin for the voltage regulation.\n"
+"- 3 terminal pins."
+msgstr ""
+"レギュレータの種類を設定します.n\n"
+"下記の2種類が想定されています: \n"
+"- 出力電圧設定のための独立したSensピンあるもの.n\n"
+"- 3端子レギュレータ."
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:174
+msgid "Standard Type"
+msgstr "スタンダード"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:174
+msgid "3 Terminal Type"
+msgstr "三端子タイプ"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:186
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1112
+msgid "Calculate"
+msgstr "計算"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:190
+msgid "Regulator"
+msgstr "レギュレータ"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:197
+msgid "Regulators data file:"
+msgstr "レギュレータデータファイル:"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:199
+msgid "The name of the data file which stores known regulators parameters."
+msgstr "既存のレギュレータのパラメータで保存されているデータファイル名。"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:219
+msgid "Edit Regulator"
+msgstr "レギュレータの編集"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:220
+msgid "Edit the current selected regulator."
+msgstr "選択されているレギュレータを編集"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:224
+msgid "Add Regulator"
+msgstr "レギュレータの追加"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:225
+msgid "Enter a new item to the current list of available regulators"
+msgstr "レギュレータリストへ新しい項目を追加します"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:229
+#: pcb_calculator/regulators_funct.cpp:321
+msgid "Remove Regulator"
+msgstr "レギュレータの削除"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:230
+msgid "Remove an item from the current list of available regulators"
+msgstr "レギュレータのリストから項目を削除します"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:240
+msgid "Message"
+msgstr "メッセージ"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:251
+msgid "Regulators"
+msgstr "レギュレータ"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:260
+msgid "Parameters"
+msgstr "パラメータ"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:268
+msgid "Current"
+msgstr "電流"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:280
+msgid "Temperature rise"
+msgstr "温度上昇"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:288
+msgid "deg C"
+msgstr "℃"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:292
+msgid "Conductor length"
+msgstr "導体長"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:305
+msgid "Resistivity"
+msgstr "抵抗率"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:312
+msgid "Ohm-meter"
+msgstr "電気抵抗計"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:335
+msgid "External layer traces"
+msgstr "外層配線"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:343
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:432
+msgid "Trace width"
+msgstr "配線幅"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:356
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:445
+msgid "Trace thickness"
+msgstr "配線の銅箔厚"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:369
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:458
+msgid "Cross-section area"
+msgstr "断面積"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:373
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:385
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:397
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:409
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:462
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:474
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:486
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:498
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:966
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:970
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:974
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:978
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:982
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:986
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:990
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:994
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:998
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1002
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1006
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1010
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1014
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1018
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:170
+msgid "dummy"
+msgstr "ダミー"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:377
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:466
+msgid "mm ^ 2"
+msgstr "mm^2"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:381
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:470
+msgid "Resistance"
+msgstr "抵抗"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:393
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:482
+msgid "Voltage drop"
+msgstr "電圧降下"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:405
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:494
+msgid "Power loss"
+msgstr "電力損失"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:413
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:502
+msgid "Watt"
+msgstr "W"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:424
+msgid "Internal layer traces"
+msgstr "内層配線"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:519
+#: pcbnew/dialogs/dialog_design_rules_base.cpp:49
+msgid "Track Width"
+msgstr "配線幅"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:535
+msgid "Voltage > 500V:"
+msgstr "電圧 > 500V:"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:543
+msgid "Update Values"
+msgstr "値の更新"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:552
+msgid "Note: Values are minimal values (from IPC 2221)"
+msgstr ""
+"注: 値は最小値です (IPC 2221 より) 　設計時には他の規格も確認して下さい"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:571
+msgid "B1"
+msgstr "B1"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:572
+msgid "B2"
+msgstr "B2"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:573
+msgid "B3"
+msgstr "B3"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:574
+msgid "B4"
+msgstr "B4"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:575
+msgid "A5"
+msgstr "A5"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:576
+msgid "A6"
+msgstr "A6"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:577
+msgid "A7"
+msgstr "A7"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:584
+msgid "0 ... 15V"
+msgstr "0 ... 15V"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:585
+msgid "16 ... 30V"
+msgstr "16 ... 30V"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:586
+msgid "31 ... 50V"
+msgstr "31 ... 50V"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:587
+msgid "51 ... 100V"
+msgstr "51 ... 100V"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:588
+msgid "101 ... 150V"
+msgstr "101 ... 150V"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:589
+msgid "151 ... 170V"
+msgstr "151 ... 170V"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:590
+msgid "171 ... 250V"
+msgstr "171 ... 250V"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:591
+msgid "251 ... 300V"
+msgstr "251 ... 300V"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:592
+msgid "301 ... 500V"
+msgstr "301 ... 500V"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:593
+msgid " > 500V"
+msgstr " > 500V"
+
+# IPC2221 Table 6-1の説明
+# IEC60950など他の規格も参照する必要がある事は謳うべき？
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:602
+msgid ""
+"*  B1 - Internal Conductors\n"
+"*  B2 - External Conductors, uncoated, sea level to 3050 m\n"
+"*  B3 - External Conductors, uncoated, over 3050 m\n"
+"*  B4 - External Conductors, with permanent polymer coating (any elevation)\n"
+"*  A5 - External Conductors, with conformal coating over assembly (any "
+"elevation)\n"
+"*  A6 - External Component lead/termination, uncoated\n"
+"*  A7 - External Component lead termination, with conformal coating (any "
+"elevation)"
+msgstr ""
+"*  B1 - 内層導体\n"
+"*  B2 - 外層導体, コーティングなし, 海抜3050mまで\n"
+"*  B3 - 外層導体, コーティングなし, 海抜3050m以上\n"
+"*  B4 - 外層導体, 耐久ポリマーコーティング (海抜によらず)\n"
+"*  A5 - 外層導体, Assy全体に絶縁保護コーティング (海抜によらず)\n"
+"*  A6 - 外層　コンポーネント リード/終端, コーティングなし\n"
+"*  A7 - 外層　コンポーネント リード/終端, 絶縁保護コーティング (海抜によらず)"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:613
+msgid "Electrical Spacing"
+msgstr "導体間隔"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:621
+msgid "Microstrip Line"
+msgstr "マイクロストリップ ライン"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:621
+msgid "Coplanar wave guide"
+msgstr "コプレーナ導波路"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:621
+msgid "Coplanar wave guide with ground plane"
+msgstr "グランドプレーン付きコプレーナ導波路"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:621
+msgid "Rectangular Waveguide"
+msgstr "方形導波管"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:621
+msgid "Coaxial Line"
+msgstr "同軸線路"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:621
+msgid "Coupled Microstrip Line"
+msgstr "カップルド・マイクロストリップライン"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:621
+msgid "Stripline"
+msgstr "ストリップライン"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:621
+msgid "Twisted Pair"
+msgstr "ツイストペア"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:623
+msgid "Transmission Line Type:"
+msgstr "伝送線路のタイプ:"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:640
+msgid "Substrate Parameters"
+msgstr "基本パラメータ:"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:648
+#: pcb_calculator/transline_ident.cpp:142
+msgid "Er"
+msgstr "Er"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:656
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:667
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:680
+#: pcbnew/dialogs/dialog_drc_base.cpp:94
+msgid "..."
+msgstr "..."
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:659
+#: pcb_calculator/transline_ident.cpp:145
+msgid "TanD"
+msgstr "tanδ"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:670
+#: pcb_calculator/transline_ident.cpp:150
+msgid "Rho"
+msgstr "Rho"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:672
+msgid "Specific resistance in ohms * meters"
+msgstr "Ω・mでの抵抗率"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:683
+#: pcb_calculator/transline_ident.cpp:171
+#: pcb_calculator/transline_ident.cpp:208
+#: pcb_calculator/transline_ident.cpp:240
+#: pcb_calculator/transline_ident.cpp:341
+#: pcb_calculator/transline_ident.cpp:377
+msgid "H"
+msgstr "H"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:696
+#: pcb_calculator/transline_ident.cpp:173
+#: pcb_calculator/transline_ident.cpp:343
+msgid "H_t"
+msgstr "H_t"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:709
+#: pcb_calculator/transline_ident.cpp:175
+#: pcb_calculator/transline_ident.cpp:210
+#: pcb_calculator/transline_ident.cpp:242
+#: pcb_calculator/transline_ident.cpp:345
+#: pcb_calculator/transline_ident.cpp:382
+msgid "T"
+msgstr "T"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:722
+#: pcb_calculator/transline_ident.cpp:177
+#: pcb_calculator/transline_ident.cpp:347
+msgid "Rough"
+msgstr "表面荒さ"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:735
+msgid "mu Rel"
+msgstr "ミュー (比透磁率)"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:748
+#: pcb_calculator/transline_ident.cpp:182
+#: pcb_calculator/transline_ident.cpp:212
+#: pcb_calculator/transline_ident.cpp:244
+#: pcb_calculator/transline_ident.cpp:279
+#: pcb_calculator/transline_ident.cpp:310
+#: pcb_calculator/transline_ident.cpp:349
+#: pcb_calculator/transline_ident.cpp:384
+#: pcb_calculator/transline_ident.cpp:412
+msgid "mu Rel C"
+msgstr "μ (比透磁率) C (導体)"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:768
+msgid "Component Parameters:"
+msgstr "コンポーネント パラメータ:"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:776
+#: pcb_calculator/transline_ident.cpp:156
+msgid "Frequency"
+msgstr "周波数"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:811
+msgid "Physical Parameters"
+msgstr "物理パラメータ:"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:822
+msgid "Prm1"
+msgstr "Prm1"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:838
+msgid "prm2"
+msgstr "prm2"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:854
+msgid "prm3"
+msgstr "prm3"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:888
+msgid "Analyze"
+msgstr "分析"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:891
+msgid "Synthetize"
+msgstr "合成"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:904
+msgid "Electrical Parameters:"
+msgstr "電気的パラメータ:"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:912
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:925
+msgid "Z"
+msgstr "Z"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:938
+#: pcbnew/class_drawsegment.cpp:379 pcbnew/class_drawsegment.cpp:397
+#: pcbnew/class_module.cpp:593 pcbnew/class_pad.cpp:679
+#: pcbnew/class_pcb_text.cpp:148 pcbnew/class_text_mod.cpp:395
+msgid "Angle"
+msgstr "角度"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:958
+msgid "Results:"
+msgstr "結果:"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1035
+msgid "TransLine"
+msgstr "伝送線路"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1038
+msgid "label"
+msgstr "ラベル"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1043
+msgid "PI"
+msgstr "パイ型"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1043
+msgid "Tee"
+msgstr "T型"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1043
+msgid "Bridged Tee"
+msgstr "ブリッジT型"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1043
+msgid "Resistive Splitter"
+msgstr "抵抗分割型"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1045
+msgid "Attenuators:"
+msgstr "アッテネータ:"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1059
+msgid "Parameters:"
+msgstr "パラメータ:"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1067
+msgid "Attenuation"
+msgstr "減衰量"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1075
+msgid "dB"
+msgstr "dB"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1079
+msgid "Zin"
+msgstr "Zin"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1087
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1099
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1138
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1150
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1162
+msgid "Ohms"
+msgstr "Ω"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1091
+msgid "Zout"
+msgstr "Zout"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1122
+#: pcbnew/class_pcb_layer_widget.cpp:78
+msgid "Values"
+msgstr "値"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1154
+msgid "R3"
+msgstr "R3"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1197
+msgid "RF Attenuators"
+msgstr "RFアッテネータ"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1202
+msgid "10%"
+msgstr "10%"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1202
+msgid "5%"
+msgstr "5%"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1202
+msgid "2%"
+msgstr "2%"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1202
+msgid "1%"
+msgstr "1%"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1202
+msgid "0.5%"
+msgstr "0.5%"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1202
+msgid "0.25%"
+msgstr "0.25%"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1202
+msgid "0.1%"
+msgstr "0.1%"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1202
+msgid "0.05%"
+msgstr "0.05%"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1204
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1233
+msgid "Tolerance"
+msgstr "誤差"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1213
+msgid "1st Band"
+msgstr "第１帯"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1217
+msgid "2nd Band"
+msgstr "第２帯"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1221
+msgid "3rd Band"
+msgstr "第３帯"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1225
+msgid "4rd Band"
+msgstr "第４帯"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1229
+msgid "Multiplier"
+msgstr "乗数"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1262
+msgid "Color Code"
+msgstr "カラーコード"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1275
+msgid "Note: Values are minimal values"
+msgstr "注: 値は最小値です。"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1294
+msgid "Class 1"
+msgstr "クラス 1"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1295
+msgid "Class 2"
+msgstr "クラス 2"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1296
+msgid "Class 3"
+msgstr "クラス 3"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1297
+msgid "Class 4"
+msgstr "クラス 4"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1298
+msgid "Class 5"
+msgstr "クラス 5"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1299
+msgid "Class 6"
+msgstr "クラス 6"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1306
+msgid "Lines width"
+msgstr "配線幅"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1307
+msgid "Min clearance"
+msgstr "最小クリアランス"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1308
+msgid "Via: (diam - drill)"
+msgstr "ビア: (直径 - ドリル径)"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1309
+msgid "Plated Pad: (diam - drill)"
+msgstr "PTHパッド:  (直径-ドリル)"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1310
+msgid "NP Pad: (diam - drill)"
+msgstr "NPTHパッド(直径-ドリル)"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1329
+msgid "Board Classes"
+msgstr "ボードのクラス"
+
+#: pcb_calculator/pcb_calculator_frame.cpp:144
+msgid ""
+"Data modified, and no data filename to save modifications\n"
+"Do you want to exit and abandon your change?"
+msgstr ""
+"変更されたデータが保存されていません。\n"
+"変更を破棄して終了してよいですか？"
+
+#: pcb_calculator/pcb_calculator_frame.cpp:146
+msgid "Regulator list change"
+msgstr "レギュレータが変更されています"
+
+#: pcb_calculator/pcb_calculator_frame.cpp:157
+#, c-format
+msgid ""
+"Unable to write file<%s>\n"
+"Do you want to exit and abandon your change?"
+msgstr ""
+"<%s>に書込めませんでした．\n"
+"変更を破棄して終了しますか？"
+
+#: pcb_calculator/pcb_calculator_frame.cpp:161
+msgid "Write Data File Error"
+msgstr "データファイル書き出しエラー"
+
+#: pcb_calculator/regulators_funct.cpp:100
+#: pcb_calculator/regulators_funct.cpp:274
+msgid "Bad or missing parameters!"
+msgstr "パラメータ設定値が不正です!"
+
+#: pcb_calculator/regulators_funct.cpp:226
+#, c-format
+msgid "PCB Calculator data  file (*.%s)|*.%s"
+msgstr "Pcb Calculatorデータファイル (*.%s)|*.%s"
+
+#: pcb_calculator/regulators_funct.cpp:231
+msgid "Select a PCB Calculator data file"
+msgstr "Pcb Calculator データファイルの選択"
+
+#: pcb_calculator/regulators_funct.cpp:246
+msgid "Do you want to load this file and replace current regulator list?"
+msgstr "ファイルを読み込み、現在のレギュレータ設定を置換えて良いですか？"
+
+#: pcb_calculator/regulators_funct.cpp:262
+#, c-format
+msgid "Unable to read data file <%s>"
+msgstr "ファイル <%s> が読み込めません"
+
+#: pcb_calculator/regulators_funct.cpp:293
+msgid "This regulator is already in list. Aborted"
+msgstr "指定されたレギュレータは既にリストへ登録されています。"
+
+#: pcb_calculator/regulators_funct.cpp:397
+msgid " Vout must be greater than vref"
+msgstr " Vout は　Vref 以上にしてください。"
+
+#: pcb_calculator/regulators_funct.cpp:403
+msgid " Vref set to 0 !"
+msgstr " Vref が 0 に設定されています！"
+
+#: pcb_calculator/regulators_funct.cpp:409
+msgid "Incorrect value for R1 R2"
+msgstr "R1 R2の値が正しくありません"
+
+#: pcb_calculator/tracks_width_versus_current.cpp:446
+msgid ""
+"If you specify the maximum current, then the trace widths will be calculated "
+"to suit."
+msgstr "最大電流を指定した場合、配線幅は適応するように計算されます。"
+
+#: pcb_calculator/tracks_width_versus_current.cpp:448
+msgid ""
+"If you specify one of the trace widths, the maximum current it can handle "
+"will be calculated. The width for the other trace to also handle this "
+"current will then be calculated."
+msgstr ""
+"配線幅の一つを指定した場合、流せる最大電流が計算されます。また、この電流を流"
+"すことができるように他の配線幅の計算が行われます。"
+
+#: pcb_calculator/tracks_width_versus_current.cpp:452
+msgid "The controlling value is shown in bold."
+msgstr "コントロール値は、ボールド体で表示されます。"
+
+#: pcb_calculator/tracks_width_versus_current.cpp:453
+msgid ""
+"The calculations are valid for currents up to 35A (external) or 17.5A "
+"(internal), temperature rises up to 100 deg C, and widths of up to 400mil "
+"(10mm)."
+msgstr ""
+"計算は、電流に対しては 35A (外部) または 17.5A (内部) まで、温度上昇は 100℃ "
+"まで、幅は 400mil (10mm) まで有効です。"
+
+#: pcb_calculator/tracks_width_versus_current.cpp:456
+msgid "The formula, from IPC 2221, is"
+msgstr "計算式 (IPC 2221 より) は"
+
+#: pcb_calculator/tracks_width_versus_current.cpp:458
+msgid "where:"
+msgstr "ここで:"
+
+#: pcb_calculator/tracks_width_versus_current.cpp:459
+msgid "maximum current in amps"
+msgstr "アンペア表記による最大電流"
+
+#: pcb_calculator/tracks_width_versus_current.cpp:461
+msgid "temperature rise above ambient in deg C"
+msgstr "℃ 表記による周囲に対する上昇温度"
+
+#: pcb_calculator/tracks_width_versus_current.cpp:463
+msgid "width and thickness in mils"
+msgstr "mil 表記による幅と厚さ"
+
+#: pcb_calculator/tracks_width_versus_current.cpp:465
+msgid "0.024 for internal traces or 0.048 for external traces"
+msgstr "内層配線 0.024 または外層配線 0.048"
+
+#: pcb_calculator/transline_dlg_funct.cpp:66
+msgid "Relative Dielectric Constants"
+msgstr "比誘電率"
+
+#: pcb_calculator/transline_dlg_funct.cpp:96
+msgid "Dielectric Loss Factor"
+msgstr "誘電損失"
+
+#: pcb_calculator/transline_dlg_funct.cpp:124
+msgid "Specific Resistance"
+msgstr "固有抵抗"
+
+#: pcb_calculator/transline_ident.cpp:142
+msgid "Epsilon R: substrate relative dielectric constant"
+msgstr "Epsilon R: 比誘電率"
+
+#: pcb_calculator/transline_ident.cpp:145
+msgid "Tangent delta: dielectric loss factor."
+msgstr "Tanδ: 誘電損失"
+
+#: pcb_calculator/transline_ident.cpp:151
+msgid ""
+"Electrical resistivity or specific electrical resistance of conductor "
+"(Ohm*meter)"
+msgstr "電気抵抗率または導体固有の電気抵抗 (Ohm*meter)"
+
+# 原文の関連付けエラー？
+#: pcb_calculator/transline_ident.cpp:156
+#: pcb_calculator/transline_ident.cpp:171
+#: pcb_calculator/transline_ident.cpp:208
+#: pcb_calculator/transline_ident.cpp:240
+#: pcb_calculator/transline_ident.cpp:341
+#: pcb_calculator/transline_ident.cpp:377
+msgid "Height of Substrate"
+msgstr "サブストレートの高さ"
+
+#: pcb_calculator/transline_ident.cpp:165
+#: pcb_calculator/transline_ident.cpp:202
+#: pcb_calculator/transline_ident.cpp:234
+#: pcb_calculator/transline_ident.cpp:268
+#: pcb_calculator/transline_ident.cpp:301
+#: pcb_calculator/transline_ident.cpp:371
+#: pcb_calculator/transline_ident.cpp:404
+msgid "ErEff"
+msgstr "実効誘電率"
+
+#: pcb_calculator/transline_ident.cpp:166
+#: pcb_calculator/transline_ident.cpp:203
+#: pcb_calculator/transline_ident.cpp:235
+#: pcb_calculator/transline_ident.cpp:269
+#: pcb_calculator/transline_ident.cpp:302
+#: pcb_calculator/transline_ident.cpp:372
+#: pcb_calculator/transline_ident.cpp:405
+msgid "Conductor Losses"
+msgstr "導体損失"
+
+#: pcb_calculator/transline_ident.cpp:167
+#: pcb_calculator/transline_ident.cpp:204
+#: pcb_calculator/transline_ident.cpp:236
+#: pcb_calculator/transline_ident.cpp:270
+#: pcb_calculator/transline_ident.cpp:303
+#: pcb_calculator/transline_ident.cpp:373
+#: pcb_calculator/transline_ident.cpp:406
+msgid "Dielectric Losses"
+msgstr "誘電体損失"
+
+#: pcb_calculator/transline_ident.cpp:168
+#: pcb_calculator/transline_ident.cpp:205
+#: pcb_calculator/transline_ident.cpp:237
+#: pcb_calculator/transline_ident.cpp:338
+#: pcb_calculator/transline_ident.cpp:374
+#: pcb_calculator/transline_ident.cpp:407
+msgid "Skin Depth"
+msgstr "表皮深さ"
+
+#: pcb_calculator/transline_ident.cpp:173
+#: pcb_calculator/transline_ident.cpp:343
+msgid "Height of Box Top"
+msgstr "ボックスの高さ"
+
+#: pcb_calculator/transline_ident.cpp:175
+#: pcb_calculator/transline_ident.cpp:210
+#: pcb_calculator/transline_ident.cpp:242
+#: pcb_calculator/transline_ident.cpp:345
+#: pcb_calculator/transline_ident.cpp:382
+msgid "Strip Thickness"
+msgstr "銅箔厚"
+
+#: pcb_calculator/transline_ident.cpp:177
+#: pcb_calculator/transline_ident.cpp:347
+msgid "Conductor Roughness"
+msgstr "導体の荒さ"
+
+#: pcb_calculator/transline_ident.cpp:179
+msgid "mu Rel S"
+msgstr "μ (比透磁率) S (サブストレート)"
+
+#: pcb_calculator/transline_ident.cpp:180
+msgid "Relative Permeability (mu) of Substrate"
+msgstr "サブストレートの比透磁率 (μ)"
+
+#: pcb_calculator/transline_ident.cpp:182
+#: pcb_calculator/transline_ident.cpp:212
+#: pcb_calculator/transline_ident.cpp:244
+#: pcb_calculator/transline_ident.cpp:279
+#: pcb_calculator/transline_ident.cpp:310
+#: pcb_calculator/transline_ident.cpp:349
+#: pcb_calculator/transline_ident.cpp:384
+#: pcb_calculator/transline_ident.cpp:412
+msgid "Relative Permeability (mu) of Conductor"
+msgstr "導体の比透磁率 (μ)"
+
+#: pcb_calculator/transline_ident.cpp:186
+#: pcb_calculator/transline_ident.cpp:216
+#: pcb_calculator/transline_ident.cpp:248
+#: pcb_calculator/transline_ident.cpp:353
+#: pcb_calculator/transline_ident.cpp:388
+msgid "W"
+msgstr "W"
+
+#: pcb_calculator/transline_ident.cpp:188
+#: pcb_calculator/transline_ident.cpp:220
+#: pcb_calculator/transline_ident.cpp:252
+#: pcb_calculator/transline_ident.cpp:287
+#: pcb_calculator/transline_ident.cpp:318
+#: pcb_calculator/transline_ident.cpp:357
+#: pcb_calculator/transline_ident.cpp:390
+#: pcb_calculator/transline_ident.cpp:422
+msgid "L"
+msgstr "L"
+
+#: pcb_calculator/transline_ident.cpp:188
+#: pcb_calculator/transline_ident.cpp:220
+#: pcb_calculator/transline_ident.cpp:252
+#: pcb_calculator/transline_ident.cpp:318
+#: pcb_calculator/transline_ident.cpp:357
+#: pcb_calculator/transline_ident.cpp:390
+msgid "Line Length"
+msgstr "線路長"
+
+#: pcb_calculator/transline_ident.cpp:191
+#: pcb_calculator/transline_ident.cpp:223
+#: pcb_calculator/transline_ident.cpp:255
+#: pcb_calculator/transline_ident.cpp:290
+#: pcb_calculator/transline_ident.cpp:321
+#: pcb_calculator/transline_ident.cpp:393
+#: pcb_calculator/transline_ident.cpp:425
+msgid "Z0"
+msgstr "Z0"
+
+#: pcb_calculator/transline_ident.cpp:191
+#: pcb_calculator/transline_ident.cpp:223
+#: pcb_calculator/transline_ident.cpp:255
+#: pcb_calculator/transline_ident.cpp:290
+#: pcb_calculator/transline_ident.cpp:321
+#: pcb_calculator/transline_ident.cpp:393
+#: pcb_calculator/transline_ident.cpp:425
+msgid "Characteristic Impedance"
+msgstr "特性インピーダンス"
+
+#: pcb_calculator/transline_ident.cpp:194
+#: pcb_calculator/transline_ident.cpp:226
+#: pcb_calculator/transline_ident.cpp:258
+#: pcb_calculator/transline_ident.cpp:293
+#: pcb_calculator/transline_ident.cpp:324
+#: pcb_calculator/transline_ident.cpp:364
+#: pcb_calculator/transline_ident.cpp:396
+#: pcb_calculator/transline_ident.cpp:428
+msgid "Ang_l"
+msgstr "Ang_l"
+
+#: pcb_calculator/transline_ident.cpp:194
+#: pcb_calculator/transline_ident.cpp:226
+#: pcb_calculator/transline_ident.cpp:258
+#: pcb_calculator/transline_ident.cpp:293
+#: pcb_calculator/transline_ident.cpp:324
+#: pcb_calculator/transline_ident.cpp:396
+#: pcb_calculator/transline_ident.cpp:428
+msgid "Electrical Length"
+msgstr "電気長"
+
+#: pcb_calculator/transline_ident.cpp:218
+#: pcb_calculator/transline_ident.cpp:250
+#: pcb_calculator/transline_ident.cpp:355
+msgid "S"
+msgstr "S"
+
+#: pcb_calculator/transline_ident.cpp:218
+#: pcb_calculator/transline_ident.cpp:250
+#: pcb_calculator/transline_ident.cpp:355
+msgid "Gap Width"
+msgstr "ギャップ幅"
+
+#: pcb_calculator/transline_ident.cpp:267
+msgid "ZF(H10) = Ey / Hx"
+msgstr "ZF(H10) = Ey / Hx"
+
+#: pcb_calculator/transline_ident.cpp:271
+#: pcb_calculator/transline_ident.cpp:304
+msgid "TE-Modes"
+msgstr "TEモード"
+
+#: pcb_calculator/transline_ident.cpp:272
+#: pcb_calculator/transline_ident.cpp:305
+msgid "TM-Modes"
+msgstr "TMモード"
+
+#: pcb_calculator/transline_ident.cpp:275
+#: pcb_calculator/transline_ident.cpp:308
+msgid "mu Rel I"
+msgstr "μ (比透磁率) I (絶縁体)"
+
+#: pcb_calculator/transline_ident.cpp:275
+#: pcb_calculator/transline_ident.cpp:308
+msgid "Relative Permeability (mu) of Insulator"
+msgstr "絶縁体の比透磁率 (μ)"
+
+#: pcb_calculator/transline_ident.cpp:277
+msgid "TanM"
+msgstr "TanM"
+
+#: pcb_calculator/transline_ident.cpp:277
+msgid "Magnetic Loss Tangent"
+msgstr "磁気損失正接"
+
+#: pcb_calculator/transline_ident.cpp:283
+#: pcb_calculator/transline_ident.cpp:379
+msgid "a"
+msgstr "a"
+
+#: pcb_calculator/transline_ident.cpp:283
+msgid "Width of Waveguide"
+msgstr "導波管の幅"
+
+#: pcb_calculator/transline_ident.cpp:285
+msgid "b"
+msgstr "b"
+
+#: pcb_calculator/transline_ident.cpp:285
+msgid "Height of Waveguide"
+msgstr "導波管の高さ"
+
+#: pcb_calculator/transline_ident.cpp:287
+msgid "Waveguide Length"
+msgstr "導波管長"
+
+#: pcb_calculator/transline_ident.cpp:314
+#: pcb_calculator/transline_ident.cpp:418
+msgid "Din"
+msgstr "Din"
+
+#: pcb_calculator/transline_ident.cpp:314
+#: pcb_calculator/transline_ident.cpp:418
+msgid "Inner Diameter (conductor)"
+msgstr "内径 (導体)"
+
+#: pcb_calculator/transline_ident.cpp:316
+#: pcb_calculator/transline_ident.cpp:420
+msgid "Dout"
+msgstr "Dout"
+
+#: pcb_calculator/transline_ident.cpp:316
+#: pcb_calculator/transline_ident.cpp:420
+msgid "Outer Diameter (insulator)"
+msgstr "外形 (絶縁体)"
+
+#: pcb_calculator/transline_ident.cpp:332
+msgid "ErEff Even"
+msgstr "実効比誘電率 Even"
+
+#: pcb_calculator/transline_ident.cpp:333
+msgid "ErEff Odd"
+msgstr "実効比誘電率 Odd"
+
+#: pcb_calculator/transline_ident.cpp:334
+msgid "Conductor Losses Even"
+msgstr "導体損 Even"
+
+#: pcb_calculator/transline_ident.cpp:335
+msgid "Conductor Losses Odd"
+msgstr "導体損 Odd"
+
+#: pcb_calculator/transline_ident.cpp:336
+msgid "Dielectric Losses Even"
+msgstr "誘電体損 Even"
+
+#: pcb_calculator/transline_ident.cpp:337
+msgid "Dielectric Losses Odd"
+msgstr "誘電体損 Odd"
+
+#: pcb_calculator/transline_ident.cpp:360
+msgid "Zeven"
+msgstr "Zeven (偶モードインピーダンス)"
+
+#: pcb_calculator/transline_ident.cpp:360
+msgid "Even mode impedance (lines driven by common voltages)"
+msgstr "偶モードインピーダンス (線路は同じ (同相) 電圧で駆動される)"
+
+#: pcb_calculator/transline_ident.cpp:362
+msgid "Zodd"
+msgstr "Zodd (奇モードインピーダンス)"
+
+#: pcb_calculator/transline_ident.cpp:362
+msgid "Odd mode impedance (lines driven by opposite (differential) voltages)"
+msgstr "奇モードインピーダンス (線路は逆 (差動) 電圧で駆動される)"
+
+#: pcb_calculator/transline_ident.cpp:364
+msgid "Electrical length"
+msgstr "電気長"
+
+#: pcb_calculator/transline_ident.cpp:379
+msgid "distance between strip and top metal"
+msgstr "ストリップラインと上部導体の距離"
+
+#: pcb_calculator/transline_ident.cpp:410
+msgid "Twists"
+msgstr "ツイスト数"
+
+#: pcb_calculator/transline_ident.cpp:410
+msgid "Number of Twists per Length"
+msgstr "長さあたりの撚り数"
+
+#: pcb_calculator/transline_ident.cpp:415
+msgid "ErEnv"
+msgstr "ErEnv"
+
+#: pcb_calculator/transline_ident.cpp:415
+msgid "Relative Permittivity of Environment"
+msgstr "環境の比誘電率"
+
+#: pcb_calculator/transline_ident.cpp:422
+msgid "Cable Length"
+msgstr "ケーブル長"
+
+#: pcbnew/append_board_to_current.cpp:91 pcbnew/files.cpp:511
+#: pcbnew/tools/pcbnew_control.cpp:818
 #, c-format
 msgid ""
 "Error loading board.\n"
@@ -609,19 +11555,74 @@ msgstr ""
 "ボード読み込み中のエラーです\n"
 "%s"
 
+#: pcbnew/autorouter/auto_place_footprints.cpp:165
+msgid "Footprints NOT LOCKED will be moved"
+msgstr "ロックしていないフットプリントは移動されます"
+
+#: pcbnew/autorouter/auto_place_footprints.cpp:172
+msgid "Footprints NOT PLACED will be moved"
+msgstr "配置していないフットプリントは移動されます"
+
+#: pcbnew/autorouter/auto_place_footprints.cpp:281
+#, c-format
+msgid "Place footprint %d of %d"
+msgstr "フットプリント %d / %d の配置"
+
+#: pcbnew/autorouter/auto_place_footprints.cpp:466
+msgid "No PCB edge found, unknown board size!"
+msgstr "基板外形がないため、ボードサイズが不明です。"
+
+#: pcbnew/autorouter/auto_place_footprints.cpp:475
+msgid "Cols"
+msgstr "列"
+
+#: pcbnew/autorouter/auto_place_footprints.cpp:479
+msgid "Cells."
+msgstr "セル"
+
+#: pcbnew/autorouter/auto_place_footprints.cpp:692
+msgid "OK to abort?"
+msgstr "中止して宜しいですか？"
+
+#: pcbnew/autorouter/autorout.cpp:90
+msgid "Net not selected"
+msgstr "ネットが選択されていません"
+
+#: pcbnew/autorouter/autorout.cpp:98
+msgid "Footprint not selected"
+msgstr "フットプリントが選択されていません"
+
+#: pcbnew/autorouter/autorout.cpp:108
+msgid "Pad not selected"
+msgstr "パッドが選択されていません"
+
+#: pcbnew/autorouter/autorout.cpp:180
+msgid "No memory for autorouting"
+msgstr "オートルーターのためのメモリがありません"
+
+#: pcbnew/autorouter/autorout.cpp:185
+msgid "Place Cells"
+msgstr "セルの配置"
+
+#: pcbnew/autorouter/move_and_route_event_functions.cpp:133
+msgid "Not locked footprints inside the board will be moved. OK?"
+msgstr "基板内側のロックしていないフットプリントは移動されます。宜しいですか？"
+
+#: pcbnew/autorouter/move_and_route_event_functions.cpp:139
+msgid "No footprint found!"
+msgstr "フットプリントが見つかりません！"
+
+#: pcbnew/autorouter/solve.cpp:301
+msgid "Abort routing?"
+msgstr "配線作業を中止しますか？"
+
+#: pcbnew/autorouter/spread_footprints.cpp:181
+msgid "Could not automatically place footprints. No board outlines detected."
+msgstr "フットプリントを自動配置できません。基板外形が検出できません。"
+
 #: pcbnew/basepcbframe.cpp:465
 msgid "Display rectangular coordinates"
 msgstr "直交座標表示"
-
-#: pcbnew/basepcbframe.cpp:466 pcbnew/tool_pcb.cpp:340
-#: cvpcb/class_DisplayFootprintsFrame.cpp:180
-msgid "Display polar coordinates"
-msgstr "極座標表示"
-
-#: pcbnew/basepcbframe.cpp:476 pcbnew/tool_pcb.cpp:379
-#: cvpcb/class_DisplayFootprintsFrame.cpp:197
-msgid "Show pads in outline mode"
-msgstr "アウトライン モードでパッドを表示"
 
 #: pcbnew/basepcbframe.cpp:477
 msgid "Show pads in fill mode"
@@ -684,28 +11685,22 @@ msgstr "Supplier and ref"
 msgid "This is the default net class."
 msgstr "これは標準のネット クラスです。"
 
-#: pcbnew/class_board.cpp:951 pcbnew/class_module.cpp:580
-#: pcbnew/class_netinfo_item.cpp:113 pcbnew/pcb_draw_panel_gal.cpp:388
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:61
-msgid "Pads"
-msgstr "パッド"
-
 #: pcbnew/class_board.cpp:954 pcbnew/class_netinfo_item.cpp:133
-#: pcbnew/pcb_draw_panel_gal.cpp:391
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:68
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:123
+#: pcbnew/pcb_draw_panel_gal.cpp:350
 msgid "Vias"
 msgstr "ビア数"
 
-#: pcbnew/class_board.cpp:957 pcbnew/pcb_draw_panel_gal.cpp:394
+#: pcbnew/class_board.cpp:957 pcbnew/pcb_draw_panel_gal.cpp:353
 msgid "Track Segments"
 msgstr "配線セグメント数"
 
-#: pcbnew/class_board.cpp:960 pcbnew/pcb_draw_panel_gal.cpp:397
+#: pcbnew/class_board.cpp:960 pcbnew/pcb_draw_panel_gal.cpp:356
 msgid "Nodes"
 msgstr "ノード数"
 
-#: pcbnew/class_board.cpp:963 pcbnew/pcb_draw_panel_gal.cpp:400
+#: pcbnew/class_board.cpp:963 pcbnew/pcb_draw_panel_gal.cpp:359
 msgid "Nets"
 msgstr "ネット数"
 
@@ -717,64 +11712,64 @@ msgstr "リンク数"
 msgid "Connections"
 msgstr "接続"
 
-#: pcbnew/class_board.cpp:977 pcbnew/pcb_draw_panel_gal.cpp:403
-#: pcbnew/dialogs/dialog_drc_base.cpp:184
+#: pcbnew/class_board.cpp:977 pcbnew/dialogs/dialog_drc_base.cpp:184
+#: pcbnew/pcb_draw_panel_gal.cpp:362
 msgid "Unconnected"
 msgstr "未配線"
 
-#: pcbnew/class_board.cpp:2291
+#: pcbnew/class_board.cpp:2299
 #, c-format
 msgid "Checking netlist component footprint \"%s:%s:%s\".\n"
 msgstr ""
 "ネットリストよりコンポーネントとフットプリントをチェックしています \"%s:%s:%s"
 "\"。\n"
 
-#: pcbnew/class_board.cpp:2309
+#: pcbnew/class_board.cpp:2317
 #, c-format
 msgid "Adding new component \"%s:%s\" footprint \"%s\".\n"
 msgstr "コンポーネント \"%s:%s\" フットプリント \"%s\" を追加します。\n"
 
-#: pcbnew/class_board.cpp:2318
+#: pcbnew/class_board.cpp:2326
 #, c-format
 msgid "Cannot add new component \"%s:%s\" due to missing footprint \"%s\".\n"
 msgstr ""
 "新規コンポーネント \"%s:%s\" が作成できませんでした。これは フットプリント  "
 "\"%s\" が不正であることに起因します。\n"
 
-#: pcbnew/class_board.cpp:2350
+#: pcbnew/class_board.cpp:2358
 #, c-format
 msgid "Replacing component \"%s:%s\" footprint \"%s\" with \"%s\".\n"
 msgstr ""
 "コンポーネント \"%s:%s\" フットプリント \"%s\" - \"%s\" を置換します.\n"
 
-#: pcbnew/class_board.cpp:2361
+#: pcbnew/class_board.cpp:2369
 #, c-format
 msgid "Cannot replace component \"%s:%s\" due to missing footprint \"%s\".\n"
 msgstr ""
 "コンポーネント \"%s:%s\" が置換できませんでした。これは フットプリント  \"%s"
 "\" が不正であることに起因します。\n"
 
-#: pcbnew/class_board.cpp:2394
+#: pcbnew/class_board.cpp:2402
 #, c-format
 msgid "Changing component \"%s:%s\" reference to \"%s\".\n"
 msgstr "コンポーネント \"%s:%s\" の変更. (\"%s\" を参照する) \n"
 
-#: pcbnew/class_board.cpp:2410
+#: pcbnew/class_board.cpp:2418
 #, c-format
 msgid "Changing component \"%s:%s\" value from \"%s\" to \"%s\".\n"
 msgstr "コンポーネント \"%s:%s\" の値を， \"%s\" から \"%s\" に変更．\n"
 
-#: pcbnew/class_board.cpp:2427
+#: pcbnew/class_board.cpp:2435
 #, c-format
 msgid "Changing component path \"%s:%s\" to \"%s\".\n"
 msgstr "コンポーネントのパス， \"%s:%s\" を \"%s\" に変更．\n"
 
-#: pcbnew/class_board.cpp:2451
+#: pcbnew/class_board.cpp:2459
 #, c-format
 msgid "Clearing component \"%s:%s\" pin \"%s\" net name.\n"
 msgstr "コンポーネントの \"%s:%s\" ピン \"%s\" ネット名をクリア．\n"
 
-#: pcbnew/class_board.cpp:2467
+#: pcbnew/class_board.cpp:2475
 #, c-format
 msgid ""
 "Changing component \"%s:%s\" pin \"%s\" net name from \"%s\" to \"%s\".\n"
@@ -782,50 +11777,31 @@ msgstr ""
 "コンポーネントを \"%s:%s\" ピン \"%s\" ネット名を， \"%s\" から \"%s\" に変"
 "更．\n"
 
-#: pcbnew/class_board.cpp:2516
+#: pcbnew/class_board.cpp:2524
 #, c-format
 msgid "Removing unused component \"%s:%s\".\n"
 msgstr "未使用のコンポーネント \"%s:%s\" を削除しました.\n"
 
-#: pcbnew/class_board.cpp:2576
+#: pcbnew/class_board.cpp:2584
 #, c-format
 msgid "Remove single pad net \"%s\" on \"%s\" pad '%s'\n"
 msgstr "孤立したパッドを削除：ネット \"%s\" / \"%s\" パッド '%s'\n"
 
-#: pcbnew/class_board.cpp:2631
+#: pcbnew/class_board.cpp:2639
 #, c-format
 msgid "Component '%s' pad '%s' not found in footprint '%s'\n"
 msgstr ""
 "コンポーネント '%s' のパッド '%s' がフットプリント '%s' に見つかりませんでし"
 "た.\n"
 
-#: pcbnew/class_board.cpp:2649
+#: pcbnew/class_board.cpp:2657
 #, c-format
 msgid "Copper zone (net name '%s'): net has no pads connected."
 msgstr "導体ゾーン(ネット名 '%s' )：ネットがパッドへ接続されていません."
 
-#: pcbnew/class_board_item.cpp:42
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:241
-#: pcbnew/dialogs/dialog_keepout_area_properties_base.cpp:53
-#: pcbnew/dialogs/dialog_non_copper_zones_properties_base.cpp:52
-#: eeschema/lib_pin.cpp:207 gerbview/class_gerber_draw_item.cpp:183
-msgid "Line"
-msgstr "ライン"
-
 #: pcbnew/class_board_item.cpp:43 pcbnew/class_pad.cpp:867
 msgid "Rect"
 msgstr "矩形"
-
-#: pcbnew/class_board_item.cpp:44 pcbnew/class_drawsegment.cpp:377
-#: eeschema/lib_arc.cpp:95 gerbview/class_gerber_draw_item.cpp:186
-msgid "Arc"
-msgstr "円弧"
-
-#: pcbnew/class_board_item.cpp:45 pcbnew/class_drawsegment.cpp:373
-#: pcbnew/class_pad.cpp:861 eeschema/lib_circle.cpp:53
-#: gerbview/class_gerber_draw_item.cpp:189
-msgid "Circle"
-msgstr "円"
 
 #: pcbnew/class_board_item.cpp:46
 msgid "Bezier Curve"
@@ -845,31 +11821,10 @@ msgstr "寸法 \"%s\" - %s"
 msgid "Drawing"
 msgstr "図形"
 
-#: pcbnew/class_drawsegment.cpp:366 pcbnew/class_marker_pcb.cpp:97
-#: pcbnew/class_text_mod.cpp:375 pcbnew/class_track.cpp:1142
-#: pcbnew/class_track.cpp:1169 pcbnew/class_track.cpp:1218
-#: pcbnew/class_zone.cpp:584 pcbnew/dialogs/dialog_layers_setup.cpp:346
-#: eeschema/lib_draw_item.cpp:65 eeschema/lib_pin.cpp:1986
-#: eeschema/libedit.cpp:507 eeschema/sch_text.cpp:785
-#: eeschema/dialogs/dialog_lib_edit_pin_table.cpp:158
-#: gerbview/class_gerber_draw_item.cpp:549
-#: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:47
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:168
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:29
-msgid "Type"
-msgstr "タイプ"
-
 #: pcbnew/class_drawsegment.cpp:368
 #: pcbnew/dialogs/dialog_target_properties_base.cpp:50
 msgid "Shape"
 msgstr "形状"
-
-#: pcbnew/class_drawsegment.cpp:379 pcbnew/class_drawsegment.cpp:397
-#: pcbnew/class_module.cpp:593 pcbnew/class_pad.cpp:679
-#: pcbnew/class_pcb_text.cpp:148 pcbnew/class_text_mod.cpp:395
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:938
-msgid "Angle"
-msgstr "角度"
 
 #: pcbnew/class_drawsegment.cpp:383
 msgid "Curve"
@@ -880,35 +11835,7 @@ msgstr "曲線"
 msgid "Segment"
 msgstr "セグメント"
 
-#: pcbnew/class_drawsegment.cpp:391 pcbnew/class_track.cpp:1045
-#: eeschema/lib_pin.cpp:2008
-msgid "Length"
-msgstr "長さ"
-
-#: pcbnew/class_drawsegment.cpp:408 pcbnew/class_module.cpp:568
-#: pcbnew/class_pad.cpp:644 pcbnew/class_pcb_layer_widget.cpp:242
-#: pcbnew/class_pcb_text.cpp:140 pcbnew/class_text_mod.cpp:385
-#: pcbnew/class_track.cpp:1152 pcbnew/class_track.cpp:1179
-#: pcbnew/class_zone.cpp:630 pcbnew/layer_widget.cpp:545
-#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:89
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:115
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:144
-#: gerbview/class_gerbview_layer_widget.cpp:89
-#: gerbview/dialogs/dialog_print_using_printer.cpp:163
-#: gerbview/dialogs/dialog_select_one_pcb_layer.cpp:163
-msgid "Layer"
-msgstr "レイヤ"
-
-#: pcbnew/class_drawsegment.cpp:410 pcbnew/class_pad.cpp:650
-#: pcbnew/class_pcb_text.cpp:154 pcbnew/class_text_mod.cpp:401
-#: pcbnew/class_track.cpp:1157 pcbnew/class_track.cpp:1184
-#: pcbnew/dialogs/dialog_design_rules_base.cpp:327
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:48
-#: eeschema/lib_field.cpp:749
-msgid "Width"
-msgstr "幅"
-
-#: pcbnew/class_drawsegment.cpp:666
+#: pcbnew/class_drawsegment.cpp:608
 #, c-format
 msgid "Pcb Graphic: %s, length %s on %s"
 msgstr "基板上の図形: %s, 長さ %s (レイヤ %s)"
@@ -1042,31 +11969,6 @@ msgstr "配線がテキスト内に入っています"
 msgid "Pad inside a text"
 msgstr "パッドがテキスト内に入っています"
 
-#: pcbnew/class_edge_mod.cpp:260 pcbnew/class_module.cpp:616
-#: pcbnew/class_pad.cpp:628 pcbnew/class_text_mod.cpp:369
-#: pcbnew/loadcmp.cpp:436 eeschema/lib_field.cpp:588
-#: eeschema/onrightclick.cpp:433 eeschema/sch_component.cpp:1536
-#: eeschema/template_fieldnames.cpp:45
-msgid "Footprint"
-msgstr "フットプリント"
-
-#: pcbnew/class_edge_mod.cpp:261 pcbnew/class_text_mod.cpp:365
-#: pcbnew/footprint_wizard_frame.cpp:151
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:43
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:59
-#: pcbnew/dialogs/dialog_fp_plugin_options_base.cpp:40
-#: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:31
-#: eeschema/lib_field.cpp:581 eeschema/lib_field.cpp:759
-#: eeschema/onrightclick.cpp:423 eeschema/sch_component.cpp:1518
-#: eeschema/template_fieldnames.cpp:42
-#: eeschema/dialogs/dialog_color_config.cpp:79
-#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:186
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:184
-#: eeschema/dialogs/dialog_rescue_each.cpp:108
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:83
-msgid "Value"
-msgstr "定数"
-
 #: pcbnew/class_edge_mod.cpp:263
 msgid "TimeStamp"
 msgstr "タイムスタンプ"
@@ -1099,10 +12001,6 @@ msgstr "マーカ @(%d,%d)"
 msgid "Target size %s"
 msgstr "ターゲットサイズ %s"
 
-#: pcbnew/class_module.cpp:561 eeschema/dialogs/dialog_choose_component.cpp:273
-msgid "Unknown"
-msgstr "不明"
-
 #: pcbnew/class_module.cpp:563
 msgid "Last Change"
 msgstr "前回の変更"
@@ -1112,36 +12010,10 @@ msgid "Netlist Path"
 msgstr "ネットリストのパス"
 
 #: pcbnew/class_module.cpp:590 pcbnew/class_track.cpp:1134
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:179
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:191
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:186
 msgid "Status"
 msgstr "ステータス"
-
-#: pcbnew/class_module.cpp:599 pcbnew/muonde.cpp:812
-#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:83
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:140
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:98
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:104
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:70
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:100
-#: eeschema/libedit.cpp:498 eeschema/onrightclick.cpp:381
-#: eeschema/sch_text.cpp:758
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:56
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:182
-#: eeschema/dialogs/dialog_edit_label_base.cpp:76
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:92
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:97
-#: gerbview/class_GERBER.cpp:359 gerbview/class_GERBER.cpp:363
-#: gerbview/class_GERBER.cpp:366 common/eda_text.cpp:377
-#: bitmap2component/bitmap2cmp_gui_base.cpp:135
-msgid "Normal"
-msgstr "標準"
-
-#: pcbnew/class_module.cpp:603
-#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:43
-#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:90
-msgid "Insert"
-msgstr "挿入"
 
 #: pcbnew/class_module.cpp:607
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:140
@@ -1206,17 +12078,9 @@ msgstr "パッド"
 msgid "Net"
 msgstr "ネット"
 
-#: pcbnew/class_pad.cpp:653 pcbnew/class_pcb_text.cpp:157
-#: pcbnew/class_text_mod.cpp:404
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:56
-#: eeschema/lib_field.cpp:752
-msgid "Height"
-msgstr "高さ"
-
 #: pcbnew/class_pad.cpp:659 pcbnew/class_track.cpp:1247
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:278
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:262
-#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:177
 msgid "Drill"
 msgstr "ドリル"
 
@@ -1224,17 +12088,11 @@ msgstr "ドリル"
 msgid "Drill X / Y"
 msgstr "ドリル X/Y"
 
-#: pcbnew/class_pad.cpp:682
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:80
-#: eeschema/dialogs/dialog_lib_edit_pin_table.cpp:165
-msgid "Position"
-msgstr "ポジション"
-
 #: pcbnew/class_pad.cpp:687
 msgid "Length in package"
 msgstr "パッケージ内の長さ"
 
-#: pcbnew/class_pad.cpp:864
+#: pcbnew/class_pad.cpp:864 pcbnew/dialogs/dialog_pad_properties_base.cpp:68
 msgid "Oval"
 msgstr "楕円"
 
@@ -1360,19 +12218,6 @@ msgstr "アンカー"
 msgid "Show footprint and text origins as a cross"
 msgstr "フットプリントとテキストの原点を十字で表示"
 
-#: pcbnew/class_pcb_layer_widget.cpp:74
-#: pcbnew/dialogs/dialog_create_array_base.cpp:170
-#: pcbnew/tools/selection_tool.cpp:116
-#: eeschema/dialogs/dialog_color_config.cpp:96
-#: gerbview/class_gerbview_layer_widget.cpp:110
-msgid "Grid"
-msgstr "グリッド"
-
-#: pcbnew/class_pcb_layer_widget.cpp:74
-#: gerbview/class_gerbview_layer_widget.cpp:110
-msgid "Show the (x,y) grid dots"
-msgstr "(x,y) グリッドのドットを表示"
-
 #: pcbnew/class_pcb_layer_widget.cpp:75
 msgid "No-Connects"
 msgstr "未接続"
@@ -1396,11 +12241,6 @@ msgstr "裏面のフットプリント"
 #: pcbnew/class_pcb_layer_widget.cpp:77
 msgid "Show footprints that are on board's back"
 msgstr "ボード裏面のフットプリントを表示"
-
-#: pcbnew/class_pcb_layer_widget.cpp:78
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1122
-msgid "Values"
-msgstr "値"
 
 #: pcbnew/class_pcb_layer_widget.cpp:78
 msgid "Show footprint's values"
@@ -1429,11 +12269,6 @@ msgstr "全てのアクティブでない導体レイヤを隠す"
 #: pcbnew/class_pcb_layer_widget.cpp:172
 msgid "Hide All Copper Layers"
 msgstr "全ての導体レイヤを非表示"
-
-#: pcbnew/class_pcb_layer_widget.cpp:243 pcbnew/layer_widget.cpp:565
-#: gerbview/class_gerbview_layer_widget.cpp:90
-msgid "Render"
-msgstr "表示"
 
 #: pcbnew/class_pcb_layer_widget.cpp:333
 msgid "Front copper layer"
@@ -1523,40 +12358,6 @@ msgstr "寸法線入力"
 msgid "PCB Text"
 msgstr "PCBテキスト"
 
-#: pcbnew/class_pcb_text.cpp:143 pcbnew/class_pcb_text.cpp:145
-#: pcbnew/class_text_mod.cpp:392 pcbnew/modedit_onclick.cpp:292
-#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:83
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:100
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:58
-#: gerbview/class_gerber_draw_item.cpp:574
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:79
-msgid "Mirror"
-msgstr "ミラー"
-
-#: pcbnew/class_pcb_text.cpp:143 pcbnew/class_text_mod.cpp:378
-#: eeschema/lib_pin.cpp:2002
-#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:984
-#: gerbview/class_gerber_draw_item.cpp:572
-#: gerbview/class_gerber_draw_item.cpp:573
-msgid "No"
-msgstr "いいえ"
-
-#: pcbnew/class_pcb_text.cpp:145 pcbnew/class_text_mod.cpp:380
-#: eeschema/lib_pin.cpp:2000
-#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:982
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:41
-#: gerbview/class_gerber_draw_item.cpp:572
-#: gerbview/class_gerber_draw_item.cpp:573
-msgid "Yes"
-msgstr "はい"
-
-#: pcbnew/class_pcb_text.cpp:151 pcbnew/class_text_mod.cpp:398
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:64
-#: pcbnew/dialogs/dialog_target_properties_base.cpp:39
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:325
-msgid "Thickness"
-msgstr "太さ"
-
 #: pcbnew/class_pcb_text.cpp:191
 #, c-format
 msgid "Pcb Text \"%s\" on %s"
@@ -1565,15 +12366,6 @@ msgstr "基板上のテキスト \"%s\" (%s)"
 #: pcbnew/class_text_mod.cpp:365
 msgid "Ref."
 msgstr "リファレンス"
-
-#: pcbnew/class_text_mod.cpp:365 pcbnew/class_text_mod.cpp:372
-#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:21
-#: pcbnew/dialogs/dialog_global_deletion_base.cpp:28 eeschema/lib_text.cpp:51
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:28
-#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:113
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:67
-msgid "Text"
-msgstr "テキスト"
 
 #: pcbnew/class_text_mod.cpp:382
 #: pcbnew/dialogs/dialog_dimension_editor_base.cpp:85
@@ -1653,8 +12445,8 @@ msgid "NC Via Drill"
 msgstr "ネットクラス ビア ドリル径"
 
 #: pcbnew/class_track.cpp:1091 pcbnew/class_zone.cpp:615
-#: pcbnew/zones_by_polygon_fill_functions.cpp:113
 #: pcbnew/dialogs/dialog_global_edit_tracks_and_vias_base.cpp:46
+#: pcbnew/zones_by_polygon_fill_functions.cpp:113
 msgid "NetName"
 msgstr "ネット名"
 
@@ -1685,7 +12477,6 @@ msgid "Layers"
 msgstr "レイヤ"
 
 #: pcbnew/class_track.cpp:1240 pcbnew/dialogs/dialog_design_rules_base.cpp:277
-#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:165
 msgid "Diameter"
 msgstr "直径"
 
@@ -1723,6 +12514,7 @@ msgid "No track"
 msgstr "配線なし"
 
 #: pcbnew/class_zone.cpp:597
+#: pcbnew/dialogs/dialog_keepout_area_properties_base.cpp:68
 msgid "No copper pour"
 msgstr "ベタパターン無し"
 
@@ -1750,11 +12542,6 @@ msgstr "角"
 msgid "Segments"
 msgstr "セグメント"
 
-#: pcbnew/class_zone.cpp:638
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:67
-msgid "Polygons"
-msgstr "ポリゴン"
-
 #: pcbnew/class_zone.cpp:640
 msgid "Fill Mode"
 msgstr "塗りつぶしモード"
@@ -1775,19 +12562,10 @@ msgstr "(禁止エリア)"
 msgid "** NO BOARD DEFINED **"
 msgstr "** NO BOARD DEFINED ボードが定義されていません **"
 
-#: pcbnew/class_zone.cpp:848 eeschema/schframe.cpp:169
-msgid "Not Found"
-msgstr "見つかりませんでした"
-
 #: pcbnew/class_zone.cpp:853
 #, c-format
 msgid "Zone Outline %s on %s"
 msgstr "ゾーンの外枠 %s - %s"
-
-#: pcbnew/controle.cpp:231 pcbnew/modedit.cpp:130
-#: pagelayout_editor/pl_editor_frame.cpp:747
-msgid "Selection Clarification"
-msgstr "明示的な選択"
 
 #: pcbnew/cross-probing.cpp:66
 #, c-format
@@ -1813,4004 +12591,118 @@ msgstr "%s ピン %s が見つかりました"
 msgid "Delete NET?"
 msgstr "NETを削除しますか？"
 
-#: pcbnew/dimension.cpp:149
+#: pcbnew/dialogs/dialog_SVG_print.cpp:222
+#: pcbnew/dialogs/dialog_gendrill.cpp:302
+#: pcbnew/exporters/gen_modules_placefile.cpp:184
+msgid "Use a relative path? "
+msgstr "相対パスを使用しますか？"
+
+#: pcbnew/dialogs/dialog_SVG_print.cpp:233
+#: pcbnew/exporters/gen_modules_placefile.cpp:193
 msgid ""
-"This item has an illegal layer id.\n"
-"Now, forced on the drawings layer. Please, fix it"
+"Cannot make path relative (target volume different from board file volume)!"
 msgstr ""
-"このアイテム中には不正なレイヤIDがあります．\n"
-"現在は強制的に描画レイヤにしているため，適切に修正してください．"
+"パスの関連付けを作成できません (ターゲットボリュームがボードファイルのボ"
+"リュームと異なります"
 
-#: pcbnew/dimension.cpp:173
+#: pcbnew/dialogs/dialog_SVG_print.cpp:306
+#, c-format
+msgid "Plot: '%s' OK."
+msgstr "プロット: '%s' OK."
+
+#: pcbnew/dialogs/dialog_SVG_print.cpp:312 pcbnew/dialogs/dialog_plot.cpp:819
+#: pcbnew/exporters/gen_modules_placefile.cpp:310
+#, c-format
+msgid "Unable to create file '%s'."
+msgstr "ファイル '%s' を作成できません"
+
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:30
 msgid ""
-"The layer currently selected is not enabled for this board\n"
-"You cannot use it"
+"Enter a filename if you do not want to use default file names\n"
+"Can be used only when printing the current sheet"
 msgstr ""
-"現在選択されているレイヤはこのボードで有効になっていません。\n"
-"現在使用することができません"
+"デフォルトのファイル名でないものを使いたい場合、ファイル名を入力してくださ"
+"い。\n"
+"これは現在のシートを印刷するときにのみ使用されます。"
 
-#: pcbnew/dimension.cpp:217
-msgid "The text thickness is too large for the text size.  It will be clamped"
-msgstr "文字太さが文字サイズに比べて太過ぎるため、文字が潰れてしまいます。"
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:47
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:25
+msgid "Copper Layers:"
+msgstr "導体レイヤ:"
 
-#: pcbnew/drc.cpp:180
-msgid "Compile ratsnest...\n"
-msgstr "ラッツネストのコンパイル中...\n"
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:52
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:30
+msgid "Technical Layers:"
+msgstr "テクニカル レイヤ:"
 
-#: pcbnew/drc.cpp:196
-msgid "Aborting\n"
-msgstr "停止割り込み中\n"
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:61
+msgid "Print SVG options:"
+msgstr "SVG印刷オプション:"
 
-#: pcbnew/drc.cpp:209
-msgid "Pad clearances...\n"
-msgstr "パッドのクリアランス...\n"
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:63
+#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:84
+msgid "Default pen size"
+msgstr "デフォルト ペン サイズ"
 
-#: pcbnew/drc.cpp:219
-msgid "Track clearances...\n"
-msgstr "配線のクリアランス...\n"
-
-#: pcbnew/drc.cpp:229
-msgid "Fill zones...\n"
-msgstr "ゾーンの塗りつぶし...\n"
-
-#: pcbnew/drc.cpp:239
-msgid "Test zones...\n"
-msgstr "ゾーンのテスト...\n"
-
-#: pcbnew/drc.cpp:250
-msgid "Unconnected pads...\n"
-msgstr "未接続パッド...\n"
-
-#: pcbnew/drc.cpp:262
-msgid "Keepout areas ...\n"
-msgstr "禁止エリア ...\n"
-
-#: pcbnew/drc.cpp:272
-msgid "Test texts...\n"
-msgstr "テストテキスト...\n"
-
-#: pcbnew/drc.cpp:285
-msgid "Finished"
-msgstr "終了"
-
-#: pcbnew/drc.cpp:323
-#, c-format
-msgid "NETCLASS: '%s' has Clearance:%s which is less than global:%s"
-msgstr ""
-"ネットクラス: '%s' のクリアランス:%s はグローバル クリアランス:%s よりも小さ"
-"いです"
-
-#: pcbnew/drc.cpp:339
-#, c-format
-msgid "NETCLASS: '%s' has TrackWidth:%s which is less than global:%s"
-msgstr "ネットクラス: '%s' の配線幅:%s はグローバル配線幅:%s より小さいです"
-
-#: pcbnew/drc.cpp:354
-#, c-format
-msgid "NETCLASS: '%s' has Via Dia:%s which is less than global:%s"
-msgstr "ネットクラス: '%s' のビア径:%s はグローバル ビア径:%s より小さいです"
-
-#: pcbnew/drc.cpp:369
-#, c-format
-msgid "NETCLASS: '%s' has Via Drill:%s which is less than global:%s"
-msgstr ""
-"ネットクラス: '%s' のビア ドリル径: %s はグローバル ビア ドリル径: %s より小"
-"さいです"
-
-#: pcbnew/drc.cpp:384
-#, c-format
-msgid "NETCLASS: '%s' has uVia Dia:%s which is less than global:%s"
-msgstr ""
-"ネットクラス: '%s' のマイクロビア径: %s はグローバル マイクロビア径: %s より"
-"小さいです"
-
-#: pcbnew/drc.cpp:399
-#, c-format
-msgid "NETCLASS: '%s' has uVia Drill:%s which is less than global:%s"
-msgstr ""
-"ネットクラス: '%s' のマイクロビア ドリル径 :%s はグローバル マイクロビア ドリ"
-"ル径 :%s より小さいです"
-
-#: pcbnew/drc.cpp:492
-msgid "Track clearances"
-msgstr "配線のクリアランス"
-
-#: pcbnew/eagle_plugin.cpp:1674
-#, c-format
-msgid "<package> name: '%s' duplicated in eagle <library>: '%s'"
-msgstr "<package> の名前:'%s' が，Eagleの <library> 名と重複しています:'%s'"
-
-#: pcbnew/eagle_plugin.cpp:1731
-#, c-format
-msgid "No '%s' package in library '%s'"
-msgstr "パッケージ '%s' がライブラリ '%s' 内に見つかりませんでした"
-
-#: pcbnew/eagle_plugin.cpp:2797
-#, c-format
-msgid "File '%s' is not readable."
-msgstr "ファイル '%s' が読み込めません。"
-
-#: pcbnew/edgemod.cpp:213
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:65
 msgid ""
-"The graphic item will be on a copper layer.\n"
-"This is very dangerous. Are you sure?"
-msgstr ""
-"図形アイテムが銅箔層の上に配置されます。\n"
-"これは非常に危険ですが、続行しますか？"
-
-#: pcbnew/edgemod.cpp:254
-msgid "New Width:"
-msgstr "新しい幅:"
-
-#: pcbnew/edgemod.cpp:254
-msgid "Edge Width"
-msgstr "エッジの幅"
-
-#: pcbnew/edit.cpp:693 pcbnew/edit.cpp:715 pcbnew/edit.cpp:741
-#: pcbnew/edit.cpp:769 pcbnew/edit.cpp:797 pcbnew/edit.cpp:825
-#, c-format
-msgid "Footprint %s found, but it is locked"
-msgstr "フットプリント %s はロックされています"
-
-#: pcbnew/edit.cpp:897 pcbnew/edit.cpp:916
-#, c-format
-msgid "The parent (%s) of the pad is locked"
-msgstr "パッドの親 (%s) はロックされています"
-
-#: pcbnew/edit.cpp:1433 pcbnew/edit.cpp:1435
-msgid "Add tracks"
-msgstr "配線の入力"
-
-#: pcbnew/edit.cpp:1445 pcbnew/edit.cpp:1492
-#: pcbnew/tools/pcb_editor_control.cpp:224
-msgid "Add module"
-msgstr "モジュールの入力"
-
-#: pcbnew/edit.cpp:1449 pcbnew/tools/drawing_tool.cpp:417
-msgid "Add zones"
-msgstr "ゾーンの入力"
-
-#: pcbnew/edit.cpp:1452
-msgid "Warning: zone display is OFF!!!"
-msgstr "警告: ゾーンの表示がOFFになっています!!!"
-
-#: pcbnew/edit.cpp:1460 pcbnew/tools/drawing_tool.cpp:425
-msgid "Add keepout"
-msgstr "キープアウト(禁止)エリアの追加"
-
-#: pcbnew/edit.cpp:1464 pcbnew/menubar_pcbframe.cpp:421 pcbnew/tool_pcb.cpp:470
-#: pcbnew/tools/common_actions.cpp:384 pcbnew/tools/pcb_editor_control.cpp:346
-msgid "Add layer alignment target"
-msgstr "層合わせマーク(ターゲットマーク)の入力"
-
-#: pcbnew/edit.cpp:1468 pcbnew/tools/pcb_editor_control.cpp:647
-msgid "Adjust zero"
-msgstr "ゼロ設定"
-
-#: pcbnew/edit.cpp:1472 pcbnew/tools/pcbnew_control.cpp:657
-msgid "Adjust grid origin"
-msgstr "グリッドの原点設定"
-
-#: pcbnew/edit.cpp:1476 pcbnew/tools/drawing_tool.cpp:78
-#: pcbnew/tools/drawing_tool.cpp:103
-msgid "Add graphic line"
-msgstr "図形ライン入力"
-
-#: pcbnew/edit.cpp:1480 pcbnew/menubar_modedit.cpp:287
-#: pcbnew/menubar_pcbframe.cpp:403 pcbnew/tool_modedit.cpp:176
-#: pcbnew/tool_pcb.cpp:460 pcbnew/tools/drawing_tool.cpp:182
-#: pcbnew/tools/drawing_tool.cpp:202
-msgid "Add graphic arc"
-msgstr "円弧入力"
-
-#: pcbnew/edit.cpp:1484 pcbnew/menubar_modedit.cpp:276
-#: pcbnew/menubar_pcbframe.cpp:406 pcbnew/tool_modedit.cpp:173
-#: pcbnew/tool_pcb.cpp:457 pcbnew/tools/drawing_tool.cpp:135
-#: pcbnew/tools/drawing_tool.cpp:155
-msgid "Add graphic circle"
-msgstr "円入力"
-
-#: pcbnew/edit.cpp:1488 pcbnew/modedit.cpp:948
-#: pcbnew/tools/drawing_tool.cpp:1227 pcbnew/tools/drawing_tool.cpp:1351
-#: eeschema/libeditframe.cpp:1131 eeschema/schedit.cpp:559
-msgid "Add text"
-msgstr "テキストの追加"
-
-#: pcbnew/edit.cpp:1496 pcbnew/menubar_pcbframe.cpp:417 pcbnew/tool_pcb.cpp:467
-#: pcbnew/tools/drawing_tool.cpp:248
-msgid "Add dimension"
-msgstr "寸法線入力"
-
-#: pcbnew/edit.cpp:1500 pcbnew/modedit.cpp:973
-#: pcbnew/tools/pcbnew_control.cpp:748 eeschema/libeditframe.cpp:1173
-#: eeschema/schedit.cpp:595 eeschema/help_common_strings.h:48
-msgid "Delete item"
-msgstr "アイテム削除"
-
-#: pcbnew/edit.cpp:1504 pcbnew/tool_pcb.cpp:432
-#: pcbnew/tools/pcb_editor_control.cpp:703
-msgid "Highlight net"
-msgstr "ネットをハイライト"
-
-#: pcbnew/edit.cpp:1508
-msgid "Select rats nest"
-msgstr "ラッツネストを選択"
-
-#: pcbnew/editedge.cpp:152
-msgid "Copper layer global delete not allowed!"
-msgstr "導体層はグローバル削除できません！"
-
-#: pcbnew/editedge.cpp:157
-#, c-format
-msgid "Delete everything on layer %s?"
-msgstr "レイヤ %s 上の全てを削除する"
-
-#: pcbnew/editmod.cpp:115
-msgid "Cannot delete REFERENCE!"
-msgstr "リファレンスは削除できません!"
-
-#: pcbnew/editmod.cpp:119
-msgid "Cannot delete VALUE!"
-msgstr "部品定数は削除することが出来ません!"
-
-#: pcbnew/editrack.cpp:815
-msgid "Track Len"
-msgstr "配線長"
-
-#: pcbnew/editrack.cpp:819
-msgid "Full Len"
-msgstr "全長"
-
-#: pcbnew/editrack.cpp:821
-msgid "Pad to die"
-msgstr "パッドからダイ"
-
-#: pcbnew/editrack.cpp:826
-msgid "Segs Count"
-msgstr "セグメント数"
-
-#: pcbnew/files.cpp:121
-msgid "Open Board File"
-msgstr "ボード ファイルを開く"
-
-#: pcbnew/files.cpp:159
-msgid "Save Board File As"
-msgstr "ボード ファイルを名前を付けて保存"
-
-#: pcbnew/files.cpp:184
-#, c-format
-msgid ""
-"The file '%s' already exists.\n"
-"\n"
-"Do you want to overwrite it?"
-msgstr ""
-"'%s' のファイルは既に存在します．\n"
-"\n"
-"上書きしますか？"
-
-#: pcbnew/files.cpp:203
-msgid "Printed circuit board"
-msgstr "プリント基板"
-
-#: pcbnew/files.cpp:274
-#, c-format
-msgid "Recovery file '%s' not found."
-msgstr "リカバリファイル '%s' が見つかりません。"
-
-#: pcbnew/files.cpp:280
-#, c-format
-msgid "OK to load recovery or backup file '%s'"
-msgstr "リカバリー バックアップ ファイル \"%s\" を読み込みます、宜しいですか？"
-
-#: pcbnew/files.cpp:339
-msgid "noname"
-msgstr "名前なし"
-
-#: pcbnew/files.cpp:407
-#, c-format
-msgid "PCB file '%s' is already open."
-msgstr "PCBファイル '%s' は既に開かれています。"
-
-#: pcbnew/files.cpp:417
-msgid "The current board has been modified.  Do you wish to save the changes?"
-msgstr "現在のボードは変更されています。変更を保存しますか？"
-
-#: pcbnew/files.cpp:419 eeschema/files-io.cpp:215
-msgid "Save and Load"
-msgstr "保存と読み込み"
-
-#: pcbnew/files.cpp:420 eeschema/files-io.cpp:216
-msgid "Load Without Saving"
-msgstr "保存しないで読み込み"
-
-#: pcbnew/files.cpp:443
-#, c-format
-msgid "Board '%s' does not exist.  Do you wish to create it?"
-msgstr "ボード '%s' は存在しません。新規作成しますか?"
-
-#: pcbnew/files.cpp:539
-msgid ""
-"This file was created by an older version of Pcbnew.\n"
-"It will be stored in the new file format when you save this file again."
-msgstr ""
-"このファイルは古いバージョンの Pcbnew で作成されています。\n"
-"次に保存する際に、新しいフォーマットで保存し直されます。"
-
-#: pcbnew/files.cpp:640
-#, c-format
-msgid "Warning: unable to create backup file '%s'"
-msgstr "警告: バックアップ ファイル '%s' を作成できません"
-
-#: pcbnew/files.cpp:667 pcbnew/files.cpp:762
-#, c-format
-msgid "No access rights to write to file '%s'"
-msgstr "'%s' ファイルへの書き込み権限がありません。"
-
-#: pcbnew/files.cpp:708 pcbnew/files.cpp:788
-#, c-format
-msgid ""
-"Error saving board file '%s'.\n"
-"%s"
-msgstr ""
-"ボード保存中のエラー '%s'\n"
-"%s"
-
-#: pcbnew/files.cpp:714
-#, c-format
-msgid "Failed to create '%s'"
-msgstr "'%s' の作成に失敗しました"
-
-#: pcbnew/files.cpp:740
-#, c-format
-msgid "Backup file: '%s'"
-msgstr "バックアップファイル: '%s'"
-
-#: pcbnew/files.cpp:742
-#, c-format
-msgid "Wrote board file: '%s'"
-msgstr "ボードファイルに書き込みました: '%s'"
-
-#: pcbnew/files.cpp:797
-#, c-format
-msgid ""
-"Board copied to:\n"
-"'%s'"
-msgstr ""
-"次へボードをコピーしました:\n"
-"'%s'"
-
-#: pcbnew/footprint_wizard.cpp:78 pcbnew/footprint_wizard_frame.cpp:99
-msgid "Footprint Wizard"
-msgstr "フットプリントウィザード"
-
-#: pcbnew/footprint_wizard.cpp:84
-msgid "no wizard selected"
-msgstr "ウィザードが選択されていません"
-
-#: pcbnew/footprint_wizard.cpp:130
-msgid "Couldn't reload footprint wizard"
-msgstr "フットプリントウィザードの再読み込みに失敗しました"
-
-#: pcbnew/footprint_wizard_frame.cpp:150
-msgid "Parameter"
-msgstr "パラメータ"
-
-#: pcbnew/footprint_wizard_frame.cpp:152
-#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:35
-#: pcbnew/dialogs/dialog_set_grid_base.cpp:27
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:33
-#: common/draw_frame.cpp:489
-msgid "Units"
-msgstr "単位"
-
-#: pcbnew/footprint_wizard_frame.cpp:536 pcbnew/modview_frame.cpp:649
-#, c-format
-msgid "ModView: 3D Viewer [%s]"
-msgstr "ModView: 3Dビューア [%s]"
-
-#: pcbnew/footprint_wizard_frame.cpp:562
-msgid "Select wizard to use"
-msgstr "参照するウィザードの選択"
-
-#: pcbnew/footprint_wizard_frame.cpp:567
-msgid "Select previous editable item"
-msgstr "前の編集可能アイテムを選択"
-
-#: pcbnew/footprint_wizard_frame.cpp:571
-msgid "Select next editable item"
-msgstr "次の編集可能アイテムを選択"
-
-#: pcbnew/footprint_wizard_frame.cpp:576 pcbnew/menubar_modedit.cpp:237
-#: pcbnew/tool_modview.cpp:76 pcbnew/tool_modview.cpp:178
-msgid "Show footprint in 3D viewer"
-msgstr "フットプリントを3Dビューアで表示"
-
-#: pcbnew/footprint_wizard_frame.cpp:579 pcbnew/tool_modedit.cpp:123
-#: pcbnew/tool_modview.cpp:79 eeschema/tool_viewlib.cpp:75
-#: gerbview/toolbars_gerber.cpp:77 common/zoom.cpp:248
-#: 3d-viewer/3d_toolbar.cpp:68 pagelayout_editor/toolbars_pl_editor.cpp:78
-#: pcbnew/help_common_strings.h:19 eeschema/help_common_strings.h:43
-msgid "Zoom in"
-msgstr "ズーム イン"
-
-#: pcbnew/footprint_wizard_frame.cpp:584 pcbnew/tool_modedit.cpp:126
-#: pcbnew/tool_modview.cpp:84 eeschema/tool_viewlib.cpp:80
-#: gerbview/toolbars_gerber.cpp:80 common/zoom.cpp:250
-#: 3d-viewer/3d_toolbar.cpp:71 pagelayout_editor/toolbars_pl_editor.cpp:81
-#: pcbnew/help_common_strings.h:20 eeschema/help_common_strings.h:44
-msgid "Zoom out"
-msgstr "ズーム アウト"
-
-#: pcbnew/footprint_wizard_frame.cpp:589 pcbnew/tool_modedit.cpp:129
-#: pcbnew/tool_modview.cpp:89 eeschema/tool_viewlib.cpp:85
-#: gerbview/toolbars_gerber.cpp:83 common/zoom.cpp:252
-#: 3d-viewer/3d_toolbar.cpp:75 pagelayout_editor/toolbars_pl_editor.cpp:84
-msgid "Redraw view"
-msgstr "ビューの再描画"
-
-#: pcbnew/footprint_wizard_frame.cpp:594 pcbnew/tool_modedit.cpp:133
-#: pcbnew/tool_modview.cpp:94 eeschema/tool_viewlib.cpp:90
-#: gerbview/toolbars_gerber.cpp:86 common/zoom.cpp:254
-#: pagelayout_editor/toolbars_pl_editor.cpp:87
-msgid "Zoom auto"
-msgstr "自動ズーム"
-
-#: pcbnew/footprint_wizard_frame.cpp:605
-msgid "Add footprint to board"
-msgstr "ボードへフットプリントを挿入"
-
-#: pcbnew/gpcb_plugin.cpp:85
-#, c-format
-msgid "Cannot convert \"%s\" to an integer"
-msgstr "\"%s\" を整数に変換できません"
-
-#: pcbnew/gpcb_plugin.cpp:269 pcbnew/gpcb_plugin.cpp:905
-#: pcbnew/kicad_plugin.cpp:1757
-#, c-format
-msgid "footprint library path '%s' does not exist"
-msgstr "フットプリントライブラリのパス '%s' は存在しません"
-
-#: pcbnew/gpcb_plugin.cpp:309
-#, c-format
-msgid "library <%s> has no footprint '%s' to delete"
-msgstr "ライブラリ <%s> には削除するフットプリント '%s' がありません"
-
-#: pcbnew/gpcb_plugin.cpp:411 pcbnew/pcb_parser.cpp:405
-#: pcbnew/pcb_parser.cpp:494
-#, c-format
-msgid "unknown token \"%s\""
-msgstr "未知のトークン \"%s\""
-
-#: pcbnew/gpcb_plugin.cpp:418
-#, c-format
-msgid "Element token contains %d parameters."
-msgstr "要素は%dのパラメータを持っています。"
-
-#: pcbnew/gpcb_plugin.cpp:973 pcbnew/kicad_plugin.cpp:1830
-#: pcbnew/kicad_plugin.cpp:1895 pcbnew/legacy_plugin.cpp:4648
-#: pcbnew/legacy_plugin.cpp:4693 pcbnew/librairi.cpp:493
-#, c-format
-msgid "Library '%s' is read only"
-msgstr "ライブラリ '%s' は読み込み専用です。"
-
-#: pcbnew/gpcb_plugin.cpp:992 pcbnew/kicad_plugin.cpp:1932
-#, c-format
-msgid "user does not have permission to delete directory '%s'"
-msgstr "現在のユーザは、ディレクトリ '%s' を削除する権限がありません"
-
-#: pcbnew/gpcb_plugin.cpp:1000 pcbnew/kicad_plugin.cpp:1940
-#, c-format
-msgid "library directory '%s' has unexpected sub-directories"
-msgstr ""
-"ライブラリのディレクトリ <%s> が予期しないサブディレクトリを含んでいます"
-
-#: pcbnew/gpcb_plugin.cpp:1019 pcbnew/kicad_plugin.cpp:1959
-#, c-format
-msgid "unexpected file '%s' was found in library path '%s'"
-msgstr "不正なファイル '%s' がライブラリパス '%s'から見つかりました"
-
-#: pcbnew/gpcb_plugin.cpp:1037 pcbnew/kicad_plugin.cpp:1977
-#, c-format
-msgid "footprint library '%s' cannot be deleted"
-msgstr "フットプリントライブラリ '%s' は削除できません"
-
-#: pcbnew/highlight.cpp:56
-msgid "Filter Net Names"
-msgstr "ネット名のフィルター"
-
-#: pcbnew/highlight.cpp:56
-msgid "Net Filter"
-msgstr "ネット フィルター"
-
-#: pcbnew/highlight.cpp:79
-msgid "Select Net"
-msgstr "ネットの選択"
-
-#: pcbnew/hotkeys_board_editor.cpp:63
-#, c-format
-msgid "Recording macro %d"
-msgstr "マクロの記録中 %d"
-
-#: pcbnew/hotkeys_board_editor.cpp:70
-#, c-format
-msgid "Macro %d recorded"
-msgstr "マクロ %d が記録されました"
-
-#: pcbnew/hotkeys_board_editor.cpp:82
-#, c-format
-msgid "Call macro %d"
-msgstr "マクロ %d の呼び出し"
-
-#: pcbnew/hotkeys_board_editor.cpp:160
-#, c-format
-msgid "Add key [%c] in macro %d"
-msgstr "[%c] キーをマクロ %d に追加"
-
-#: pcbnew/initpcb.cpp:47
-msgid ""
-"Current Board will be lost and this operation cannot be undone. Continue ?"
-msgstr "現在のボードは失われます、この操作はやり直しできません。 続けますか？"
-
-#: pcbnew/initpcb.cpp:101 pcbnew/modedit.cpp:340
-msgid ""
-"Current Footprint will be lost and this operation cannot be undone. "
-"Continue ?"
-msgstr ""
-"現在のフットプリントは失われます、この操作はやり直しできません。 続けますか？"
-
-#: pcbnew/io_mgr.cpp:42 pcbnew/plugin.cpp:27
-#, c-format
-msgid "Plugin '%s' does not implement the '%s' function."
-msgstr "'%s' プラグインには '%s' 機能はありません．"
-
-#: pcbnew/io_mgr.cpp:43
-#, c-format
-msgid "Plugin type '%s' is not found."
-msgstr "プラグインタイプ \"%s\" が見つかりません。"
-
-#: pcbnew/io_mgr.cpp:126
-#, c-format
-msgid "Unknown PCB_FILE_T value: %d"
-msgstr "未知の PCB_FILE_T の値: %d"
-
-#: pcbnew/kicad_netlist_reader.cpp:255
-#, c-format
-msgid "Cannot find component with reference \"%s\" in netlist."
-msgstr ""
-"リファレンス \"%s\" のコンポーネントは、ネットリストから見つかりませんでし"
-"た。"
-
-#: pcbnew/kicad_netlist_reader.cpp:372 pcbnew/pcb_parser.cpp:1673
-#, c-format
-msgid ""
-"invalid PFID in\n"
-"file: <%s>\n"
-"line: %d\n"
-"offset: %d"
-msgstr ""
-"不正なPFIDが見つかりました: \n"
-"ファイル:<%s>\n"
-"%d行目\n"
-"%d文字目"
-
-#: pcbnew/kicad_plugin.cpp:215
-#, c-format
-msgid "Cannot create footprint library path '%s'"
-msgstr "フットプリントライブラリのパス '%s' が生成できません。"
-
-#: pcbnew/kicad_plugin.cpp:221
-#, c-format
-msgid "Footprint library path '%s' is read only"
-msgstr "フットプリントライブラリパス '%s' は読み込み専用です"
-
-#: pcbnew/kicad_plugin.cpp:260
-#, c-format
-msgid "Cannot rename temporary file '%s' to footprint library file '%s'"
-msgstr ""
-"一時ファイル '%s' をフットプリントライブラリ '%s' へファイル名変更できませ"
-"ん。"
-
-#: pcbnew/kicad_plugin.cpp:280
-#, c-format
-msgid "Footprint library path '%s' does not exist"
-msgstr "フットプリントライブラリのパス '%s' は存在しません"
-
-#: pcbnew/kicad_plugin.cpp:327 pcbnew/legacy_plugin.cpp:4703
-#, c-format
-msgid "library '%s' has no footprint '%s' to delete"
-msgstr "ライブラリ '%s' には削除するフットプリント '%s' がありません"
-
-#: pcbnew/kicad_plugin.cpp:1234 pcbnew/legacy_plugin.cpp:98
-#, c-format
-msgid "unknown pad type: %d"
-msgstr "未知のパッド形状です: %d"
-
-#: pcbnew/kicad_plugin.cpp:1247 pcbnew/legacy_plugin.cpp:99
-#, c-format
-msgid "unknown pad attribute: %d"
-msgstr "未知のパッド属性です: %d"
-
-#: pcbnew/kicad_plugin.cpp:1429
-#, c-format
-msgid "unknown via type %d"
-msgstr "未知のビア形状です: %d"
-
-#: pcbnew/kicad_plugin.cpp:1560
-#, c-format
-msgid "unknown zone corner smoothing type %d"
-msgstr "未知のゾーンの角の平滑化タイプ %d "
-
-#: pcbnew/kicad_plugin.cpp:1846
-#, c-format
-msgid "Footprint file name '%s' is not valid."
-msgstr "不正なフットプリントファイル名です '%s' 。"
-
-#: pcbnew/kicad_plugin.cpp:1852
-#, c-format
-msgid "user does not have write permission to delete file '%s' "
-msgstr "現在のユーザは '%s' を削除するための書き込み権限がありません"
-
-#: pcbnew/kicad_plugin.cpp:1907
-#, c-format
-msgid "cannot overwrite library path '%s'"
-msgstr "ライブラリパス '%s' は上書きできません"
-
-#: pcbnew/layer_widget.cpp:432
-msgid ""
-"Left click to select, middle click for color change, right click for menu"
-msgstr "左クリックで選択, 中クリックで色の変更, 右クリックでメニュー"
-
-#: pcbnew/layer_widget.cpp:440
-msgid "Enable this for visibility"
-msgstr "表示する"
-
-#: pcbnew/layer_widget.cpp:467
-msgid "Middle click for color change"
-msgstr "中クリックで色の変更"
-
-#: pcbnew/legacy_netlist_reader.cpp:121
-msgid "Cannot parse time stamp in component section of netlist."
-msgstr ""
-"ネットリスト中のコンポーネント情報内のタイムスタンプを解釈することが出来ませ"
-"んでした。"
-
-#: pcbnew/legacy_netlist_reader.cpp:131
-msgid "Cannot parse footprint name in component section of netlist."
-msgstr ""
-"ネットリスト中のコンポーネント情報内のフットプリント名を解釈することが出来ま"
-"せんでした。"
-
-#: pcbnew/legacy_netlist_reader.cpp:145
-msgid "Cannot parse reference designator in component section of netlist."
-msgstr ""
-"ネットリスト中のコンポーネント情報内のリファレンス情報を解釈することが出来ま"
-"せんでした。"
-
-#: pcbnew/legacy_netlist_reader.cpp:155
-msgid "Cannot parse value in component section of netlist."
-msgstr ""
-"ネットリスト中のコンポーネント情報内の定数を解釈することが出来ませんでした。"
-
-#: pcbnew/legacy_netlist_reader.cpp:192
-msgid "Cannot parse pin name in component net section of netlist."
-msgstr ""
-"ネットリスト中のコンポーネント情報内のピン名を解釈することが出来ませんでし"
-"た。"
-
-#: pcbnew/legacy_netlist_reader.cpp:201
-msgid "Cannot parse net name in component net section of netlist."
-msgstr ""
-"ネットリスト中のコンポーネント情報内のネット名を解釈することが出来ませんでし"
-"た。"
-
-#: pcbnew/legacy_netlist_reader.cpp:249
-#, c-format
-msgid "Cannot find component '%s' in footprint filter section of netlist."
-msgstr ""
-"コンポーネント '%s' はネットリストのフットプリント情報から見つかりませんでし"
-"た。"
-
-#: pcbnew/legacy_plugin.cpp:96
-#, c-format
-msgid ""
-"File '%s' is format version: %d.\n"
-"I only support format version <= %d.\n"
-"Please upgrade Pcbnew to load this file."
-msgstr ""
-"ファイル '%s' のフォーマットバージョン: %d\n"
-"このプログラムでは、%d 以下のフォーマットバージョンしかサポートしていません。"
-"新しいバージョンの Pcbnew を取得し、ロードし直してください。"
-
-#: pcbnew/legacy_plugin.cpp:97
-#, c-format
-msgid "unknown graphic type: %d"
-msgstr "未知のグラフィックタイプ: %d"
-
-#: pcbnew/legacy_plugin.cpp:761
-#, c-format
-msgid "Unknown sheet type '%s' on line:%d"
-msgstr "未知のシートタイプ \"%s\" : %d 行目"
-
-#: pcbnew/legacy_plugin.cpp:1457
-#, c-format
-msgid "Unknown padshape '%c=0x%02x' on line: %d of module: '%s'"
-msgstr "未知のパッド形状 '%c=0x%02x' %d 行目 (モジュール '%s')"
-
-#: pcbnew/legacy_plugin.cpp:2506
-#, c-format
-msgid "duplicate NETCLASS name '%s'"
-msgstr "重複したネットクラス名 '%s'"
-
-#: pcbnew/legacy_plugin.cpp:3033 pcbnew/legacy_plugin.cpp:3070
-#, c-format
-msgid ""
-"invalid float number in file: '%s'\n"
-"line: %d, offset: %d"
-msgstr ""
-"不正な浮動小数点数値が見つかりました: '%s' \n"
-"%d行目, %d文字目"
-
-#: pcbnew/legacy_plugin.cpp:3042 pcbnew/legacy_plugin.cpp:3078
-#, c-format
-msgid ""
-"missing float number in file: '%s'\n"
-"line: %d, offset: %d"
-msgstr ""
-"不正な浮動小数点数値が見つかりました: '%s' \n"
-"行番号: %d, 位置: %d"
-
-#: pcbnew/legacy_plugin.cpp:3243
-#, c-format
-msgid "Unable to open file '%s'"
-msgstr "ファイル '%s' が開けません"
-
-#: pcbnew/legacy_plugin.cpp:3268 common/richio.cpp:588
-#, c-format
-msgid "error writing to file '%s'"
-msgstr "'%s' ファイルの書き込み中のエラー"
-
-#: pcbnew/legacy_plugin.cpp:4350
-#, c-format
-msgid "File '%s' is empty or is not a legacy library"
-msgstr "ファイル \"%s\" は空であるか、古い形式のライブラリです"
-
-#: pcbnew/legacy_plugin.cpp:4488
-#, c-format
-msgid "Legacy library file '%s' is read only"
-msgstr "レガシーライブラリファイル '%s' は読み込み専用です"
-
-#: pcbnew/legacy_plugin.cpp:4507
-#, c-format
-msgid "Unable to open or create legacy library file '%s'"
-msgstr ""
-"レガシーフォーマットのライブラリファイル '%s' を読み込み/保存できませんでした"
-
-#: pcbnew/legacy_plugin.cpp:4533
-#, c-format
-msgid "Unable to rename tempfile '%s' to library file '%s'"
-msgstr ""
-"一時ファイル '%s' をライブラリファイル '%s' へファイル名の変更ができませんで"
-"した"
-
-#: pcbnew/legacy_plugin.cpp:4716
-#, c-format
-msgid "library '%s' already exists, will not create a new"
-msgstr "ライブラリ '%s' は既に存在します。新規作成できません。"
-
-#: pcbnew/legacy_plugin.cpp:4745
-#, c-format
-msgid "library '%s' cannot be deleted"
-msgstr "ライブラリ '%s' が削除できませんでした"
-
-#: pcbnew/librairi.cpp:59
-#, c-format
-msgid "Library '%s' exists, OK to replace ?"
-msgstr "ライブラリ '%s' は既に存在します。置換してよろしいですか？"
-
-#: pcbnew/librairi.cpp:60
-msgid "Create New Library Folder (the .pretty folder is the library)"
-msgstr "新しくライブラリのフォルダ (.prettyフォルダはライブラリ) を作成"
-
-#: pcbnew/librairi.cpp:61
-#, c-format
-msgid "OK to delete module %s in library '%s'"
-msgstr "モジュール '%s' をライブラリ '%s' から削除します、宜しいですか？"
-
-#: pcbnew/librairi.cpp:62
-msgid "Import Footprint"
-msgstr "フットプリントのインポート"
-
-#: pcbnew/librairi.cpp:63
-#, c-format
-msgid "File '%s' not found"
-msgstr "ファイル '%s' が見つかりません"
-
-#: pcbnew/librairi.cpp:64
-msgid "Not a footprint file"
-msgstr "フットプリントファイルではありません"
-
-#: pcbnew/librairi.cpp:65
-#, c-format
-msgid "Unable to find or load footprint %s from lib path '%s'"
-msgstr ""
-"フットプリント %s をライブラリパス '%s' から見つけることが出来ませんでした"
-
-#: pcbnew/librairi.cpp:66
-#, c-format
-msgid "Unable to find or load footprint from path '%s'"
-msgstr "フットプリントを '%s' からロードすることができませんでした"
-
-#: pcbnew/librairi.cpp:67
-#, c-format
-msgid ""
-"The footprint library '%s' could not be found in any of the search paths."
-msgstr "フットプリントライブラリ <%s> はデフォルト検索パス内に存在しません。"
-
-#: pcbnew/librairi.cpp:68
-#, c-format
-msgid "Library '%s' is read only, not writable"
-msgstr "ライブラリ '%s' は読み込み専用です。"
-
-#: pcbnew/librairi.cpp:70
-msgid "Export Footprint"
-msgstr "フットプリントのエクスポート"
-
-#: pcbnew/librairi.cpp:71
-msgid "Save Footprint"
-msgstr "フットプリントの保存"
-
-#: pcbnew/librairi.cpp:72
-msgid "Enter footprint name:"
-msgstr "フットプリント名:"
-
-#: pcbnew/librairi.cpp:73
-#, c-format
-msgid "Footprint exported to file '%s'"
-msgstr "フットプリントを '%s' へ出力しました"
-
-#: pcbnew/librairi.cpp:74
-#, c-format
-msgid "Footprint %s deleted from library '%s'"
-msgstr "フットプリント %s をライブラリ '%s' から削除しました"
-
-#: pcbnew/librairi.cpp:75
-msgid "New Footprint"
-msgstr "新規フットプリント"
-
-#: pcbnew/librairi.cpp:77
-msgid "No footprints to archive!"
-msgstr "アーカイブにフットプリントがありません！"
-
-#: pcbnew/librairi.cpp:78
-#, c-format
-msgid "Footprint %s already exists in library '%s'"
-msgstr "フットプリント %s は既にライブラリ %s 内に既に存在します。"
-
-#: pcbnew/librairi.cpp:79
-msgid "No footprint name defined."
-msgstr "フットプリント名が定義されていません。"
-
-#: pcbnew/librairi.cpp:80 eeschema/selpart.cpp:89
-msgid "Select Library"
-msgstr "ライブラリの選択"
-
-#: pcbnew/librairi.cpp:83
-msgid ""
-"Writing/modifying legacy libraries (.mod files) is not allowed\n"
-"Please save the current library to the new .pretty format\n"
-"and update your footprint lib table\n"
-"to save your footprint (a .kicad_mod file) in the .pretty library folder"
-msgstr ""
-"旧式のライブラリ (.mod ファイル) を作成したり編集したりすることはできませ"
-"ん．\n"
-"現在のライブラリを新しい .pretty フォーマットで保存して，\n"
-"フットプリント lib テーブルを更新するために，\n"
-"フットプリント (.kicad_mod ファイル) を .pretty ライブラリフォルダの中で保存"
-"してください．"
-
-#: pcbnew/librairi.cpp:89
-msgid ""
-"Modifying legacy libraries (.mod files) is not allowed\n"
-"Please save the current library under the new .pretty format\n"
-"and update your footprint lib table\n"
-"before deleting a footprint"
-msgstr ""
-"旧式のライブラリ (.mod ファイル) を編集することはできません．\n"
-"フットプリントを削除する前に，\n"
-"現在のライブラリを新しい .pretty フォーマットで保存して，\n"
-"フットプリント lib テーブルを更新してください．"
-
-#: pcbnew/librairi.cpp:94
-msgid "Legacy foot print export files (*.emp)|*.emp"
-msgstr "レガシー フットプリント ファイル (*.emp)|*.emp"
-
-#: pcbnew/librairi.cpp:95
-msgid "GPcb foot print files (*)|*"
-msgstr "GPcb フットプリント ファイル (*)|*"
-
-#: pcbnew/librairi.cpp:624 eeschema/dialogs/dialog_bom_base.cpp:44
-#: eeschema/dialogs/dialog_netlist_base.cpp:115
-#: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.cpp:28
-#: common/dialogs/dialog_get_component_base.cpp:22
-msgid "Name:"
-msgstr "名前:"
-
-#: pcbnew/librairi.cpp:639
-#, c-format
-msgid ""
-"Error:\n"
-"one of invalid chars '%s' found\n"
-"in '%s'"
-msgstr ""
-"エラー: \n"
-"不正な文字 '%s' が見つかりました。\n"
-"('%s')"
-
-#: pcbnew/librairi.cpp:700
-#, c-format
-msgid "Component [%s] replaced in '%s'"
-msgstr "コンポーネント [%s] を <%s> に置き換えました"
-
-#: pcbnew/librairi.cpp:701
-#, c-format
-msgid "Component [%s] added in  '%s'"
-msgstr "コンポーネント [%s] を <%s> に追加しました"
-
-#: pcbnew/librairi.cpp:790 pcbnew/dialogs/dialog_fp_lib_table.cpp:204
-msgid "Nickname"
-msgstr "別名(ニックネーム)"
-
-#: pcbnew/librairi.cpp:791
-#: pcbnew/dialogs/dialog_footprint_wizard_list_base.cpp:35
-#: pcbnew/dialogs/dialog_fp_lib_table.cpp:210 eeschema/libedit.cpp:508
-#: eeschema/sch_component.cpp:1539 eeschema/viewlibs.cpp:308
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:117
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:163
-#: common/dialog_about/AboutDialog_main.cpp:130
-msgid "Description"
-msgstr "説明"
-
-#: pcbnew/loadcmp.cpp:175
-msgid "Load Footprint"
-msgstr "フットプリントの読み込み"
-
-#: pcbnew/loadcmp.cpp:386
-#, c-format
-msgid ""
-"No footprints could be read from library file(s):\n"
-"\n"
-"%s\n"
-"in any of the library search paths.  Verify your system is configured "
-"properly so the footprint libraries can be found."
-msgstr ""
-"ライブラリファイル中からフットプリントが見つかりませんでした：\n"
-"\n"
-"%s \n"
-"ライブラリの検索パス．フットプリントライブラリのパスがシステムで正しく設定さ"
-"れていることを確認してください．"
-
-#: pcbnew/loadcmp.cpp:437 pcbnew/dialogs/wizard_add_fplib_base.cpp:185
-#: eeschema/sch_component.cpp:1528
-msgid "Library"
-msgstr "ライブラリ"
-
-#: pcbnew/loadcmp.cpp:439
-#, c-format
-msgid "Footprints [%d items]"
-msgstr "フットプリント一覧 [%d のアイテム]"
-
-#: pcbnew/loadcmp.cpp:456
-msgid "No footprint found."
-msgstr "フットプリントが見つかりません。"
-
-#: pcbnew/loadcmp.cpp:479 cvpcb/cvframe.cpp:636
-msgid "Description: "
-msgstr "説明:"
-
-#: pcbnew/loadcmp.cpp:480
-msgid ""
-"\n"
-"Key words: "
-msgstr ""
-"\n"
-"キーワード:"
-
-#: pcbnew/loadcmp.cpp:496
-#, c-format
-msgid "Modules [%d items]"
-msgstr "モジュール [%d アイテム]"
-
-#: pcbnew/loadcmp.cpp:500
-msgid "Module"
-msgstr "モジュール"
-
-#: pcbnew/loadcmp.cpp:560
-#, c-format
-msgid "Footprint '%s' saved"
-msgstr "フットプリント '%s' を保存しました"
-
-#: pcbnew/loadcmp.cpp:574
-#, c-format
-msgid "Footprint library '%s' saved as '%s'."
-msgstr "フットプリントライブラリ '%s' を '%s' へ保存しました。"
-
-#: pcbnew/menubar_modedit.cpp:67
-msgid "Set Acti&ve Library"
-msgstr "アクティブなライブラリの設定(&V)"
-
-#: pcbnew/menubar_modedit.cpp:68 pcbnew/tool_modedit.cpp:55
-msgid "Select active library"
-msgstr "アクティブなライブラリを選択してください"
-
-#: pcbnew/menubar_modedit.cpp:74
-msgid "&New Footprint"
-msgstr "新規フットプリント(&N)"
-
-#: pcbnew/menubar_modedit.cpp:74
-msgid "Create new footprint"
-msgstr "新規フットプリントを作成"
-
-#: pcbnew/menubar_modedit.cpp:82
-msgid "&Import Footprint From File"
-msgstr "ファイルからフットプリントのインポート(&I)"
-
-#: pcbnew/menubar_modedit.cpp:83
-msgid "Import footprint from an existing file"
-msgstr "既存のファイルからフットプリントをインポート"
-
-#: pcbnew/menubar_modedit.cpp:88
-msgid "Load Footprint From Current Li&brary"
-msgstr "現在のライブラリからフットプリントを読み込み(&B)"
-
-#: pcbnew/menubar_modedit.cpp:89
-msgid "Open a footprint from library"
-msgstr "ライブラリからフットプリントを開く"
-
-#: pcbnew/menubar_modedit.cpp:94
-msgid "Load Footprint From &Current Board"
-msgstr "現在のボードからフットプリントを読み込む(&C)"
-
-#: pcbnew/menubar_modedit.cpp:95
-msgid "Load a footprint from the current board"
-msgstr "現在のボードからフットプリントを読み込む"
-
-#: pcbnew/menubar_modedit.cpp:100
-msgid "&Load Footprint"
-msgstr "フットプリントの読み出し(&L)"
-
-#: pcbnew/menubar_modedit.cpp:101
-msgid "Load footprint"
-msgstr "フットプリントの読み出し"
-
-#: pcbnew/menubar_modedit.cpp:107
-msgid "Save &Current Library As..."
-msgstr "現在のライブラリを名前をつけて保存(&C)"
-
-#: pcbnew/menubar_modedit.cpp:108
-msgid "Save entire current library under a new name."
-msgstr "現在のライブラリ全体を新規保存"
-
-#: pcbnew/menubar_modedit.cpp:112
-msgid "&Save Footprint in Active Library"
-msgstr "アクティブなライブラリにフットプリントを保存(&S)"
-
-#: pcbnew/menubar_modedit.cpp:116 pcbnew/tool_modedit.cpp:58
-msgid "Save footprint in active library"
-msgstr "アクティブなライブラリへフットプリントを保存"
-
-#: pcbnew/menubar_modedit.cpp:121
-msgid "S&ave Footprint in New Library"
-msgstr "フットプリントを新規ライブラリへ保存(&A)"
-
-#: pcbnew/menubar_modedit.cpp:122
-msgid "Create a new library and save current module into it"
-msgstr "新規ライブラリを作成して現在のモジュールを保存"
-
-#: pcbnew/menubar_modedit.cpp:127
-msgid "&Export Footprint"
-msgstr "フットプリントのエクスポート(&E)"
-
-#: pcbnew/menubar_modedit.cpp:128
-msgid "Save currently loaded footprint into file"
-msgstr "現在ロードされているフットプリントをファイルに保存"
-
-#: pcbnew/menubar_modedit.cpp:133
-msgid "&Import DXF File"
-msgstr "DXFファイルのインポート(&I)"
-
-#: pcbnew/menubar_modedit.cpp:134 pcbnew/menubar_pcbframe.cpp:196
-msgid "Import a 2D Drawing DXF file to Pcbnew on the Drawings layer"
-msgstr "2D図面を Pcbnew の図面描画レイヤ上へインポートする"
-
-#: pcbnew/menubar_modedit.cpp:141 pcbnew/menubar_pcbframe.cpp:237
-#: gerbview/menubar.cpp:135 pagelayout_editor/menubar.cpp:101
-msgid "&Print"
-msgstr "印刷(&P)"
-
-#: pcbnew/menubar_modedit.cpp:142
-msgid "Print current footprint"
-msgstr "現在のフットプリントを印刷"
-
-#: pcbnew/menubar_modedit.cpp:150 pcbnew/tool_modview.cpp:150
-#: eeschema/tool_viewlib.cpp:218
-msgid "Cl&ose"
-msgstr "閉じる(&O)"
-
-#: pcbnew/menubar_modedit.cpp:151
-msgid "Close footprint editor"
-msgstr "フットプリントエディタを閉じる"
-
-#: pcbnew/menubar_modedit.cpp:158 pcbnew/menubar_pcbframe.cpp:277
-#: eeschema/menubar.cpp:178 eeschema/menubar_libedit.cpp:118
-msgid "&Undo"
-msgstr "元に戻す(&U)"
-
-#: pcbnew/menubar_modedit.cpp:160
-msgid "Undo last action"
-msgstr "一つ前の編集を元に戻す"
-
-#: pcbnew/menubar_modedit.cpp:164 pcbnew/menubar_pcbframe.cpp:280
-#: eeschema/menubar.cpp:183 eeschema/menubar_libedit.cpp:127
-msgid "&Redo"
-msgstr "やり直し(&R)"
-
-#: pcbnew/menubar_modedit.cpp:166
-msgid "Redo last action"
-msgstr "一つ前のコマンドをやり直し"
-
-#: pcbnew/menubar_modedit.cpp:171 pcbnew/menubar_pcbframe.cpp:284
-#: eeschema/menubar.cpp:190 eeschema/menubar_libedit.cpp:140
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:265
-msgid "&Delete"
-msgstr "削除(&D)"
-
-#: pcbnew/menubar_modedit.cpp:171
-msgid "Delete objects with eraser"
-msgstr "消しゴムでオブジェクトを削除"
-
-#: pcbnew/menubar_modedit.cpp:179
-msgid "Edit &Properties"
-msgstr "プロパティ(&P)"
-
-#: pcbnew/menubar_modedit.cpp:180
-msgid "Edit footprint properties"
-msgstr "フットプリント プロパティの編集"
-
-#: pcbnew/menubar_modedit.cpp:188
-msgid "&User Grid Size"
-msgstr "ユーザ グリッドのサイズ(&U)"
-
-#: pcbnew/menubar_modedit.cpp:188
-msgid "Adjust user grid"
-msgstr "ユーザ グリッドに合わせる"
-
-#: pcbnew/menubar_modedit.cpp:193
-msgid "&Size and Width"
-msgstr "サイズと幅(&S)"
-
-#: pcbnew/menubar_modedit.cpp:194
-msgid "Adjust width for texts and drawings"
-msgstr "テキストと図形の幅をアジャスト"
-
-#: pcbnew/menubar_modedit.cpp:199
-msgid "&Pad Setting"
-msgstr "パッドの設定(&P)"
-
-#: pcbnew/menubar_modedit.cpp:199
-msgid "Edit settings for new pads"
-msgstr "新規パッドの設定を編集"
-
-#: pcbnew/menubar_modedit.cpp:216 pcbnew/menubar_pcbframe.cpp:328
-#: pcbnew/tool_modview.cpp:157 eeschema/menubar.cpp:229
-#: eeschema/menubar_libedit.cpp:161 eeschema/tool_viewlib.cpp:225
-msgid "Zoom &In"
-msgstr "ズーム イン(&I)"
-
-#: pcbnew/menubar_modedit.cpp:220 pcbnew/menubar_pcbframe.cpp:332
-#: pcbnew/tool_modview.cpp:161 eeschema/menubar.cpp:233
-#: eeschema/menubar_libedit.cpp:165 eeschema/tool_viewlib.cpp:229
-msgid "Zoom &Out"
-msgstr "ズーム アウト(&O)"
-
-#: pcbnew/menubar_modedit.cpp:224 pcbnew/menubar_pcbframe.cpp:336
-#: pcbnew/tool_modview.cpp:165 eeschema/menubar.cpp:237
-#: eeschema/menubar_libedit.cpp:169 eeschema/tool_viewlib.cpp:233
-msgid "&Fit on Screen"
-msgstr "スクリーンにフィット(&F)"
-
-#: pcbnew/menubar_modedit.cpp:229 pcbnew/menubar_pcbframe.cpp:341
-#: pcbnew/tool_modview.cpp:170 eeschema/menubar.cpp:241
-#: eeschema/menubar_libedit.cpp:176 eeschema/tool_viewlib.cpp:238
-msgid "&Redraw"
-msgstr "再描画(&R)"
-
-#: pcbnew/menubar_modedit.cpp:236 pcbnew/menubar_pcbframe.cpp:347
-msgid "&3D Viewer"
-msgstr "3Dビューア(&3)"
-
-#: pcbnew/menubar_modedit.cpp:243 pcbnew/menubar_pcbframe.cpp:358
-msgid "&Switch canvas to default"
-msgstr "キャンバスを標準へ切り替え(&S)"
-
-#: pcbnew/menubar_modedit.cpp:247 pcbnew/menubar_pcbframe.cpp:362
-msgid "Switch the canvas implementation to default"
-msgstr "描画ライブラリを標準へ切り替え"
-
-#: pcbnew/menubar_modedit.cpp:250 pcbnew/menubar_pcbframe.cpp:365
-msgid "Switch canvas to Open&GL"
-msgstr "描画キャンバスを OpenGL(3D) へ切替(&G)"
-
-#: pcbnew/menubar_modedit.cpp:254 pcbnew/menubar_pcbframe.cpp:369
-msgid "Switch the canvas implementation to OpenGL"
-msgstr "描画キャンバスをOpenGLへ切り替え"
-
-#: pcbnew/menubar_modedit.cpp:257 pcbnew/menubar_pcbframe.cpp:372
-msgid "Switch canvas to &Cairo"
-msgstr "描画キャンバスを Cairo(2D) へ切替(&C)"
-
-#: pcbnew/menubar_modedit.cpp:261 pcbnew/menubar_pcbframe.cpp:376
-msgid "Switch the canvas implementation to Cairo"
-msgstr "描画キャンバスをCairoへ切り替え"
-
-#: pcbnew/menubar_modedit.cpp:269
-msgid "&Pad"
-msgstr "パッド(&P)"
-
-#: pcbnew/menubar_modedit.cpp:269 pcbnew/modedit.cpp:962
-msgid "Add pad"
-msgstr "パッドの追加"
-
-#: pcbnew/menubar_modedit.cpp:276 pcbnew/menubar_pcbframe.cpp:406
-#: eeschema/menubar_libedit.cpp:206
-msgid "&Circle"
-msgstr "円(&C)"
-
-#: pcbnew/menubar_modedit.cpp:281 pcbnew/menubar_pcbframe.cpp:410
-#: eeschema/menubar_libedit.cpp:220
-msgid "&Line or Polygon"
-msgstr "線 (ポリゴン) (&L)"
-
-#: pcbnew/menubar_modedit.cpp:282 pcbnew/menubar_pcbframe.cpp:411
-#: pcbnew/tool_modedit.cpp:170 pcbnew/tool_pcb.cpp:454
-msgid "Add graphic line or polygon"
-msgstr "図形ライン (またはポリゴン) を入力"
-
-#: pcbnew/menubar_modedit.cpp:287 pcbnew/menubar_pcbframe.cpp:403
-#: eeschema/menubar_libedit.cpp:213
-msgid "&Arc"
-msgstr "円弧(&A)"
-
-#: pcbnew/menubar_modedit.cpp:292
-msgid "&Text"
-msgstr "テキスト(&T)"
-
-#: pcbnew/menubar_modedit.cpp:292
-msgid "Add graphic text"
-msgstr "図形テキスト入力"
-
-#: pcbnew/menubar_modedit.cpp:299
-msgid "A&nchor"
-msgstr "アンカー(&N)"
-
-#: pcbnew/menubar_modedit.cpp:300
-msgid "Place footprint reference anchor"
-msgstr "フットプリントのアンカー (基準点) を配置"
-
-#: pcbnew/menubar_modedit.cpp:308 pcbnew/menubar_pcbframe.cpp:483
-msgid "&Footprint Libraries Wizard"
-msgstr "フットプリント ライブラリ ウィザード(&F)"
-
-#: pcbnew/menubar_modedit.cpp:308 pcbnew/menubar_pcbframe.cpp:483
-msgid "Add footprint libraries with wizard"
-msgstr "ウィザード で フットプリント ライブラリ を追加"
-
-#: pcbnew/menubar_modedit.cpp:312 pcbnew/menubar_pcbframe.cpp:487
-msgid "Footprint Li&braries Manager"
-msgstr "フットプリント ライブラリの管理(&B)"
-
-#: pcbnew/menubar_modedit.cpp:312 pcbnew/menubar_pcbframe.cpp:487
-#: cvpcb/menubar.cpp:83
-msgid "Configure footprint libraries"
-msgstr "フットプリント ライブラリの設定"
-
-#: pcbnew/menubar_modedit.cpp:324
-msgid "&Settings"
-msgstr "設定(&S)"
-
-#: pcbnew/menubar_modedit.cpp:324
-msgid "Select default parameters values in Footprint Editor"
-msgstr "フットプリント エディタでのデフォルト値を選択"
-
-#: pcbnew/menubar_modedit.cpp:341 pcbnew/tool_modview.cpp:189
-msgid "P&cbnew Manual"
-msgstr "Pcbnew マニュアル(&c)"
-
-#: pcbnew/menubar_modedit.cpp:342 pcbnew/tool_modview.cpp:190
-msgid "Open the Pcbnew manual"
-msgstr "Pcbnew のマニュアルを開く"
-
-#: pcbnew/menubar_modedit.cpp:347 pcbnew/menubar_pcbframe.cpp:652
-#: pcbnew/tool_modview.cpp:195 eeschema/menubar_libedit.cpp:270
-#: eeschema/tool_viewlib.cpp:256
-msgid "Open the \"Getting Started in KiCad\" guide for beginners"
-msgstr "チュートリアル\"KiCadを始めよう\"を開く"
-
-#: pcbnew/menubar_modedit.cpp:353 pcbnew/menubar_pcbframe.cpp:657
-#: pcbnew/tool_modview.cpp:201
-msgid "&About Pcbnew"
-msgstr "Pcbnew について(&A)"
-
-#: pcbnew/menubar_modedit.cpp:354 pcbnew/tool_modview.cpp:202
-msgid "About Pcbnew PCB designer"
-msgstr "Pcbnew PCBデザイナーについて"
-
-#: pcbnew/menubar_modedit.cpp:359 pcbnew/menubar_pcbframe.cpp:663
-#: eeschema/menubar.cpp:510 eeschema/menubar_libedit.cpp:284
-msgid "&Edit"
-msgstr "編集(&E)"
-
-#: pcbnew/menubar_modedit.cpp:360 pcbnew/menubar_pcbframe.cpp:664
-#: pcbnew/tool_modview.cpp:208 eeschema/menubar.cpp:511
-#: eeschema/menubar_libedit.cpp:285 eeschema/tool_viewlib.cpp:269
-msgid "&View"
-msgstr "表示(&V)"
-
-#: pcbnew/menubar_modedit.cpp:361 pcbnew/menubar_pcbframe.cpp:665
-#: eeschema/menubar.cpp:512 eeschema/menubar_libedit.cpp:286
-msgid "&Place"
-msgstr "配置(&P)"
-
-#: pcbnew/menubar_modedit.cpp:362 pcbnew/menubar_pcbframe.cpp:667
-#: eeschema/menubar.cpp:513 eeschema/menubar_libedit.cpp:287
-msgid "P&references"
-msgstr "設定(&R)"
-
-#: pcbnew/menubar_modedit.cpp:363
-msgid "Di&mensions"
-msgstr "寸法(&M)"
-
-#: pcbnew/menubar_pcbframe.cpp:68
-msgid "&New"
-msgstr "新規(&N)"
-
-#: pcbnew/menubar_pcbframe.cpp:69
-msgid "Clear current board and initialize a new one"
-msgstr "現在のボードをクリアし，新規ボードに初期化"
-
-#: pcbnew/menubar_pcbframe.cpp:72
-msgid "&Open"
-msgstr "開く(&O)"
-
-#: pcbnew/menubar_pcbframe.cpp:74
-msgid "Delete current board and load new board"
-msgstr "現在のボードを破棄し．新規ボードを読み込む"
-
-#: pcbnew/menubar_pcbframe.cpp:95
-msgid "Open a recent opened board"
-msgstr "最近開いたボードを開く"
-
-#: pcbnew/menubar_pcbframe.cpp:100
-msgid "&Append Board"
-msgstr "ボードを追加(&A)"
-
-#: pcbnew/menubar_pcbframe.cpp:101
-msgid ""
-"Append another Pcbnew board to the current loaded board. Available only when "
-"Pcbnew runs in stand alone mode"
-msgstr ""
-"現在読み込まれているボードに別の Pcbnew ボードを付け加えます。これは Pcbnew "
-"がスタンドアロンモードで起動している時のみ有効です。"
-
-#: pcbnew/menubar_pcbframe.cpp:111
-msgid "Save current board"
-msgstr "現在のボードを保存"
-
-#: pcbnew/menubar_pcbframe.cpp:121
-msgid "Sa&ve As..."
-msgstr "名前をつけて保存...(&V)"
-
-#: pcbnew/menubar_pcbframe.cpp:123
-msgid "Save the current board as..."
-msgstr "現在ボードを名前をつけて保存"
-
-#: pcbnew/menubar_pcbframe.cpp:130
-msgid "Sa&ve Copy As..."
-msgstr "名前をつけて保存...(&V)"
-
-#: pcbnew/menubar_pcbframe.cpp:132
-msgid "Save a copy of the current board as..."
-msgstr "現在のボードを名前をつけて保存"
-
-#: pcbnew/menubar_pcbframe.cpp:139
-msgid "Revert to Las&t"
-msgstr "リカバリバックアップより復帰(&T)"
-
-#: pcbnew/menubar_pcbframe.cpp:140
-msgid "Clear board and get previous backup version of board"
-msgstr "ボードをクリアし，一つ前に保存されたバージョンのボードを取得"
-
-#: pcbnew/menubar_pcbframe.cpp:144
-msgid "Resc&ue"
-msgstr "レスキュー(&U)"
-
-#: pcbnew/menubar_pcbframe.cpp:145
-msgid "Clear board and get last rescue file automatically saved by Pcbnew"
-msgstr "ボードをクリアし，直近のレスキューファイルを取得"
-
-#: pcbnew/menubar_pcbframe.cpp:152
-msgid "Footprint &Position (.pos) File"
-msgstr "フットプリント位置情報ファイル(.pos) (&P)"
-
-#: pcbnew/menubar_pcbframe.cpp:153
-msgid "Generate footprint position file for pick and place"
-msgstr "部品実装用のフットプリント座標ファイルを生成します"
-
-#: pcbnew/menubar_pcbframe.cpp:157
-msgid "&Drill (.drl) File"
-msgstr "ドリル ファイル(.drl) (&D)"
-
-#: pcbnew/menubar_pcbframe.cpp:158
-msgid "Generate excellon2 drill file"
-msgstr "excellon2 ドリル ファイルの生成"
-
-#: pcbnew/menubar_pcbframe.cpp:162
-msgid "&Footprint (.rpt) Report"
-msgstr "フットプリントレポート(.rpt) (&F)"
-
-#: pcbnew/menubar_pcbframe.cpp:163
-msgid "Create a report of all footprints on the current board"
-msgstr "現在のボード中の全てのフットプリントのレポートを作成"
-
-#: pcbnew/menubar_pcbframe.cpp:167
-msgid "IPC-D-356 Netlist File"
-msgstr "IPC-D-356形式ネットリスト ファイル"
-
-#: pcbnew/menubar_pcbframe.cpp:168
-msgid "Generate IPC-D-356 netlist file"
-msgstr "IPC-D-356形式ネットリストの生成"
-
-#: pcbnew/menubar_pcbframe.cpp:172
-msgid "&Component (.cmp) File"
-msgstr "コンポーネント ファイル(.cmp) (&C)"
-
-#: pcbnew/menubar_pcbframe.cpp:173
-msgid "(Re)create components file (*.cmp) for CvPcb"
-msgstr "CvPcb用のコンポーネント ファイル(*.cmp)を(再)作成"
-
-#: pcbnew/menubar_pcbframe.cpp:177
-msgid "&BOM File"
-msgstr "BOM ファイル(&B)"
-
-#: pcbnew/menubar_pcbframe.cpp:178
-msgid "Create a bill of materials from schematic"
-msgstr "回路図からBom(部品表)を作成する"
-
-#: pcbnew/menubar_pcbframe.cpp:182
-msgid "&Fabrication Outputs"
-msgstr "製造用各種ファイル出力(&F)"
-
-#: pcbnew/menubar_pcbframe.cpp:183
-msgid "Generate files for fabrication"
-msgstr "製造用ファイルの生成"
-
-#: pcbnew/menubar_pcbframe.cpp:190
-msgid "&Specctra Session"
-msgstr "Specctra セッション(&S)"
-
-#: pcbnew/menubar_pcbframe.cpp:191
-msgid "Import a routed \"Specctra Session\" (*.ses) file"
-msgstr "配線済みのSpecctra セッション ファイル (*.ses) のインポート"
-
-#: pcbnew/menubar_pcbframe.cpp:195
-msgid "&DXF File"
-msgstr "DXFファイル(&D)"
-
-#: pcbnew/menubar_pcbframe.cpp:200
-msgid "&Import"
-msgstr "インポート(&I)"
-
-#: pcbnew/menubar_pcbframe.cpp:201
-msgid "Import files"
-msgstr "ファイルのインポート"
-
-#: pcbnew/menubar_pcbframe.cpp:208
-msgid "&Specctra DSN"
-msgstr "Specctra DSN ファイル(&S)"
-
-#: pcbnew/menubar_pcbframe.cpp:209
-msgid "Export the current board to a \"Specctra DSN\" file"
-msgstr "現在のボードを \"Specctra DSN\" ファイルへエクスポート"
-
-#: pcbnew/menubar_pcbframe.cpp:213
-msgid "&GenCAD"
-msgstr "GenCAD(&G)"
-
-#: pcbnew/menubar_pcbframe.cpp:213
-msgid "Export GenCAD format"
-msgstr "GenCADフォーマット"
-
-#: pcbnew/menubar_pcbframe.cpp:217
-msgid "&VRML"
-msgstr "VRML(&V)"
-
-#: pcbnew/menubar_pcbframe.cpp:218
-msgid "Export a VRML board representation"
-msgstr "VRMLボード"
-
-#: pcbnew/menubar_pcbframe.cpp:222
-msgid "I&DFv3 Export"
-msgstr "IDFv3 エクスポート(&D)"
-
-#: pcbnew/menubar_pcbframe.cpp:222
-msgid "IDFv3 board and component export"
-msgstr "IDFv3 ボードフォーマットのエクスポート"
-
-#: pcbnew/menubar_pcbframe.cpp:226
-msgid "E&xport"
-msgstr "エクスポート(&X)"
-
-#: pcbnew/menubar_pcbframe.cpp:227
-msgid "Export board"
-msgstr "ボードのエクスポート"
-
-#: pcbnew/menubar_pcbframe.cpp:232
-msgid "Page s&ettings"
-msgstr "ページ設定(&E)"
-
-#: pcbnew/menubar_pcbframe.cpp:233 pcbnew/tool_pcb.cpp:230
-msgid "Page settings for paper size and texts"
-msgstr "ページ設定 (用紙サイズ 及び テキスト)"
-
-#: pcbnew/menubar_pcbframe.cpp:237 pcbnew/tool_pcb.cpp:249
-msgid "Print board"
-msgstr "ボードの印刷"
-
-#: pcbnew/menubar_pcbframe.cpp:241
-msgid "Export SV&G"
-msgstr "SVGファイルのエクスポート(&G)"
-
-#: pcbnew/menubar_pcbframe.cpp:242
-msgid "Export a board file in Scalable Vector Graphics format"
-msgstr "SVG(Scalable Vector Graphics) 形式でエクスポート"
-
-#: pcbnew/menubar_pcbframe.cpp:246
-msgid "P&lot"
-msgstr "プロット(&L)"
-
-#: pcbnew/menubar_pcbframe.cpp:247
-msgid "Plot board in HPGL, PostScript or Gerber RS-274X format)"
-msgstr "ボードをHPGLかPostScript, ガーバー(RS-274Xフォーマット)で出図"
-
-#: pcbnew/menubar_pcbframe.cpp:256
-msgid "&Archive New Footprints"
-msgstr "フットプリントを新規にアーカイブ(&A)"
-
-#: pcbnew/menubar_pcbframe.cpp:257
-msgid ""
-"Archive new footprints only in a library (keep other footprints in this lib)"
-msgstr ""
-"(このライブラリ中の他のフットプリントを維持したまま) ライブラリ中の新規フット"
-"プリントをアーカイブ"
-
-#: pcbnew/menubar_pcbframe.cpp:261
-msgid "&Create Footprint Archive"
-msgstr "フットプリント アーカイブの作成(&C)"
-
-#: pcbnew/menubar_pcbframe.cpp:262
-msgid "Archive all footprints in a library (old library will be deleted)"
-msgstr ""
-"ライブラリ中の全てのフットプリントをアーカイブ (古いライブラリは削除されます)"
-
-#: pcbnew/menubar_pcbframe.cpp:267
-msgid "Arc&hive Footprints"
-msgstr "フットプリントのアーカイブ(&H)"
-
-#: pcbnew/menubar_pcbframe.cpp:268
-msgid "Archive or add footprints in a library file"
-msgstr "ライブラリ ファイル中のフットプリントをアーカイブか追加"
-
-#: pcbnew/menubar_pcbframe.cpp:272
-msgid "Close Pcbnew"
-msgstr "Pcbnew の終了"
-
-#: pcbnew/menubar_pcbframe.cpp:284 pcbnew/tool_modedit.cpp:188
-#: pcbnew/tool_pcb.cpp:474
-msgid "Delete items"
-msgstr "アイテム削除"
-
-#: pcbnew/menubar_pcbframe.cpp:289 eeschema/menubar.cpp:195
-#: eeschema/dialogs/dialog_schematic_find_base.cpp:111
-msgid "&Find"
-msgstr "検索(&F)"
-
-#: pcbnew/menubar_pcbframe.cpp:295
-msgid "&Global Deletions"
-msgstr "広域削除(&G)"
-
-#: pcbnew/menubar_pcbframe.cpp:296
-msgid "Delete tracks, footprints, texts... on board"
-msgstr "ボードの配線・フットプリント・テキストなどを削除"
-
-#: pcbnew/menubar_pcbframe.cpp:300
-msgid "&Cleanup Tracks and Vias"
-msgstr "配線とビアのクリーンアップ(&C)"
-
-#: pcbnew/menubar_pcbframe.cpp:301
-msgid ""
-"Clean stubs, vias, delete break points, or connect dangling tracks to pads "
-"and vias"
-msgstr ""
-"パッドやビアに接続している浮き配線・スタブ・ビア・ブレークポイントをクリア"
-
-#: pcbnew/menubar_pcbframe.cpp:305
-msgid "&Swap Layers"
-msgstr "レイヤの入替え(&S)"
-
-#: pcbnew/menubar_pcbframe.cpp:306
-msgid "Swap tracks on copper layers or drawings on other layers"
-msgstr "配線層や他の図形層をスワップします"
-
-#: pcbnew/menubar_pcbframe.cpp:310
-msgid "&Reset Footprint Field Sizes"
-msgstr "フットプリントフィールドのサイズをリセット(&R)"
-
-#: pcbnew/menubar_pcbframe.cpp:311
-msgid "Reset text size and width of all footprint fields to current defaults"
-msgstr ""
-"全フットプリントの定数の文字サイズ、文字太さを現在のデフォルト値にリセット"
-
-#: pcbnew/menubar_pcbframe.cpp:349
-msgid "Show board in 3D viewer"
-msgstr "ボードを3Dビューアで表示"
-
-#: pcbnew/menubar_pcbframe.cpp:353
-msgid "&List Nets"
-msgstr "ネットの一覧を表示(&L)"
-
-#: pcbnew/menubar_pcbframe.cpp:353
-msgid "View a list of nets with names and id's"
-msgstr "名前とIDでネットのリストを見る"
-
-#: pcbnew/menubar_pcbframe.cpp:382
-msgid "&Footprint"
-msgstr "フットプリント(&F)"
-
-#: pcbnew/menubar_pcbframe.cpp:385 pcbnew/tool_pcb.cpp:440
-msgid "Add footprints"
-msgstr "フットプリントの追加"
-
-#: pcbnew/menubar_pcbframe.cpp:387
-msgid "&Track"
-msgstr "配線(&T)"
-
-#: pcbnew/menubar_pcbframe.cpp:390 pcbnew/tool_pcb.cpp:443
-msgid "Add tracks and vias"
-msgstr "配線とビアの追加"
-
-#: pcbnew/menubar_pcbframe.cpp:393
-msgid "&Zone"
-msgstr "塗りつぶしゾーン(&Z)"
-
-#: pcbnew/menubar_pcbframe.cpp:393 pcbnew/tool_pcb.cpp:446
-msgid "Add filled zones"
-msgstr "塗りつぶしゾーンの追加"
-
-#: pcbnew/menubar_pcbframe.cpp:396
-msgid "&Keepout Area"
-msgstr "キープアウト(禁止)エリア(&K)"
-
-#: pcbnew/menubar_pcbframe.cpp:396 pcbnew/tool_pcb.cpp:450
-msgid "Add keepout areas"
-msgstr "キープアウト(禁止)エリアの追加"
-
-#: pcbnew/menubar_pcbframe.cpp:399
-msgid "Te&xt"
-msgstr "テキスト(&x)"
-
-#: pcbnew/menubar_pcbframe.cpp:399 pcbnew/tool_pcb.cpp:463
-msgid "Add text on copper layers or graphic text"
-msgstr "導体層または図形層にテキスト入力"
-
-#: pcbnew/menubar_pcbframe.cpp:417
-msgid "&Dimension"
-msgstr "寸法線(&D)"
-
-#: pcbnew/menubar_pcbframe.cpp:421
-msgid "La&yer alignment target"
-msgstr "層合わせターゲット(&Y)"
-
-#: pcbnew/menubar_pcbframe.cpp:427
-msgid "Drill and &Place Offset"
-msgstr "ドリルと配置のオフセット(&F)"
-
-#: pcbnew/menubar_pcbframe.cpp:428 pcbnew/tool_pcb.cpp:479
-msgid "Place the origin point for drill and place files"
-msgstr "ドリルファイル、実装ファイル用の原点を設定"
-
-#: pcbnew/menubar_pcbframe.cpp:432
-msgid "&Grid Origin"
-msgstr "グリッド原点(&G)"
-
-#: pcbnew/menubar_pcbframe.cpp:433 pcbnew/tool_modedit.cpp:192
-#: pcbnew/tool_pcb.cpp:484
-msgid "Set the origin point for the grid"
-msgstr "グリッドの原点をセット"
-
-#: pcbnew/menubar_pcbframe.cpp:439
-msgid "&Single Track"
-msgstr "単線(シングル) (&S)"
-
-#: pcbnew/menubar_pcbframe.cpp:440
-msgid "Interactively route a single track"
-msgstr "単線(シングル)のインタラクティブ配線"
-
-#: pcbnew/menubar_pcbframe.cpp:444
-msgid "&Differential Pair"
-msgstr "差動ペア(&D)"
-
-#: pcbnew/menubar_pcbframe.cpp:445
-msgid "Interactively route a differential pair"
-msgstr "差動ペアのインタラクティブ配線"
-
-#: pcbnew/menubar_pcbframe.cpp:451
-msgid "&Tune Track Length"
-msgstr "配線長の調整(&T)"
-
-#: pcbnew/menubar_pcbframe.cpp:452 pcbnew/tools/common_actions.cpp:526
-msgid "Tune length of a single track"
-msgstr "単線の配線長を調整"
-
-#: pcbnew/menubar_pcbframe.cpp:456
-msgid "Tune Differential Pair &Length"
-msgstr "差動ペアの配線長の調整(&L)"
-
-#: pcbnew/menubar_pcbframe.cpp:457 pcbnew/tools/common_actions.cpp:530
-msgid "Tune length of a differential pair"
-msgstr "差動ペア配線の配線長を調整"
-
-#: pcbnew/menubar_pcbframe.cpp:461
-msgid "Tune Differential Pair &Skew/Phase"
-msgstr "差動ペアの遅延/位相の調整(&S)"
-
-#: pcbnew/menubar_pcbframe.cpp:462
-msgid "Tune skew/phase of a differential pair"
-msgstr "差動ペア配線の遅延(スキュー)/位相を調整"
-
-#: pcbnew/menubar_pcbframe.cpp:499
-msgid "&3D Shapes Libraries Downloader"
-msgstr "&3D シェイプ ライブラリ ダウンローダ"
-
-#: pcbnew/menubar_pcbframe.cpp:500
-msgid "Download from Github the 3D shape libraries with wizard"
-msgstr "ウィザードで 3D シェイプ ライブラリを Github からダウンロード"
-
-#: pcbnew/menubar_pcbframe.cpp:507
-msgid "Hide La&yers Manager"
-msgstr "レイヤマネージャを非表示(&Y)"
-
-#: pcbnew/menubar_pcbframe.cpp:507
-msgid "Show La&yers Manager"
-msgstr "レイヤマネージャを表示(&Y)"
-
-#: pcbnew/menubar_pcbframe.cpp:513
-msgid "Hide Microwa&ve Toolbar"
-msgstr "高周波支援設計のツールバーの表示/非表示(&v)"
-
-#: pcbnew/menubar_pcbframe.cpp:513 pcbnew/pcbnew_config.cpp:90
-#: pcbnew/dialogs/dialog_general_options.cpp:232
-msgid "Show Microwave Toolbar"
-msgstr "高周波設計支援ツールバーの表示"
-
-#: pcbnew/menubar_pcbframe.cpp:522
-msgid "&General"
-msgstr "一般設定(&G)"
-
-#: pcbnew/menubar_pcbframe.cpp:522
-msgid "Select general options for Pcbnew"
-msgstr "Pcbnew の一般オプションを選択"
-
-#: pcbnew/menubar_pcbframe.cpp:527
-msgid "&Display"
-msgstr "表示設定(&D)"
-
-#: pcbnew/menubar_pcbframe.cpp:528
-msgid "Select how items (pads, tracks texts ... ) are displayed"
-msgstr "表示するアイテム (パッド・配線・テキストなど) を選択"
-
-#: pcbnew/menubar_pcbframe.cpp:532
-msgid "&Interactive Routing"
-msgstr "インタラクティブルーター(&I)"
-
-#: pcbnew/menubar_pcbframe.cpp:533
-msgid "Configure Interactive Routing."
-msgstr "インタラクティブルーターの設定"
-
-#: pcbnew/menubar_pcbframe.cpp:540
-msgid "G&rid"
-msgstr "グリッド(&R)"
-
-#: pcbnew/menubar_pcbframe.cpp:540
-msgid "Adjust user grid dimensions"
-msgstr "ユーザ グリッドのディメンジョンを合わせる"
-
-#: pcbnew/menubar_pcbframe.cpp:544
-msgid "Te&xts and Drawings"
-msgstr "テキストと図形(&X)"
-
-#: pcbnew/menubar_pcbframe.cpp:545
-msgid "Adjust dimensions for texts and drawings"
-msgstr "テキストと図形の寸法を調整"
-
-#: pcbnew/menubar_pcbframe.cpp:549
-msgid "&Pads"
-msgstr "パッド(&P)"
-
-#: pcbnew/menubar_pcbframe.cpp:549
-msgid "Adjust default pad characteristics"
-msgstr "デフォルトのパッドキャラクタを設定"
-
-#: pcbnew/menubar_pcbframe.cpp:553
-msgid "Pads &Mask Clearance"
-msgstr "パッド-マスク (レジスト) のクリアランス(&M)"
-
-#: pcbnew/menubar_pcbframe.cpp:554
-msgid "Adjust the global clearance between pads and the solder resist mask"
-msgstr "パッドに対するレジストのグローバルクリアランス(逃げ寸法)を調整します。"
-
-#: pcbnew/menubar_pcbframe.cpp:558
-msgid "&Differential Pairs"
-msgstr "差動ペア(&D)"
-
-#: pcbnew/menubar_pcbframe.cpp:559
-msgid "Define the global gap/width for differential pairs."
-msgstr "差動ペア配線のギャップ/幅のグローバル設定"
-
-#: pcbnew/menubar_pcbframe.cpp:564
-msgid "Save dimension preferences"
-msgstr "寸法設定の保存"
-
-#: pcbnew/menubar_pcbframe.cpp:577
-msgid "&Save macros"
-msgstr "マクロの保存(&S)"
-
-#: pcbnew/menubar_pcbframe.cpp:578
-msgid "Save macros to file"
-msgstr "マクロをファイルに保存"
-
-#: pcbnew/menubar_pcbframe.cpp:582
-msgid "&Read macros"
-msgstr "マクロ読み込み(&R)"
-
-#: pcbnew/menubar_pcbframe.cpp:583
-msgid "Read macros from file"
-msgstr "マクロをファイルから読み込む"
-
-#: pcbnew/menubar_pcbframe.cpp:587
-msgid "Ma&cros"
-msgstr "マクロ(&C)"
-
-#: pcbnew/menubar_pcbframe.cpp:588
-msgid "Macros save/read operations"
-msgstr "マクロの保存/読み込み"
-
-#: pcbnew/menubar_pcbframe.cpp:594 eeschema/menubar.cpp:409
-msgid "&Save Preferences"
-msgstr "設定の保存(&S)"
-
-#: pcbnew/menubar_pcbframe.cpp:595 eeschema/menubar.cpp:410
-msgid "Save application preferences"
-msgstr "アプリケーション設定の保存"
-
-#: pcbnew/menubar_pcbframe.cpp:599 eeschema/menubar.cpp:415
-msgid "Load Prefe&rences"
-msgstr "設定の読込み(&R)"
-
-#: pcbnew/menubar_pcbframe.cpp:600 eeschema/menubar.cpp:416
-msgid "Load application preferences"
-msgstr "アプリケーション設定の読込み"
-
-#: pcbnew/menubar_pcbframe.cpp:607
-msgid "&Netlist"
-msgstr "ネットリスト(&N)"
-
-#: pcbnew/menubar_pcbframe.cpp:608
-msgid "Read the netlist and update board connectivity"
-msgstr "ネットリストを読み込み、ボードの結線情報を更新する"
-
-#: pcbnew/menubar_pcbframe.cpp:612
-msgid "&Layer Pair"
-msgstr "レイヤペア(&L)"
-
-#: pcbnew/menubar_pcbframe.cpp:612
-msgid "Change the active layer pair"
-msgstr "アクティブなレイヤペアを変更"
-
-#: pcbnew/menubar_pcbframe.cpp:616
-msgid "&DRC"
-msgstr "デザインルール チェック (&D)"
-
-#: pcbnew/menubar_pcbframe.cpp:617 pcbnew/tool_pcb.cpp:275
-msgid "Perform design rules check"
-msgstr "デザインルール チェックの実行"
-
-#: pcbnew/menubar_pcbframe.cpp:620
-msgid "&FreeRoute"
-msgstr "&FreeRoute"
-
-#: pcbnew/menubar_pcbframe.cpp:621
-msgid "Fast access to the Web Based FreeROUTE advanced router"
-msgstr "上級なルータであるウェブベースの FreeROUTE へのクイックアクセス"
-
-#: pcbnew/menubar_pcbframe.cpp:626
-msgid "&Scripting Console"
-msgstr "スクリプト コンソール(&S)"
-
-#: pcbnew/menubar_pcbframe.cpp:627 pcbnew/tool_pcb.cpp:314
-msgid "Show/Hide the Python Scripting console"
-msgstr "Python スクリプト コンソールの表示/非表示"
-
-#: pcbnew/menubar_pcbframe.cpp:634 pcbnew/menubar_pcbframe.cpp:670
-msgid "&Design Rules"
-msgstr "デザインルール(&D)"
-
-#: pcbnew/menubar_pcbframe.cpp:635
-msgid "Open the design rules editor"
-msgstr "デザインルール エディタを開く"
-
-#: pcbnew/menubar_pcbframe.cpp:638
-msgid "&Layers Setup"
-msgstr "レイヤのセットアップ(&L)"
-
-#: pcbnew/menubar_pcbframe.cpp:638
-msgid "Enable and set layer properties"
-msgstr "レイヤのプロパティを設定して有効化"
-
-#: pcbnew/menubar_pcbframe.cpp:646 eeschema/menubar_libedit.cpp:263
-#: gerbview/menubar.cpp:224 pagelayout_editor/menubar.cpp:151
-msgid "&Contents"
-msgstr "目次(&C)"
-
-#: pcbnew/menubar_pcbframe.cpp:647
-msgid "Open the Pcbnew handbook"
-msgstr "Pcbnew のマニュアルを開く"
-
-#: pcbnew/menubar_pcbframe.cpp:658
-msgid "About Pcbnew printed circuit board designer"
-msgstr "Pcbnew プリント基板デザイナーについて"
-
-#: pcbnew/menubar_pcbframe.cpp:666
-msgid "Ro&ute"
-msgstr "配線(&u)"
-
-#: pcbnew/menubar_pcbframe.cpp:668
-msgid "D&imensions"
-msgstr "寸法(&I)"
-
-#: pcbnew/modedit.cpp:185
-msgid ""
-"Current footprint changes will be lost and this operation cannot be undone. "
-"Continue?"
-msgstr ""
-"現在のフットプリントの変更は破棄されます。 この操作はやり直しできません。続け"
-"ますか？"
-
-#: pcbnew/modedit.cpp:400
-msgid "No board currently edited"
-msgstr "編集中のボードがありません"
-
-#: pcbnew/modedit.cpp:425
-msgid "Unable to find the footprint source on the main board"
-msgstr "メインボードからフットプリントのソースを見つけられません"
-
-#: pcbnew/modedit.cpp:426
-msgid ""
-"\n"
-"Cannot update the footprint"
-msgstr ""
-"\n"
-"フットプリントを更新できません"
-
-#: pcbnew/modedit.cpp:435
-msgid "A footprint source was found on the main board"
-msgstr "メインボード上からフットプリントのソースを見つけました"
-
-#: pcbnew/modedit.cpp:436
-msgid ""
-"\n"
-"Cannot insert this footprint"
-msgstr ""
-"\n"
-"このフットプリントを挿入できません"
-
-#: pcbnew/modedit.cpp:936 eeschema/libeditframe.cpp:1147
-msgid "Add line"
-msgstr "線の追加"
-
-#: pcbnew/modedit.cpp:940 eeschema/libeditframe.cpp:1143
-msgid "Add arc"
-msgstr "円弧の追加"
-
-#: pcbnew/modedit.cpp:944 eeschema/libeditframe.cpp:1139
-msgid "Add circle"
-msgstr "円を追加"
-
-#: pcbnew/modedit.cpp:952
-msgid "Place anchor"
-msgstr "アンカーの配置"
-
-#: pcbnew/modedit.cpp:956
-msgid "Set grid origin"
-msgstr "グリッド原点のセット"
-
-#: pcbnew/modedit.cpp:966 pcbnew/tool_modedit.cpp:138
-msgid "Pad settings"
-msgstr "パッドの設定"
-
-#: pcbnew/modedit_onclick.cpp:229 pcbnew/modedit_onclick.cpp:272
-#: pcbnew/muonde.cpp:803 pcbnew/onrightclick.cpp:81 pcbnew/onrightclick.cpp:97
-#: pcbnew/dialogs/dialog_design_rules_base.cpp:382
-#: pcbnew/dialogs/dialog_global_pads_edition_base.cpp:55
-#: eeschema/libedit_onrightclick.cpp:70 eeschema/onrightclick.cpp:153
-#: eeschema/onrightclick.cpp:186 eeschema/dialogs/dialog_netlist_base.cpp:49
-#: eeschema/dialogs/dialog_netlist_base.cpp:133 gerbview/onrightclick.cpp:59
-#: gerbview/onrightclick.cpp:81
-#: gerbview/dialogs/dialog_select_one_pcb_layer.cpp:182 common/selcolor.cpp:237
-#: common/dialogs/dialog_env_var_config_base.cpp:60
-#: common/dialogs/dialog_exit_base.cpp:69
-#: common/dialogs/dialog_get_component_base.cpp:52
-#: pagelayout_editor/onrightclick.cpp:115
-msgid "Cancel"
-msgstr "キャンセル"
-
-#: pcbnew/modedit_onclick.cpp:232 pcbnew/onrightclick.cpp:87
-#: eeschema/libedit_onrightclick.cpp:88 eeschema/onrightclick.cpp:158
-#: gerbview/onrightclick.cpp:62
-msgid "End Tool"
-msgstr "ツールの終了"
-
-#: pcbnew/modedit_onclick.cpp:244 pcbnew/onrightclick.cpp:495
-#: eeschema/libedit_onrightclick.cpp:323 eeschema/onrightclick.cpp:827
-#: gerbview/onrightclick.cpp:73
-msgid "Cancel Block"
-msgstr "ブロックのキャンセル"
-
-#: pcbnew/modedit_onclick.cpp:246 eeschema/libedit_onrightclick.cpp:328
-msgid "Zoom Block (drag middle mouse)"
-msgstr "ブロック ズーム(マウスの中ボタンでドラッグ)"
-
-#: pcbnew/modedit_onclick.cpp:250 pcbnew/onrightclick.cpp:499
-#: eeschema/libedit_onrightclick.cpp:333 eeschema/onrightclick.cpp:835
-#: gerbview/onrightclick.cpp:76
-msgid "Place Block"
-msgstr "ブロックの配置"
-
-#: pcbnew/modedit_onclick.cpp:252
-msgid "Copy Block (shift + drag mouse)"
-msgstr "ブロックのコピー(Shift + マウスドラッグ)"
-
-#: pcbnew/modedit_onclick.cpp:255
-msgid "Mirror Block (alt + drag mouse)"
-msgstr "ブロックのミラー(alt + マウスドラッグ)"
-
-#: pcbnew/modedit_onclick.cpp:258
-msgid "Rotate Block (ctrl + drag mouse)"
-msgstr "ブロックの回転(ctrl + マウスドラッグ)"
-
-#: pcbnew/modedit_onclick.cpp:261
-msgid "Delete Block (shift+ctrl + drag mouse)"
-msgstr "ブロックの削除(shift + ctrl + マウスドラッグ)"
-
-#: pcbnew/modedit_onclick.cpp:264
-msgid "Move Block Exactly"
-msgstr "数値を指定してブロックを移動"
-
-#: pcbnew/modedit_onclick.cpp:290 pcbnew/onrightclick.cpp:1007
-#: pcbnew/tools/common_actions.cpp:121
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:174
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:84
-#: common/dialogs/dialog_image_editor_base.cpp:39
-msgid "Rotate"
-msgstr "回転"
-
-#: pcbnew/modedit_onclick.cpp:294
-msgid "Move Exactly"
-msgstr "数値を指定して移動"
-
-#: pcbnew/modedit_onclick.cpp:297
-msgid "Edit Footprint"
-msgstr "フットプリントの編集"
-
-#: pcbnew/modedit_onclick.cpp:300
-msgid "Transform Footprint"
-msgstr "フットプリントの変形"
-
-#: pcbnew/modedit_onclick.cpp:308 pcbnew/onrightclick.cpp:943
-msgid "Move Pad"
-msgstr "パッドの移動"
-
-#: pcbnew/modedit_onclick.cpp:312 pcbnew/onrightclick.cpp:948
-msgid "Edit Pad"
-msgstr "パッドの編集"
-
-#: pcbnew/modedit_onclick.cpp:315
-msgid "New Pad Settings"
-msgstr "パッド設定の更新"
-
-#: pcbnew/modedit_onclick.cpp:317
-msgid "Export Pad Settings"
-msgstr "パッド設定のエクスポート"
-
-#: pcbnew/modedit_onclick.cpp:318
-msgid "Delete Pad"
-msgstr "パッド削除"
-
-#: pcbnew/modedit_onclick.cpp:321
-msgid "Duplicate Pad"
-msgstr "パッドの複製"
-
-#: pcbnew/modedit_onclick.cpp:324
-msgid "Move Pad Exactly"
-msgstr "数値を指定してパッドを移動"
-
-#: pcbnew/modedit_onclick.cpp:327
-msgid "Create Pad Array"
-msgstr "パッド配列の作成"
-
-#: pcbnew/modedit_onclick.cpp:335
-msgid "Global Pad Settings"
-msgstr "グローバルパッド設定"
-
-#: pcbnew/modedit_onclick.cpp:343 pcbnew/onrightclick.cpp:882
-#: eeschema/libedit_onrightclick.cpp:188 eeschema/onrightclick.cpp:597
-msgid "Move Text"
-msgstr "テキストの移動"
-
-#: pcbnew/modedit_onclick.cpp:349 pcbnew/onrightclick.cpp:892
-#: eeschema/libedit_onrightclick.cpp:197 eeschema/onrightclick.cpp:605
-msgid "Rotate Text"
-msgstr "テキストの回転"
-
-#: pcbnew/modedit_onclick.cpp:362
-msgid "Duplicate Text"
-msgstr "テキストの複製"
-
-#: pcbnew/modedit_onclick.cpp:367
-msgid "Create Text Array"
-msgstr "テキスト配列の作成"
-
-#: pcbnew/modedit_onclick.cpp:374 pcbnew/onrightclick.cpp:886
-msgid "Move Text Exactly"
-msgstr "数値を指定してテキストをコピー"
-
-#: pcbnew/modedit_onclick.cpp:379 pcbnew/onrightclick.cpp:898
-#: eeschema/libedit_onrightclick.cpp:194 eeschema/onrightclick.cpp:96
-#: eeschema/onrightclick.cpp:607
-msgid "Edit Text"
-msgstr "テキストの編集"
-
-#: pcbnew/modedit_onclick.cpp:385 pcbnew/onrightclick.cpp:909
-#: eeschema/libedit_onrightclick.cpp:202 eeschema/onrightclick.cpp:609
-msgid "Delete Text"
-msgstr "テキストの削除"
-
-#: pcbnew/modedit_onclick.cpp:396
-msgid "End edge"
-msgstr "エッジの終了"
-
-#: pcbnew/modedit_onclick.cpp:401
-msgid "Move Edge"
-msgstr "エッジの移動"
-
-#: pcbnew/modedit_onclick.cpp:405
-msgid "Duplicate Edge"
-msgstr "エッジの複製"
-
-#: pcbnew/modedit_onclick.cpp:408
-msgid "Move Edge Exactly"
-msgstr "数値を指定してエッジを移動"
-
-#: pcbnew/modedit_onclick.cpp:411
-msgid "Create Edge Array"
-msgstr "エッジ配列の作成"
-
-#: pcbnew/modedit_onclick.cpp:415
-msgid "Place edge"
-msgstr "エッジの配置"
-
-#: pcbnew/modedit_onclick.cpp:418 pcbnew/onrightclick.cpp:1011
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:37
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:54
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:53
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:70
-#: eeschema/onrightclick.cpp:418
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:228
-msgid "Edit"
-msgstr "編集"
-
-#: pcbnew/modedit_onclick.cpp:422
-msgid "Delete Edge"
-msgstr "エッジの削除"
-
-#: pcbnew/modedit_onclick.cpp:427
-msgid "Global Changes"
-msgstr "広域変更"
-
-#: pcbnew/modedit_onclick.cpp:429
-msgid "Change Body Items Width"
-msgstr "アイテムの幅を変更"
-
-#: pcbnew/modedit_onclick.cpp:431
-msgid "Change Body Items Layer"
-msgstr "アイテムのレイヤを変更"
-
-#: pcbnew/modedit_onclick.cpp:469
-msgid "Set Line Width"
-msgstr "線幅の設定"
-
-#: pcbnew/moduleframe.cpp:288 pcbnew/pcbframe.cpp:401 pcbnew/pcbframe.cpp:895
-#: gerbview/events_called_functions.cpp:318 gerbview/gerbview_frame.cpp:146
-msgid "Visibles"
-msgstr "表示"
-
-#: pcbnew/moduleframe.cpp:500
-msgid "Save the changes to the footprint before closing?"
-msgstr "フットプリントの変更を終了前に保存しますか？"
-
-#: pcbnew/moduleframe.cpp:521
-msgid "Library is not set, the footprint could not be saved."
-msgstr "ライブラリが選択されていないため，フットプリントを保存できません．"
-
-#: pcbnew/moduleframe.cpp:690 pcbnew/pcbframe.cpp:656
-#: cvpcb/class_DisplayFootprintsFrame.cpp:401
-msgid "3D Viewer"
-msgstr "3Dビューア"
-
-#: pcbnew/moduleframe.cpp:743
-msgid "Footprint Editor "
-msgstr "フットプリントエディタ"
-
-#: pcbnew/moduleframe.cpp:750
-msgid "(no active library)"
-msgstr "(アクティブなライブラリがありません)"
-
-#: pcbnew/moduleframe.cpp:759
-msgid "Footprint Editor (active library: "
-msgstr "フットプリントエディタ (アクティブなライブラリ:"
-
-#: pcbnew/moduleframe.cpp:858 pcbnew/pcbnew_config.cpp:138
-#, c-format
-msgid ""
-"Error occurred saving the global footprint library table:\n"
-"\n"
-"%s"
-msgstr ""
-"グローバルフットプリントライブラリの一覧の保存中にエラーが発生しました:\n"
-"\n"
-"%s"
-
-#: pcbnew/moduleframe.cpp:862 pcbnew/moduleframe.cpp:882
-#: pcbnew/pcbnew_config.cpp:142 pcbnew/pcbnew_config.cpp:164
-#: cvpcb/cvframe.cpp:457 cvpcb/cvframe.cpp:477
-msgid "File Save Error"
-msgstr "ファイル保存エラー"
-
-#: pcbnew/moduleframe.cpp:878 pcbnew/pcbnew_config.cpp:160
-#, c-format
-msgid ""
-"Error occurred saving project specific footprint library table:\n"
-"\n"
-"%s"
-msgstr ""
-"フットプリントライブラリの一覧の保存中にエラーが発生しました:\n"
-"\n"
-"%s"
-
-#: pcbnew/modules.cpp:66 pcbnew/dialogs/dialog_edit_module_text.cpp:130
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:40
-msgid "Reference:"
-msgstr "リファレンス:"
-
-#: pcbnew/modules.cpp:66
-msgid "Search for footprint"
-msgstr "フットプリントの検索"
-
-#: pcbnew/modules.cpp:264
-#, c-format
-msgid "Delete Footprint %s (value %s) ?"
-msgstr "フットプリント %s (値 %s) を削除しますか？"
-
-#: pcbnew/modview_frame.cpp:120
-msgid "Footprint Library Browser"
-msgstr "フットプリント ライブラリ ブラウザ"
-
-#: pcbnew/modview_frame.cpp:453
-#, c-format
-msgid ""
-"Could not load footprint \"%s\" from library \"%s\".\n"
-"\n"
-"Error %s."
-msgstr ""
-"次のライブラリからフットプリントを読み出すことができませんでした \"%s\" / ラ"
-"イブラリ \"%s\".\n"
-"\n"
-"エラー %s."
-
-#: pcbnew/modview_frame.cpp:707 eeschema/viewlib_frame.cpp:99
-#: eeschema/viewlibs.cpp:134
-msgid "Library Browser"
-msgstr "ライブラリ ブラウザ"
-
-#: pcbnew/modview_frame.cpp:713 eeschema/libedit.cpp:65
-#: eeschema/viewlibs.cpp:141
-msgid "no library selected"
-msgstr "ライブラリが選択されていません"
-
-#: pcbnew/move_or_drag_track.cpp:714
-msgid "Unable to drag this segment: too many segments connected"
-msgstr "セグメントをドラッグできません: 多くのセグメントが接続しています"
-
-#: pcbnew/move_or_drag_track.cpp:785
-msgid "Unable to drag this segment: two collinear segments"
-msgstr "セグメントをドラッグできません: ２つの直線セグメントです"
-
-#: pcbnew/muonde.cpp:201
-msgid "Length of Trace:"
-msgstr "配線長:"
-
-#: pcbnew/muonde.cpp:212
-msgid "Requested length < minimum length"
-msgstr "指定された長さ < 最小長さ"
-
-#: pcbnew/muonde.cpp:226
-msgid "Requested length too large"
-msgstr "指定された長さは長過ぎます"
-
-#: pcbnew/muonde.cpp:232
-msgid "Component Value:"
-msgstr "コンポーネントの値:"
-
-#: pcbnew/muonde.cpp:587
-msgid "Gap"
-msgstr "ギャップ"
-
-#: pcbnew/muonde.cpp:593
-msgid "Stub"
-msgstr "スタブ"
-
-#: pcbnew/muonde.cpp:600
-msgid "Arc Stub"
-msgstr "円弧スタブ"
-
-#: pcbnew/muonde.cpp:611 pcbnew/muonde.cpp:629
-msgid "Create microwave module"
-msgstr "高周波モジュールの作成"
-
-#: pcbnew/muonde.cpp:628
-msgid "Angle in degrees:"
-msgstr "角度:"
-
-#: pcbnew/muonde.cpp:641
-msgid "Incorrect number, abort"
-msgstr "無効な数, 中止"
-
-#: pcbnew/muonde.cpp:786
-msgid "Complex shape"
-msgstr "複雑なシェイプ"
-
-#: pcbnew/muonde.cpp:800 pcbnew/dialogs/dialog_design_rules_base.cpp:378
-#: pcbnew/dialogs/dialog_orient_footprints_base.cpp:54
-#: pcbnew/dialogs/wizard_add_fplib.cpp:841
-#: eeschema/dialogs/dialog_netlist_base.cpp:129
-#: gerbview/dialogs/dialog_select_one_pcb_layer.cpp:178
-#: common/dialogs/dialog_env_var_config_base.cpp:56
-#: common/dialogs/dialog_get_component_base.cpp:45
-#: common/dialogs/dialog_hotkeys_editor_base.cpp:30
-msgid "OK"
-msgstr "OK"
-
-#: pcbnew/muonde.cpp:807
-msgid "Read Shape Description File..."
-msgstr "シェイプの説明を読む"
-
-#: pcbnew/muonde.cpp:812
-msgid "Symmetrical"
-msgstr "対称"
-
-#: pcbnew/muonde.cpp:812 pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:70
-msgid "Mirrored"
-msgstr "反転"
-
-#: pcbnew/muonde.cpp:815
-msgid "Shape Option"
-msgstr "シェイプのオプション"
-
-#: pcbnew/muonde.cpp:821 pcbnew/dialogs/dialog_target_properties_base.cpp:28
-#: eeschema/sch_text.cpp:790
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:230
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:138
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:53
-msgid "Size"
-msgstr "サイズ"
-
-#: pcbnew/muonde.cpp:847
-msgid "Read descr shape file"
-msgstr "シェイプの説明を読む"
-
-#: pcbnew/muonde.cpp:862
-msgid "File not found"
-msgstr "ファイルが見つかりません"
-
-#: pcbnew/muonde.cpp:950
-msgid "Shape has a null size!"
-msgstr "シェイプが無効なサイズです！"
-
-#: pcbnew/muonde.cpp:956
-msgid "Shape has no points!"
-msgstr "シェイプに点がありません！"
-
-#: pcbnew/muonde.cpp:1050
-msgid "No pad for this footprint"
-msgstr "このフットプリントにはパッドがありません"
-
-#: pcbnew/muonde.cpp:1058
-msgid "Only one pad for this footprint"
-msgstr "このフットプリントには1つだけパッドがあります"
-
-#: pcbnew/muonde.cpp:1069
-msgid "Gap:"
-msgstr "ギャップ:"
-
-#: pcbnew/muonde.cpp:1069
-msgid "Create Microwave Gap"
-msgstr "高周波用ギャップの作成"
-
-#: pcbnew/muwave_command.cpp:60 pagelayout_editor/onrightclick.cpp:45
-msgid "Add Line"
-msgstr "線の追加"
-
-#: pcbnew/muwave_command.cpp:64
-msgid "Add Gap"
-msgstr "ギャップの追加"
-
-#: pcbnew/muwave_command.cpp:68
-msgid "Add Stub"
-msgstr "スタブの追加"
-
-#: pcbnew/muwave_command.cpp:72
-msgid "Add Arc Stub"
-msgstr "円弧スタブの追加"
-
-#: pcbnew/muwave_command.cpp:76
-msgid "Add Polynomial Shape"
-msgstr "ポリノミナル シェイプの追加"
-
-#: pcbnew/netlist.cpp:82 pcbnew/dialogs/dialog_netlist.cpp:403
-#, c-format
-msgid "Cannot open netlist file \"%s\"."
-msgstr "ネットリストファイル \"%s\" が開けませんでした。"
-
-#: pcbnew/netlist.cpp:83 pcbnew/dialogs/dialog_netlist.cpp:404
-msgid "Netlist Load Error."
-msgstr "ネットリストの読み込みエラー"
-
-#: pcbnew/netlist.cpp:93 cvpcb/cvframe.cpp:762
-#, c-format
-msgid ""
-"Error loading netlist.\n"
-"%s"
-msgstr ""
-"ネットリスト読み込み中のエラーです。\n"
-"%s"
-
-#: pcbnew/netlist.cpp:94 pcbnew/dialogs/dialog_netlist.cpp:414
-#: cvpcb/cvframe.cpp:763
-msgid "Netlist Load Error"
-msgstr "ネットリストの読み込みエラー"
-
-#: pcbnew/netlist.cpp:153 pcbnew/dialogs/dialog_netlist.cpp:199
-msgid "No footprints"
-msgstr "フットプリント無し"
-
-#: pcbnew/netlist.cpp:176
-msgid "Components"
-msgstr "コンポーネント"
-
-#: pcbnew/netlist.cpp:223
-#, c-format
-msgid "No footprint defined for component '%s'.\n"
-msgstr ""
-"コンポーネント '%s' に対して、フットプリントが割り当てられていません。\n"
-
-#: pcbnew/netlist.cpp:245
-#, c-format
-msgid ""
-"* Warning: component '%s': board footprint '%s', netlist footprint '%s'\n"
-msgstr ""
-"* 警告: コンポーネント '%s' ：ボードのフットプリント '%s' ：ネットリストの"
-"フットプリント '%s'\n"
-
-#: pcbnew/netlist.cpp:274
-#, c-format
-msgid "Component '%s' footprint ID '%s' is not valid.\n"
-msgstr "コンポーネント '%s' のフットプリントID '%s' が不正です。\n"
-
-#: pcbnew/netlist.cpp:296
-#, c-format
-msgid ""
-"Component '%s' footprint '%s' was not found in any libraries in the "
-"footprint library table.\n"
-msgstr ""
-"コンポーネント '%s' フットプリント '%s' はどのライブラリからも見つけることが"
-"できませんでした。\n"
-
-#: pcbnew/netlist_reader.cpp:182
-#, c-format
-msgid ""
-"invalid PFID in\n"
-"file: <%s>\n"
-"line: %d"
-msgstr ""
-"不正なPFIDが見つかりました: \n"
-"ファイル:<%s>\n"
-"%d行目"
-
-#: pcbnew/onleftclick.cpp:252 pcbnew/tools/drawing_tool.cpp:718
-#: pcbnew/tools/drawing_tool.cpp:870
-msgid "Graphic not allowed on Copper layers"
-msgstr "図形は導体レイヤに配置できません"
-
-#: pcbnew/onleftclick.cpp:276
-msgid "Tracks on Copper layers only "
-msgstr "配線は導体レイヤのみです"
-
-#: pcbnew/onleftclick.cpp:335
-msgid "Texts not allowed on Edge Cut layer"
-msgstr "基板外形レイヤに文字列を配置するこはできません"
-
-#: pcbnew/onleftclick.cpp:384 pcbnew/tools/drawing_tool.cpp:308
-msgid "Dimension not allowed on Copper or Edge Cut layers"
-msgstr "寸法線は導体レイヤまたは外形線レイヤに配置できません"
-
-#: pcbnew/onrightclick.cpp:151
-msgid "Lock Footprint"
-msgstr "フットプリントをロック"
-
-#: pcbnew/onrightclick.cpp:158
-msgid "Unlock Footprint"
-msgstr "フットプリントをロック解除"
-
-#: pcbnew/onrightclick.cpp:166
-msgid "Automatically Place Footprint"
-msgstr "フットプリントを自動配置"
-
-#: pcbnew/onrightclick.cpp:173
-msgid "Automatically Route Footprint"
-msgstr "フットプリントの自動配線"
-
-#: pcbnew/onrightclick.cpp:189 eeschema/onrightclick.cpp:267
-msgid "End Drawing"
-msgstr "線ツールの終了"
-
-#: pcbnew/onrightclick.cpp:194
-msgid "Move Drawing"
-msgstr "図形の移動"
-
-#: pcbnew/onrightclick.cpp:199
-msgid "Duplicate Drawing"
-msgstr "図形の複製"
-
-#: pcbnew/onrightclick.cpp:204
-msgid "Move Drawing Exactly"
-msgstr "数値を指定して図形を移動"
-
-#: pcbnew/onrightclick.cpp:209
-msgid "Create Drawing Array"
-msgstr "図形配列の作成"
-
-#: pcbnew/onrightclick.cpp:214
-msgid "Edit Drawing"
-msgstr "図形の編集"
-
-#: pcbnew/onrightclick.cpp:220 eeschema/onrightclick.cpp:270
-msgid "Delete Drawing"
-msgstr "図形の削除"
-
-#: pcbnew/onrightclick.cpp:224
-msgid "Delete All Drawings on Layer"
-msgstr "レイヤ上の全ての図形描画を削除する"
-
-#: pcbnew/onrightclick.cpp:231
-msgid "Delete Zone Filling"
-msgstr "ゾーン塗りつぶしを削除"
-
-#: pcbnew/onrightclick.cpp:238
-msgid "Close Zone Outline"
-msgstr "ゾーンの外枠を閉じる"
-
-#: pcbnew/onrightclick.cpp:240
-msgid "Delete Last Corner"
-msgstr "一つ前の角を削除"
-
-#: pcbnew/onrightclick.cpp:266
-msgid "Edit Dimension"
-msgstr "寸法線の編集"
-
-#: pcbnew/onrightclick.cpp:270
-msgid "Move Dimension Text"
-msgstr "寸法線テキストの移動"
-
-#: pcbnew/onrightclick.cpp:275
-msgid "Duplicate Dimension"
-msgstr "寸法線の複製"
-
-#: pcbnew/onrightclick.cpp:280
-msgid "Move Dimension Exactly"
-msgstr "数値を指定して寸法線を移動"
-
-#: pcbnew/onrightclick.cpp:285
-msgid "Delete Dimension"
-msgstr "寸法線の削除"
-
-#: pcbnew/onrightclick.cpp:296
-msgid "Move Target"
-msgstr "ターゲットの移動"
-
-#: pcbnew/onrightclick.cpp:301
-msgid "Move Target Exactly"
-msgstr "数値を指定してターゲットの移動"
-
-#: pcbnew/onrightclick.cpp:306
-msgid "Duplicate Target"
-msgstr "ターゲットの複製"
-
-#: pcbnew/onrightclick.cpp:311
-msgid "Create Target Array"
-msgstr "ターゲット配列の作成"
-
-#: pcbnew/onrightclick.cpp:316
-msgid "Edit Target"
-msgstr "ターゲットの編集"
-
-#: pcbnew/onrightclick.cpp:320
-msgid "Delete Target"
-msgstr "ターゲットの削除"
-
-#: pcbnew/onrightclick.cpp:354
-msgid "Get and Move Footprint"
-msgstr "フットプリントの検索と移動"
-
-#: pcbnew/onrightclick.cpp:367
-msgid "Fill or Refill All Zones"
-msgstr "全てのゾーンを塗りつぶす"
-
-#: pcbnew/onrightclick.cpp:371
-msgid "Remove Filled Areas in All Zones"
-msgstr "全てのゾーンの塗りつぶしエリアを削除"
-
-#: pcbnew/onrightclick.cpp:379 pcbnew/onrightclick.cpp:385
-#: pcbnew/onrightclick.cpp:403 pcbnew/onrightclick.cpp:416
-#: pcbnew/onrightclick.cpp:481 pcbnew/onrightclick.cpp:574
-msgid "Select Working Layer"
-msgstr "作業レイヤの選択"
-
-#: pcbnew/onrightclick.cpp:393 pcbnew/onrightclick.cpp:473
-#: pcbnew/onrightclick.cpp:521
-msgid "Begin Track"
-msgstr "配線の開始"
-
-#: pcbnew/onrightclick.cpp:399 pcbnew/onrightclick.cpp:477
-#: pcbnew/onrightclick.cpp:645
-msgid "Select Track Width"
-msgstr "配線幅の選択"
-
-#: pcbnew/onrightclick.cpp:405
-msgid "Select Layer Pair for Vias"
-msgstr "ビアのレイヤペアを選択"
-
-#: pcbnew/onrightclick.cpp:424
-msgid "Footprint Documentation"
-msgstr "フットプリントのドキュメントを見る"
-
-#: pcbnew/onrightclick.cpp:434
-msgid "Global Spread and Place"
-msgstr "グローバル移動/配置"
-
-#: pcbnew/onrightclick.cpp:436
-msgid "Unlock All Footprints"
-msgstr "全てのフットプリントをアンロック"
-
-#: pcbnew/onrightclick.cpp:438
-msgid "Lock All Footprints"
-msgstr "全てのフットプリントをロック"
-
-#: pcbnew/onrightclick.cpp:441
-msgid "Spread out All Footprints"
-msgstr "全てのフットプリントを展開"
-
-#: pcbnew/onrightclick.cpp:443
-msgid "Spread out Footprints not Already on Board"
-msgstr "ボード上に無い全てのフットプリントを展開"
-
-#: pcbnew/onrightclick.cpp:446
-msgid "Automatically Place All Footprints"
-msgstr "全てのフットプリントを自動配置"
-
-#: pcbnew/onrightclick.cpp:448
-msgid "Automatically Place New Footprints"
-msgstr "新しいフットプリントを自動配置"
-
-#: pcbnew/onrightclick.cpp:450
-msgid "Automatically Place Next Footprints"
-msgstr "次のフットプリントを自動配置"
-
-#: pcbnew/onrightclick.cpp:453
-msgid "Orient All Footprints"
-msgstr "全てのフットプリントの方向を揃える"
-
-#: pcbnew/onrightclick.cpp:460
-msgid "Autoroute"
-msgstr "自動配線"
-
-#: pcbnew/onrightclick.cpp:462
-msgid "Select Layer Pair"
-msgstr "レイヤ ペアの選択"
-
-#: pcbnew/onrightclick.cpp:465
-msgid "Automatically Route All Footprints"
-msgstr "全てのフットプリントを自動配置"
-
-#: pcbnew/onrightclick.cpp:467
-msgid "Reset Unrouted"
-msgstr "未配線をリセット"
-
-#: pcbnew/onrightclick.cpp:497
-msgid "Zoom Block"
-msgstr "ブロックの拡大"
-
-#: pcbnew/onrightclick.cpp:500 eeschema/libedit_onrightclick.cpp:339
-#: eeschema/onrightclick.cpp:844
-msgid "Copy Block"
-msgstr "ブロックのコピー"
-
-#: pcbnew/onrightclick.cpp:501
-msgid "Flip Block"
-msgstr "ブロックを裏返す"
-
-#: pcbnew/onrightclick.cpp:502
-msgid "Rotate Block"
-msgstr "ブロックの回転"
-
-#: pcbnew/onrightclick.cpp:503 eeschema/libedit_onrightclick.cpp:346
-#: eeschema/onrightclick.cpp:848
-msgid "Delete Block"
-msgstr "ブロックの削除"
-
-#: pcbnew/onrightclick.cpp:528
-msgid "Drag Via"
-msgstr "ビアの移動"
-
-#: pcbnew/onrightclick.cpp:537
-msgid "Move Node"
-msgstr "ノードの移動"
-
-#: pcbnew/onrightclick.cpp:543
-msgid "Drag Segments, Keep Slope"
-msgstr "セグメントのドラッグ移動 (角度保持)"
-
-#: pcbnew/onrightclick.cpp:548
-msgid "Drag Segment"
-msgstr "セグメントのドラッグ移動"
-
-#: pcbnew/onrightclick.cpp:553
-msgid "Duplicate Track"
-msgstr "配線の複製"
-
-#: pcbnew/onrightclick.cpp:558
-msgid "Move Track Exactly"
-msgstr "数値を指定してトラックを移動"
-
-#: pcbnew/onrightclick.cpp:563
-msgid "Create Track Array"
-msgstr "配線配列の作成"
-
-#: pcbnew/onrightclick.cpp:569
-msgid "Break Track"
-msgstr "配線の切断"
-
-#: pcbnew/onrightclick.cpp:579
-msgid "Place Node"
-msgstr "ノード配置"
-
-#: pcbnew/onrightclick.cpp:586 pcbnew/router/length_tuner_tool.cpp:54
-#: pcbnew/router/router_tool.cpp:64
-msgid "End Track"
-msgstr "配線の終了"
-
-#: pcbnew/onrightclick.cpp:590 pcbnew/router/router_tool.cpp:75
-msgid "Place Through Via"
-msgstr "貫通ビアの配置"
-
-#: pcbnew/onrightclick.cpp:593
-msgid "Select Layer and Place Through Via"
-msgstr "スルーホールを配置するレイヤの選択"
-
-#: pcbnew/onrightclick.cpp:600 pcbnew/router/router_tool.cpp:81
-msgid "Place Blind/Buried Via"
-msgstr "ブラインドビア(BVH)/ベリッドホール(BH)の配置"
-
-#: pcbnew/onrightclick.cpp:604
-msgid "Select Layer and Place Blind/Buried Via"
-msgstr "レイヤを指定してブラインド/ベリッドビアを配置"
-
-#: pcbnew/onrightclick.cpp:610 pcbnew/router/router_tool.cpp:98
-msgid "Switch Track Posture"
-msgstr "配線の形を変える"
-
-#: pcbnew/onrightclick.cpp:618
-msgid "Place Micro Via"
-msgstr "マイクロビアを配置"
-
-#: pcbnew/onrightclick.cpp:629
-msgid "Change Via Size and Drill"
-msgstr "ビア径/ドリル径の変更"
-
-#: pcbnew/onrightclick.cpp:635
-msgid "Change Segment Width"
-msgstr "セグメント幅の変更"
-
-#: pcbnew/onrightclick.cpp:639
-msgid "Change Track Width"
-msgstr "配線幅の変更"
-
-#: pcbnew/onrightclick.cpp:650 pcbnew/onrightclick.cpp:967
-#: pcbnew/onrightclick.cpp:1019
-#: pcbnew/dialogs/dialog_fp_plugin_options_base.cpp:62
-#: pcbnew/dialogs/dialog_netlist_fbp.cpp:55
-#: pcbnew/dialogs/dialog_netlist_fbp.cpp:63
-#: pcbnew/dialogs/dialog_netlist_fbp.cpp:71
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:189
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:231
-#: common/dialogs/dialog_env_var_config_base.cpp:68
-#: pagelayout_editor/events_functions.cpp:572
-#: pagelayout_editor/onrightclick.cpp:103
-msgid "Delete"
-msgstr "削除"
-
-#: pcbnew/onrightclick.cpp:654
-msgid "Delete Via"
-msgstr "ビア削除"
-
-#: pcbnew/onrightclick.cpp:654 eeschema/libedit_onrightclick.cpp:239
-msgid "Delete Segment"
-msgstr "セグメント削除"
-
-#: pcbnew/onrightclick.cpp:661
-msgid "Delete Track"
-msgstr "配線削除"
-
-#: pcbnew/onrightclick.cpp:663
-msgid "Delete Net"
-msgstr "ネット削除"
-
-#: pcbnew/onrightclick.cpp:672
-msgid "Edit All Tracks and Vias"
-msgstr "配線とビアのグローバル編集"
-
-#: pcbnew/onrightclick.cpp:678
-msgid "Set Flags"
-msgstr "フラグのセット"
-
-#: pcbnew/onrightclick.cpp:680
-msgid "Locked: Yes"
-msgstr "セグメントロック: Yes"
-
-#: pcbnew/onrightclick.cpp:681
-msgid "Locked: No"
-msgstr "セグメントロック: No"
-
-#: pcbnew/onrightclick.cpp:690
-msgid "Track Locked: Yes"
-msgstr "配線のロック: Yes"
-
-#: pcbnew/onrightclick.cpp:691
-msgid "Track Locked: No"
-msgstr "配線のロック: No"
-
-#: pcbnew/onrightclick.cpp:693
-msgid "Net Locked: Yes"
-msgstr "ネットのロック: Yes"
-
-#: pcbnew/onrightclick.cpp:694
-msgid "Net Locked: No"
-msgstr "ネットのロック: No"
-
-#: pcbnew/onrightclick.cpp:708
-msgid "Place Edge Outline"
-msgstr "エッジの配置"
-
-#: pcbnew/onrightclick.cpp:714
-msgid "Place Corner"
-msgstr "角の入力"
-
-#: pcbnew/onrightclick.cpp:717
-msgid "Place Zone"
-msgstr "ゾーンの入力"
-
-#: pcbnew/onrightclick.cpp:724
-msgid "Keepout Area"
-msgstr "キープアウト(禁止)エリア"
-
-#: pcbnew/onrightclick.cpp:724
-#: pcbnew/dialogs/dialog_global_deletion_base.cpp:25
-#: pcbnew/tools/pcb_editor_control.cpp:121
-msgid "Zones"
-msgstr "ゾーン"
-
-#: pcbnew/onrightclick.cpp:730
-msgid "Move Corner"
-msgstr "角の移動"
-
-#: pcbnew/onrightclick.cpp:732
-msgid "Delete Corner"
-msgstr "角の削除"
-
-#: pcbnew/onrightclick.cpp:737
-msgid "Create Corner"
-msgstr "角の作成"
-
-#: pcbnew/onrightclick.cpp:738
-msgid "Drag Outline Segment"
-msgstr "外枠セグメントの移動"
-
-#: pcbnew/onrightclick.cpp:746
-msgid "Add Similar Zone"
-msgstr "同様のゾーンの追加"
-
-#: pcbnew/onrightclick.cpp:749
-msgid "Add Cutout Area"
-msgstr "切り抜きの追加"
-
-#: pcbnew/onrightclick.cpp:752
-msgid "Duplicate Zone Onto Layer"
-msgstr "レイヤ上にゾーンを複製"
-
-#: pcbnew/onrightclick.cpp:757
-msgid "Fill Zone"
-msgstr "ゾーンの塗りつぶし"
-
-#: pcbnew/onrightclick.cpp:763
-msgid "Remove Filled Areas in Zone"
-msgstr "ゾーンの塗りつぶしを削除"
-
-#: pcbnew/onrightclick.cpp:766
-msgid "Move Zone"
-msgstr "ゾーンの移動"
-
-#: pcbnew/onrightclick.cpp:769
-msgid "Move Zone Exactly"
-msgstr "数値を指定してゾーンを移動"
-
-#: pcbnew/onrightclick.cpp:774
-msgid "Edit Zone Properties"
-msgstr "ゾーンプロパティの編集"
-
-#: pcbnew/onrightclick.cpp:784
-msgid "Delete Cutout"
-msgstr "切り抜きの削除"
-
-#: pcbnew/onrightclick.cpp:787
-msgid "Delete Zone Outline"
-msgstr "ゾーン外枠の削除"
-
-#: pcbnew/onrightclick.cpp:807 pcbnew/onrightclick.cpp:999
-#: pcbnew/tools/common_actions.cpp:100
-msgid "Move"
-msgstr "移動"
-
-#: pcbnew/onrightclick.cpp:811
-msgid "Drag"
-msgstr "ドラッグ"
-
-#: pcbnew/onrightclick.cpp:816
-msgid "Rotate +"
-msgstr "左に回転"
-
-#: pcbnew/onrightclick.cpp:820
-msgid "Rotate -"
-msgstr "右に回転"
-
-#: pcbnew/onrightclick.cpp:821 pcbnew/onrightclick.cpp:1009
-#: pcbnew/tools/common_actions.cpp:125
-msgid "Flip"
-msgstr "裏返す"
-
-#: pcbnew/onrightclick.cpp:827
-msgid "Edit Parameters"
-msgstr "パラメータの編集"
-
-#: pcbnew/onrightclick.cpp:832
-msgid "Edit with Footprint Editor"
-msgstr "フットプリントエディタで編集"
-
-#: pcbnew/onrightclick.cpp:839
-msgid "Delete Footprint"
-msgstr "フットプリントの削除"
-
-#: pcbnew/onrightclick.cpp:846
-msgid "Move Footprint Exactly"
-msgstr "数値を指定してフットプリントを移動"
-
-#: pcbnew/onrightclick.cpp:851
-msgid "Duplicate Footprint"
-msgstr "フットプリントの複製"
-
-#: pcbnew/onrightclick.cpp:856
-msgid "Create Footprint Array"
-msgstr "フットプリント配列の作成"
-
-#: pcbnew/onrightclick.cpp:862
-msgid "Exchange Footprint(s)"
-msgstr "フットプリントの入れ替え"
-
-#: pcbnew/onrightclick.cpp:902 pcbnew/onrightclick.cpp:1016
-msgid "Reset Size"
-msgstr "サイズをリセット"
-
-#: pcbnew/onrightclick.cpp:945
-msgid "Drag Pad"
-msgstr "パッドの移動"
-
-#: pcbnew/onrightclick.cpp:953
-msgid "Copy Current Settings to this Pad"
-msgstr "このパッドに現在の設定をコピー"
-
-#: pcbnew/onrightclick.cpp:957
-msgid "Copy this Pad Settings to Current Settings"
-msgstr "このパッドの設定を現在の設定にコピー"
-
-#: pcbnew/onrightclick.cpp:962
-msgid "Edit All Pads"
-msgstr "パッドのグローバル編集"
-
-#: pcbnew/onrightclick.cpp:963
-msgid ""
-"Copy this pad's settings to all pads in this footprint (or similar "
-"footprints)"
-msgstr ""
-"このパッドの設定をこのフットプリント (及び同様のフットプリント) 内の全ての"
-"パッドにコピー"
-
-#: pcbnew/onrightclick.cpp:971
-msgid "Automatically Route Pad"
-msgstr "パッドの自動配線"
-
-#: pcbnew/onrightclick.cpp:972
-msgid "Automatically Route Net"
-msgstr "ネットの自動配線"
-
-#: pcbnew/onrightclick.cpp:1002
-msgid "Copy"
-msgstr "コピー"
-
-#: pcbnew/onrightclick.cpp:1027 eeschema/onrightclick.cpp:870
-msgid "Delete Marker"
-msgstr "マーカー削除"
-
-#: pcbnew/onrightclick.cpp:1029 eeschema/onrightclick.cpp:871
-msgid "Marker Error Info"
-msgstr "マーカー エラー情報"
-
-#: pcbnew/onrightclick.cpp:1047
-msgid "Auto Width"
-msgstr "自動幅"
-
-#: pcbnew/onrightclick.cpp:1048
-msgid ""
-"Use the track width when starting on a track, otherwise the current track "
-"width"
-msgstr "現在の配線幅ではなく、配線時の幅を使用する"
-
-#: pcbnew/onrightclick.cpp:1058
-msgid "Use Netclass Values"
-msgstr "ネットクラスの値を使用する"
-
-#: pcbnew/onrightclick.cpp:1059
-msgid "Use track and via sizes from their Netclass values"
-msgstr "ネットクラスの値の配線とビア径を使う"
-
-#: pcbnew/onrightclick.cpp:1065
-#, c-format
-msgid "Track %s"
-msgstr "配線 %s"
-
-#: pcbnew/onrightclick.cpp:1068 pcbnew/onrightclick.cpp:1094
-msgid " uses NetClass"
-msgstr "ネットクラスを使う"
-
-#: pcbnew/onrightclick.cpp:1086
-#, c-format
-msgid "Via %s"
-msgstr "ビア %s"
-
-#: pcbnew/onrightclick.cpp:1090
-#, c-format
-msgid "Via %s, drill %s"
-msgstr "ビア %s (%s)"
-
-#: pcbnew/pad_edition_functions.cpp:211
-#, c-format
-msgid "Delete Pad (footprint %s %s) ?"
-msgstr "パッドを削除しますか(フットプリント %s %s) ?"
-
-#: pcbnew/pcb_parser.cpp:137
-#, c-format
-msgid ""
-"invalid floating point number in\n"
-"file: <%s>\n"
-"line: %d\n"
-"offset: %d"
-msgstr ""
-"不正な浮動小数点数値が見つかりました:\n"
-"ファイル: <%s>\n"
-"行数: %d\n"
-"文字: %d"
-
-#: pcbnew/pcb_parser.cpp:146
-#, c-format
-msgid ""
-"missing floating point number in\n"
-"file: <%s>\n"
-"line: %d\n"
-"offset: %d"
-msgstr ""
-"不正な浮動小数点数値が見つかりました:\n"
-"ファイル: '%s'\n"
-"行数: %d\n"
-"文字: %d"
-
-#: pcbnew/pcb_parser.cpp:590
-#, c-format
-msgid "page type \"%s\" is not valid "
-msgstr "ページタイプ \"%s\" は不正です! "
-
-#: pcbnew/pcb_parser.cpp:822
-#, c-format
-msgid "Layer '%s' in file '%s' at line %d, is not in fixed layer hash"
-msgstr ""
-"レイヤ '%s' (ファイル: '%s' %d行) はこのレイヤハッシュで定義されていません。"
-
-#: pcbnew/pcb_parser.cpp:855
-#, c-format
-msgid "%d is not a valid layer count"
-msgstr "%d は有効なレイヤ番号ではありません"
-
-#: pcbnew/pcb_parser.cpp:886
-#, c-format
-msgid ""
-"Layer '%s' in file\n"
-"'%s'\n"
-"at line %d, position %d\n"
-"was not defined in the layers section"
-msgstr ""
-"レイヤ '%s' (ファイル:\n"
-"'%s'\n"
-", %d行, %d文字目) \n"
-"はこのレイヤセクションで定義されていません。"
-
-#: pcbnew/pcb_parser.cpp:1264
-#, c-format
-msgid "duplicate NETCLASS name '%s' in file <%s> at line %d, offset %d"
-msgstr ""
-"重複したネットクラス '%s' がファイル <%s>  %d 行目, 位置 %d に見つかりました"
-
-#: pcbnew/pcb_parser.cpp:1907
-#, c-format
-msgid "cannot handle module text type %s"
-msgstr "モジュールのテキストタイプ %s は扱うことが出来ません。"
-
-#: pcbnew/pcb_parser.cpp:2315 pcbnew/pcb_parser.cpp:2321
-#: pcbnew/pcb_parser.cpp:2421 pcbnew/pcb_parser.cpp:2503
-#: pcbnew/pcb_parser.cpp:2567
-#, c-format
-msgid ""
-"invalid net ID in\n"
-"file: <%s>\n"
-"line: %d\n"
-"offset: %d"
-msgstr ""
-"不正な net ID が見つかりました: \n"
-"ファイル:<%s>\n"
-"%d行目\n"
-"%d文字目"
-
-#: pcbnew/pcb_parser.cpp:2879
-#, c-format
-msgid ""
-"There is a zone that belongs to a not existing net\n"
-"\"%s\"\n"
-"you should verify and edit it (run DRC test)."
-msgstr ""
-"ゾーンは存在しないネット\n"
-"\"%s\"\n"
-"に属しています。確認して修正して下さい。(DRC テストを実施)"
-
-#: pcbnew/pcbframe.cpp:583 eeschema/schframe.cpp:619
-#, c-format
-msgid ""
-"Save the changes in\n"
-"'%s'\n"
-"before closing?"
-msgstr ""
-"閉じる前に下記の変更を保存しますか？\n"
-"'%s'\n"
-" "
-
-#: pcbnew/pcbframe.cpp:619
-#, c-format
-msgid "The auto save file '%s' could not be removed!"
-msgstr "自動保存ファイル '%s' は削除できませんでした!"
-
-#: pcbnew/pcbframe.cpp:969
-msgid " [new file]"
-msgstr " [新規ファイル]"
-
-#: pcbnew/pcbnew.cpp:326
-msgid ""
-"You have run Pcbnew for the first time using the new footprint library table "
-"method for finding footprints.\n"
-"Pcbnew has either copied the default table or created an empty table in the "
-"kicad configuration folder.\n"
-"You must first configure the library table to include all footprint "
-"libraries you want to use.\n"
-"See the \"Footprint Library  Table\" section of the CvPcb or Pcbnew "
-"documentation for more information."
-msgstr ""
-"Pcbnew は、最初の起動から新しいフットプリント ライブラリ テーブルを使う方法で"
-"実行されます。.\n"
-"Pcbnew はまた、KiCad 設定 フォルダにデフォルト テーブルのコピーまたは空のテー"
-"ブルを作ります。\n"
-"まず初めに、使いたい全てのフットプリントライブラリを含むようにライブラリ テー"
-"ブルを設定しなければなりません。\n"
-"詳細は、CvPcb か Pcbnew のドキュメントにある \"フットプリント ライブラリ テー"
-"ブル\" の章を参照してください."
-
-#: pcbnew/pcbnew.cpp:339 cvpcb/cvpcb.cpp:184
-#, c-format
-msgid ""
-"An error occurred attempting to load the global footprint library table:\n"
-"\n"
-"%s"
-msgstr ""
-"グローバル フットプリント ライブラリ テーブルを読み込もうとしたところ、エラー"
-"が発生しました。\n"
-"\n"
-"%s"
-
-#: pcbnew/pcbnew_config.cpp:80 pcbnew/dialogs/dialog_general_options.cpp:243
-#: gerbview/events_called_functions.cpp:381 gerbview/menubar.cpp:155
-#: gerbview/menubar.cpp:157 gerbview/options.cpp:89
-msgid "Hide &Layers Manager"
-msgstr "レイヤマネージャを非表示(&L)"
-
-#: pcbnew/pcbnew_config.cpp:80 pcbnew/dialogs/dialog_general_options.cpp:243
-#: gerbview/events_called_functions.cpp:381 gerbview/menubar.cpp:157
-#: gerbview/options.cpp:89
-msgid "Show &Layers Manager"
-msgstr "レイヤマネージャを表示(&L)"
-
-#: pcbnew/pcbnew_config.cpp:90 pcbnew/dialogs/dialog_general_options.cpp:232
-msgid "Hide Microwave Toolbar"
-msgstr "高周波設計支援ツールバーを隠す"
-
-#: pcbnew/pcbnew_config.cpp:217 eeschema/eeschema_config.cpp:262
-msgid "Read Project File"
-msgstr "プロジェクトファイルの読込み"
-
-#: pcbnew/pcbnew_config.cpp:227 pcbnew/pcbnew_config.cpp:504
-#: gerbview/excellon_read_drill_file.cpp:199
-#, c-format
-msgid "File %s not found"
-msgstr "ファイル %s が見つかりません"
-
-#: pcbnew/pcbnew_config.cpp:300 eeschema/eeschema_config.cpp:493
-msgid "Save Project File"
-msgstr "プロジェクト ファイルの保存"
-
-#: pcbnew/pcbnew_config.cpp:446
-msgid "Save Macros File"
-msgstr "マクロ ファイルの保存"
-
-#: pcbnew/pcbnew_config.cpp:494
-msgid "Read Macros File"
-msgstr "マクロ ファイルの読込み"
-
-#: pcbnew/plot_board_layers.cpp:116 pcbnew/plot_board_layers.cpp:301
-#, c-format
-msgid "Your BOARD has a bad layer number for module %s"
-msgstr "ボードがモジュール %s に対して不正なレイヤ番号を持っています"
-
-#: pcbnew/plugin.cpp:118
-msgid "Enable <b>debug</b> logging for Footprint*() functions in this PLUGIN."
-msgstr "このプラグインで Footprint*() 関数の<b>デバッグ</b>を有効にします"
-
-#: pcbnew/plugin.cpp:122
-msgid "Regular expression <b>footprint name</b> filter."
-msgstr "正規表現で<b>フットプリント名</b>を絞込み。"
-
-#: pcbnew/plugin.cpp:126
-msgid ""
-"Enable transaction logging. The mere presence of this option turns on the "
-"logging, no need to set a Value."
-msgstr ""
-"トランザクションのログを許可する。このオプションを有効にするだけでログを開始"
-"します。値のセットは必要ありません。"
-
-#: pcbnew/plugin.cpp:131
-msgid "User name for <b>login</b> to some special library server."
-msgstr "特別なライブラリサーバーへ <b>ログイン</b> するためのユーザー名."
-
-#: pcbnew/plugin.cpp:135
-msgid "Password for <b>login</b> to some special library server."
-msgstr "特別なライブラリサーバーへ <b>ログイン</b> するためのパスワード."
-
-#: pcbnew/plugin.cpp:143
-msgid ""
-"Enter the python module which implements the PLUGIN::Footprint*() functions."
-msgstr ""
-"PLUGIN::Footprint*() 関数が定義されている Python モジュールを入力して下さい。"
-
-# この訳は本当？
-# 2014.03.08 Zenyouji
-#: pcbnew/sel_layer.cpp:301
-msgid "Warning: The Top Layer and Bottom Layer are same."
-msgstr "警告: ペア層に同じレイヤが指定されています。"
-
-#: pcbnew/specctra_export.cpp:140
-#: pcbnew/dialogs/dialog_freeroute_exchange.cpp:194
-msgid "Specctra DSN file:"
-msgstr "Specctra DSN ファイル:"
-
-#: pcbnew/specctra_export.cpp:203
-msgid "BOARD exported OK."
-msgstr "ボードは正しくエクスポートされました。"
-
-#: pcbnew/specctra_export.cpp:208
-msgid "Unable to export, please fix and try again."
-msgstr "エクスポートできません。問題点を修正してやり直してください。"
-
-#: pcbnew/specctra_export.cpp:1026 pcbnew/specctra_export.cpp:1133
-#: pcbnew/specctra_export.cpp:1269
-#, c-format
-msgid "Unsupported DRAWSEGMENT type %s"
-msgstr "%s はサポートされていないDRAWSEGMENTタイプです"
-
-#: pcbnew/specctra_export.cpp:1158
-#, c-format
-msgid ""
-"Unable to find the next boundary segment with an endpoint of (%s mm, %s "
-"mm).\n"
-"Edit Edge.Cuts perimeter graphics, making them contiguous polygons each."
-msgstr ""
-"終点 (%s mm, %s mm) で次の境界線が見つかりませんでした.\n"
-"基板外形図で、外形線を互いに隣接するように編集してください."
-
-#: pcbnew/specctra_export.cpp:1294
-#, c-format
-msgid ""
-"Unable to find the next keepout segment with an endpoint of (%s mm, %s mm).\n"
-"Edit Edge.Cuts interior graphics, making them contiguous polygons each."
-msgstr ""
-"終点 (%s mm, %s mm) で次の禁止領域の境界線が見つかりませんでした.\n"
-"基板外形図で、内部の境界線を互いに隣接するように編集してください."
-
-#: pcbnew/specctra_export.cpp:1455
-#, c-format
-msgid "Component with value of '%s' has empty reference id."
-msgstr "定数 \"%s\" のコンポーネントのリファレンスIDが空です。"
-
-#: pcbnew/specctra_export.cpp:1463
-#, c-format
-msgid "Multiple components have identical reference IDs of '%s'."
-msgstr "複数のコンポーネントが同一のリファレンスID '%s' を持っています。"
-
-#: pcbnew/specctra_import.cpp:84
-msgid "Merge Specctra Session file:"
-msgstr "Spectra セッションファイルのマージ"
-
-#: pcbnew/specctra_import.cpp:109
-msgid "BOARD may be corrupted, do not save it."
-msgstr "ボードが壊れているかもしれません、保存しないでください。"
-
-#: pcbnew/specctra_import.cpp:111
-msgid "Fix problem and try again."
-msgstr "問題を修正してやり直してください。"
-
-#: pcbnew/specctra_import.cpp:129
-msgid "Session file imported and merged OK."
-msgstr "セッション ファイルはインポートされ、正常にマージできました。"
-
-#: pcbnew/specctra_import.cpp:201 pcbnew/specctra_import.cpp:313
-#, c-format
-msgid "Session file uses invalid layer id \"%s\""
-msgstr "セッションファイルで不正なレイヤID \"%s\" が使用されています"
-
-#: pcbnew/specctra_import.cpp:254
-msgid "Session via padstack has no shapes"
-msgstr "セッション ビアのパッドスタックの形状がありません"
-
-#: pcbnew/specctra_import.cpp:261 pcbnew/specctra_import.cpp:279
-#: pcbnew/specctra_import.cpp:304
-#, c-format
-msgid "Unsupported via shape: %s"
-msgstr "サポートされていないビアの形: %s"
-
-#: pcbnew/specctra_import.cpp:360
-msgid "Session file is missing the \"session\" section"
-msgstr "セッションファイルに \"session\" セクションが見つかりません"
-
-#: pcbnew/specctra_import.cpp:368
-msgid "Session file is missing the \"routes\" section"
-msgstr "セッションファイルに \"routes\" セクションが見つかりません"
-
-#: pcbnew/specctra_import.cpp:371
-msgid "Session file is missing the \"library_out\" section"
-msgstr "セッションファイルに \"library_out\" セクションが見つかりません"
-
-#: pcbnew/specctra_import.cpp:398
-#, c-format
-msgid "Session file has 'reference' to non-existent component \"%s\""
-msgstr "セッションファイルが存在しないコンポーネント \"%s\" を参照しています。"
-
-#: pcbnew/specctra_import.cpp:546
-#, c-format
-msgid "A wire_via references a missing padstack \"%s\""
-msgstr "wire_via が失われたパッドスタック \"%s\" を参照しています"
-
-#: pcbnew/swap_layers.cpp:94
-msgid "Swap Layers:"
-msgstr "レイヤの入替え:"
-
-#: pcbnew/swap_layers.cpp:245 pcbnew/swap_layers.cpp:252
-#: pcbnew/swap_layers.cpp:330
-msgid "No Change"
-msgstr "変更なし"
-
-#: pcbnew/swap_layers.cpp:285
-msgid "&OK"
-msgstr "&OK"
-
-#: pcbnew/swap_layers.cpp:289
-msgid "&Cancel"
-msgstr "キャンセル(&C)"
-
-#: pcbnew/tool_modedit.cpp:62
-msgid "Create new library and save current footprint"
-msgstr "新規ライブラリを作成して現在のフットプリントを保存"
-
-#: pcbnew/tool_modedit.cpp:65 pcbnew/tool_pcb.cpp:239
-msgid "Open footprint viewer"
-msgstr "フットプリントビューアを開く"
-
-#: pcbnew/tool_modedit.cpp:69
-msgid "Delete part from active library"
-msgstr "アクティブなライブラリからパーツを削除"
-
-#: pcbnew/tool_modedit.cpp:73
-msgid "New footprint"
-msgstr "新規フットプリント"
-
-#: pcbnew/tool_modedit.cpp:78
-msgid "New footprint using wizard"
-msgstr "ウィザードを使用して新規フットプリントを作成"
-
-#: pcbnew/tool_modedit.cpp:84
-msgid "Load footprint from library"
-msgstr "ライブラリからフットプリントを開く"
-
-#: pcbnew/tool_modedit.cpp:89
-msgid "Load footprint from current board"
-msgstr "現在のボードからフットプリントを読み込む"
-
-#: pcbnew/tool_modedit.cpp:93
-msgid "Update footprint in current board"
-msgstr "現在のボードのフットプリントを更新"
-
-#: pcbnew/tool_modedit.cpp:97
-msgid "Insert footprint into current board"
-msgstr "現在のボードへフットプリントを挿入"
-
-#: pcbnew/tool_modedit.cpp:101
-msgid "Import footprint"
-msgstr "フットプリントのインポート"
-
-#: pcbnew/tool_modedit.cpp:104
-msgid "Export footprint"
-msgstr "フットプリントのエクスポート"
-
-#: pcbnew/tool_modedit.cpp:109 pcbnew/help_common_strings.h:15
-msgid "Undo last edition"
-msgstr "一つ前の編集を元に戻す"
-
-#: pcbnew/tool_modedit.cpp:111 eeschema/menubar_libedit.cpp:131
-#: pcbnew/help_common_strings.h:16
-msgid "Redo the last undo command"
-msgstr "一つ前のコマンドをやり直し"
-
-#: pcbnew/tool_modedit.cpp:116
-msgid "Footprint properties"
-msgstr "フットプリントのプロパティ"
-
-#: pcbnew/tool_modedit.cpp:120
-msgid "Print footprint"
-msgstr "フットプリントの印刷"
-
-#: pcbnew/tool_modedit.cpp:144
-msgid "Check footprint"
-msgstr "フットプリントの確認"
-
-#: pcbnew/tool_modedit.cpp:166 pcbnew/tools/common_actions.cpp:414
-#: pcbnew/tools/module_tools.cpp:86
-msgid "Add pads"
-msgstr "パッド入力"
-
-#: pcbnew/tool_modedit.cpp:179 pagelayout_editor/onrightclick.cpp:49
-msgid "Add Text"
-msgstr "テキスト入力"
-
-#: pcbnew/tool_modedit.cpp:183
-msgid "Place the footprint reference anchor"
-msgstr "フットプリントのアンカー (基準点) を配置"
-
-#: pcbnew/tool_modedit.cpp:208 pcbnew/tool_pcb.cpp:337
-#: cvpcb/class_DisplayFootprintsFrame.cpp:176 common/draw_frame.cpp:322
-msgid "Hide grid"
-msgstr "グリッドを非表示"
-
-#: pcbnew/tool_modedit.cpp:212
-msgid "Display Polar Coord ON"
-msgstr "極座標表示 ON"
-
-#: pcbnew/tool_modedit.cpp:216 pcbnew/tool_pcb.cpp:343
-#: eeschema/tool_lib.cpp:232 cvpcb/class_DisplayFootprintsFrame.cpp:184
-msgid "Units in inches"
-msgstr "インチ単位"
-
-#: pcbnew/tool_modedit.cpp:220 pcbnew/tool_pcb.cpp:346
-#: eeschema/tool_lib.cpp:236 cvpcb/class_DisplayFootprintsFrame.cpp:188
-msgid "Units in millimeters"
-msgstr "ミリメートル単位"
-
-#: pcbnew/tool_modedit.cpp:224
-msgid "Change Cursor Shape"
-msgstr "カーソルの形を変える"
-
-#: pcbnew/tool_modedit.cpp:229
-msgid "Show Pads Sketch"
-msgstr "パッドのスケッチ表示"
-
-#: pcbnew/tool_modedit.cpp:233
-msgid "Show Texts Sketch"
-msgstr "テキストのスケッチ表示"
-
-#: pcbnew/tool_modedit.cpp:237
-msgid "Show Edges Sketch"
-msgstr "エッジのスケッチ表示"
-
-#: pcbnew/tool_modedit.cpp:241 pcbnew/tool_pcb.cpp:392
-msgid "Enable high contrast display mode"
-msgstr "ハイコントラスト表示モードを有効化"
-
-#: pcbnew/tool_modview.cpp:58 eeschema/tool_viewlib.cpp:59
-msgid "Select library to browse"
-msgstr "参照するライブラリの選択"
-
-#: pcbnew/tool_modview.cpp:62
-msgid "Select footprint to browse"
-msgstr "参照するパーツの選択"
-
-#: pcbnew/tool_modview.cpp:67
-msgid "Display previous footprint"
-msgstr "前のフットプリントの表示"
-
-#: pcbnew/tool_modview.cpp:71
-msgid "Display next footprint"
-msgstr "次のフットプリントを表示"
-
-#: pcbnew/tool_modview.cpp:104
-msgid "Insert footprint in board"
-msgstr "ボードへフットプリントを挿入"
-
-#: pcbnew/tool_modview.cpp:144 eeschema/tool_viewlib.cpp:211
-msgid "Set Current Library"
-msgstr "現在のライブラリ"
-
-#: pcbnew/tool_modview.cpp:145 eeschema/tool_viewlib.cpp:212
-msgid "Select library to be displayed"
-msgstr "参照するライブラリの選択"
-
-#: pcbnew/tool_modview.cpp:151
-msgid "Close footprint viewer"
-msgstr "フットプリントビューアを閉じる"
-
-#: pcbnew/tool_modview.cpp:177
-msgid "3&D Viewer"
-msgstr "3Dビューア(&3)"
-
-#: pcbnew/tool_pcb.cpp:52
-msgid ""
-"Show active layer selections\n"
-"and select layer pair for route and place via"
-msgstr ""
-"ペアレイヤの設定\n"
-"配線及びビア配置に使用するペア層を選択します。"
-
-#: pcbnew/tool_pcb.cpp:220
-msgid "New board"
-msgstr "新規ボード"
-
-#: pcbnew/tool_pcb.cpp:222
-msgid "Open existing board"
-msgstr "既存のボードを開く"
-
-#: pcbnew/tool_pcb.cpp:226
-msgid "Save board"
-msgstr "ボードの保存"
-
-#: pcbnew/tool_pcb.cpp:235
-msgid "Open footprint editor"
-msgstr "フットプリントエディタを開く"
-
-#: pcbnew/tool_pcb.cpp:251
-msgid "Plot (HPGL, PostScript, or GERBER format)"
-msgstr "プロット (HGPL, PostScript, GERBER フォーマット)"
-
-#: pcbnew/tool_pcb.cpp:273
-msgid "Read netlist"
-msgstr "ネットリストの読込み"
-
-#: pcbnew/tool_pcb.cpp:295
-msgid "Mode footprint: manual and automatic movement and placement"
-msgstr "フットプリントモード：手動/自動での配置と移動 "
-
-#: pcbnew/tool_pcb.cpp:298
-msgid "Mode track: autorouting"
-msgstr ""
-"トラック モード\n"
-"自動配線"
-
-#: pcbnew/tool_pcb.cpp:304
-msgid "Fast access to the FreeROUTE external advanced router"
-msgstr "上級なルータであるウェブベースの FreeROUTE へのクイックアクセス"
-
-#: pcbnew/tool_pcb.cpp:335 pcbnew/toolbars_update_user_interface.cpp:136
-msgid "Enable design rule checking"
-msgstr "デザインルール チェックを有効化"
-
-#: pcbnew/tool_pcb.cpp:349 eeschema/tool_lib.cpp:240 eeschema/tool_sch.cpp:291
-#: cvpcb/class_DisplayFootprintsFrame.cpp:192 gerbview/toolbars_gerber.cpp:167
-msgid "Change cursor shape"
-msgstr "カーソルの形を変える"
-
-#: pcbnew/tool_pcb.cpp:354 pcbnew/toolbars_update_user_interface.cpp:145
-msgid "Show board ratsnest"
-msgstr "ボードのラッツネストを表示"
-
-#: pcbnew/tool_pcb.cpp:357
-msgid "Show footprint ratsnest when moving"
-msgstr "移動時にフットプリントのラッツネストを表示する"
-
-#: pcbnew/tool_pcb.cpp:363
-msgid "Enable automatic track deletion"
-msgstr "自動的な配線削除を有効化"
-
-#: pcbnew/tool_pcb.cpp:368 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:48
-msgid "Show filled areas in zones"
-msgstr "ゾーンの塗りつぶし領域を表示"
-
-#: pcbnew/tool_pcb.cpp:371
-msgid "Do not show filled areas in zones"
-msgstr "ゾーンの塗りつぶし領域を非表示"
-
-#: pcbnew/tool_pcb.cpp:374
-msgid "Show outlines of filled areas only in zones"
-msgstr "ゾーンの塗りつぶし領域をアウトラインで表示"
-
-#: pcbnew/tool_pcb.cpp:383 pcbnew/toolbars_update_user_interface.cpp:176
-msgid "Show vias in outline mode"
-msgstr "アウトライン モードでビアを表示"
-
-#: pcbnew/tool_pcb.cpp:387 pcbnew/toolbars_update_user_interface.cpp:187
-msgid "Show tracks in outline mode"
-msgstr "アウトライン モードで配線を表示"
-
-#: pcbnew/tool_pcb.cpp:436
-msgid "Display local ratsnest"
-msgstr "ローカル ラッツネストの表示"
-
-#: pcbnew/tool_pcb.cpp:507
-msgid "Create line of specified length for microwave applications"
-msgstr "高周波設計用の指定長の線を作成"
-
-#: pcbnew/tool_pcb.cpp:512
-msgid "Create gap of specified length for microwave applications"
-msgstr "高周波設計用の指定長のギャップを作成"
-
-#: pcbnew/tool_pcb.cpp:519
-msgid "Create stub of specified length for microwave applications"
-msgstr "高周波設計用の指定長のスタブを作成"
-
-#: pcbnew/tool_pcb.cpp:524
-msgid "Create stub (arc) of specified length for microwave applications"
-msgstr "高周波設計用の指定長のスタブ (円弧) を作成"
-
-#: pcbnew/tool_pcb.cpp:529
-msgid "Create a polynomial shape for microwave applications"
-msgstr "高周波設計用の多節形を作成"
-
-#: pcbnew/tool_pcb.cpp:593
-msgid ""
-"Auto track width: when starting on an existing track use its width\n"
-"otherwise, use current width setting"
-msgstr ""
-"自動配線幅: \n"
-"既に存在する配線がある場合には、その配線幅を使用します。\n"
-"それ以外の場合には、現在の幅の設定値を使用します。"
-
-#: pcbnew/tool_pcb.cpp:639
-#, c-format
-msgid "Track: %.3f mm (%.2f mils)"
-msgstr "配線: %.3f mm (%.2f mils)"
-
-#: pcbnew/tool_pcb.cpp:642
-#, c-format
-msgid "Track: %.2f mils (%.3f mm)"
-msgstr "配線: %.2f mils (%.3f mm)"
-
-#: pcbnew/tool_pcb.cpp:677
-#, c-format
-msgid "Via: %.2f mm (%.1f mils)"
-msgstr "ビア: %.2f mm (%.1f mils)"
-
-#: pcbnew/tool_pcb.cpp:680
-#, c-format
-msgid "Via: %.1f mils (%.2f mm)"
-msgstr "ビア: %.1f mils (%.2f mm)"
-
-#: pcbnew/tool_pcb.cpp:693
-#, c-format
-msgid "%.2f mm (%.1f mils)"
-msgstr "%.2f mm (%.1f mils)"
-
-#: pcbnew/tool_pcb.cpp:696
-#, c-format
-msgid "%.1f mils (%.2f mm)"
-msgstr "%.1f mils (%.2f mm)"
-
-#: pcbnew/tool_pcb.cpp:721
-msgid "+/- to switch"
-msgstr "+/- でスイッチします"
-
-#: pcbnew/toolbars_update_user_interface.cpp:135
-msgid "Disable design rule checking"
-msgstr "デザインルール チェックを無効化"
-
-#: pcbnew/toolbars_update_user_interface.cpp:144
-msgid "Hide board ratsnest"
-msgstr "ボードのラッツネストを非表示"
-
-#: pcbnew/toolbars_update_user_interface.cpp:155
-msgid "Hide footprint ratsnest"
-msgstr "フットプリントのラッツネストを隠す"
-
-#: pcbnew/toolbars_update_user_interface.cpp:156
-msgid "Show footprint ratsnest"
-msgstr "フットプリントに接続されたラッツネストを表示"
-
-#: pcbnew/toolbars_update_user_interface.cpp:165
-msgid "Disable auto delete old track"
-msgstr "古い配線の自動削除を無効化"
-
-#: pcbnew/toolbars_update_user_interface.cpp:166
-msgid "Enable auto delete old track"
-msgstr "古い配線の自動削除を有効化"
-
-#: pcbnew/toolbars_update_user_interface.cpp:177
-msgid "Show vias in fill mode"
-msgstr "フィル モードでビアを表示"
-
-#: pcbnew/toolbars_update_user_interface.cpp:188
-msgid "Show tracks in fill mode"
-msgstr "フィル モードで配線を表示"
-
-#: pcbnew/toolbars_update_user_interface.cpp:198
-msgid "Normal contrast display mode"
-msgstr "ノーマル コントラスト表示モード"
-
-#: pcbnew/toolbars_update_user_interface.cpp:199
-msgid "High contrast display mode"
-msgstr "ハイコントラスト表示モード"
-
-#: pcbnew/xchgmod.cpp:123
-#, c-format
-msgid "Change footprint of '%s'"
-msgstr "フットプリント '%s' の変更"
-
-#: pcbnew/xchgmod.cpp:131
-#, c-format
-msgid "Change footprints '%s'"
-msgstr "フットプリント '%s' の変更"
-
-#: pcbnew/xchgmod.cpp:217
-#, c-format
-msgid "File '%s' created\n"
-msgstr "ファイル '%s' が生成されました。\n"
-
-#: pcbnew/xchgmod.cpp:222
-#, c-format
-msgid "** Could not create file '%s' ***\n"
-msgstr "** ファイル '%s' が生成できませんでした ***\n"
-
-#: pcbnew/xchgmod.cpp:282
-#, c-format
-msgid "Change footprint %s -> %s (for value = %s)?"
-msgstr "フットプリントを変更しますか？ %s → %s (値 = %s)"
-
-#: pcbnew/xchgmod.cpp:289
-#, c-format
-msgid "Change footprint %s -> %s ?"
-msgstr "フットプリントを変更しますか？ %s → %s"
-
-#: pcbnew/xchgmod.cpp:344
-msgid "Are you sure you want to change all footprints?"
-msgstr "本当に全てのフットプリントを変更して宜しいですか？"
-
-#: pcbnew/xchgmod.cpp:394
-#, c-format
-msgid "Change footprint '%s' (from '%s') to '%s'"
-msgstr "フットプリント '%s' の値を， '%s' から '%s' に変更"
-
-#: pcbnew/xchgmod.cpp:525
-msgid "No footprints!"
-msgstr "フットプリントがありません！"
-
-#: pcbnew/xchgmod.cpp:536
-msgid "Save Footprint Association File"
-msgstr "フットプリントの関連付けファイルの保存"
-
-#: pcbnew/xchgmod.cpp:547
-#, c-format
-msgid "Could not create file '%s'"
-msgstr "ファイル '%s' が作成できません"
-
-#: pcbnew/zones_by_polygon.cpp:131
-msgid ""
-"The duplicated zone is on the same layer as the initial zone, which has no "
-"sense.\n"
-"Please, choose an other layer for the new zone"
-msgstr ""
-"重複したゾーンが同じレイヤに既に存在するので、意味がありません.\n"
-"新しいゾーンには別のレイヤを選んでください"
-
-#: pcbnew/zones_by_polygon.cpp:162
-msgid "The outline of the duplicated zone fails DRC check!"
-msgstr "重複したゾーンの外形線が DRC で不正となりました！"
-
-#: pcbnew/zones_by_polygon.cpp:366 pcbnew/zones_by_polygon.cpp:424
-#: pcbnew/zones_by_polygon.cpp:811
-msgid "Area: DRC outline error"
-msgstr "エリア: DRCアウトライン エラー"
-
-#: pcbnew/zones_by_polygon.cpp:539
-msgid "Error: a keepout area is allowed only on copper layers"
-msgstr "エラー: キープアウト(禁止)エリアは導体レイヤ上のみに配置できます。"
-
-#: pcbnew/zones_by_polygon.cpp:686
-msgid "DRC error: this start point is inside or too close an other area"
-msgstr "DRCエラー: 開始点が内部にあるか、他のエリアに近すぎます"
-
-#: pcbnew/zones_by_polygon.cpp:745
-msgid "DRC error: closing this area creates a drc error with an other area"
-msgstr "DRCエラー: このゾーンを閉じると他のエリアとのDRCエラーが発生します"
-
-#: pcbnew/zones_by_polygon_fill_functions.cpp:46
-#, c-format
-msgid "Filling zone %d out of %d (net %s)..."
-msgstr "ゾーンの塗りつぶし中 %d out of %d (ネット %s)..."
-
-#: pcbnew/zones_by_polygon_fill_functions.cpp:140
-msgid "Fill All Zones"
-msgstr "全ゾーンの塗りつぶし"
-
-#: pcbnew/zones_by_polygon_fill_functions.cpp:146
-msgid "Starting zone fill..."
-msgstr "ゾーンの塗りつぶしを開始しています..."
-
-#: pcbnew/zones_by_polygon_fill_functions.cpp:175
-msgid "Updating ratsnest..."
-msgstr "ラッツネストの更新中..."
-
-#: pcbnew/autorouter/auto_place_footprints.cpp:165
-msgid "Footprints NOT LOCKED will be moved"
-msgstr "ロックしていないフットプリントは移動されます"
-
-#: pcbnew/autorouter/auto_place_footprints.cpp:172
-msgid "Footprints NOT PLACED will be moved"
-msgstr "配置していないフットプリントは移動されます"
-
-#: pcbnew/autorouter/auto_place_footprints.cpp:281
-#, c-format
-msgid "Place footprint %d of %d"
-msgstr "フットプリント %d / %d の配置"
-
-#: pcbnew/autorouter/auto_place_footprints.cpp:466
-msgid "No PCB edge found, unknown board size!"
-msgstr "基板外形がないため、ボードサイズが不明です。"
-
-#: pcbnew/autorouter/auto_place_footprints.cpp:475
-msgid "Cols"
-msgstr "列"
-
-#: pcbnew/autorouter/auto_place_footprints.cpp:477
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:55
-msgid "Lines"
-msgstr "行"
-
-#: pcbnew/autorouter/auto_place_footprints.cpp:479
-msgid "Cells."
-msgstr "セル"
-
-#: pcbnew/autorouter/auto_place_footprints.cpp:692
-msgid "OK to abort?"
-msgstr "中止して宜しいですか？"
-
-#: pcbnew/autorouter/autorout.cpp:90
-msgid "Net not selected"
-msgstr "ネットが選択されていません"
-
-#: pcbnew/autorouter/autorout.cpp:98
-msgid "Footprint not selected"
-msgstr "フットプリントが選択されていません"
-
-#: pcbnew/autorouter/autorout.cpp:108
-msgid "Pad not selected"
-msgstr "パッドが選択されていません"
-
-#: pcbnew/autorouter/autorout.cpp:180
-msgid "No memory for autorouting"
-msgstr "オートルーターのためのメモリがありません"
-
-#: pcbnew/autorouter/autorout.cpp:185
-msgid "Place Cells"
-msgstr "セルの配置"
-
-#: pcbnew/autorouter/move_and_route_event_functions.cpp:133
-msgid "Not locked footprints inside the board will be moved. OK?"
-msgstr "基板内側のロックしていないフットプリントは移動されます。宜しいですか？"
-
-#: pcbnew/autorouter/move_and_route_event_functions.cpp:139
-msgid "No footprint found!"
-msgstr "フットプリントが見つかりません！"
-
-#: pcbnew/autorouter/solve.cpp:301
-msgid "Abort routing?"
-msgstr "配線作業を中止しますか？"
-
-#: pcbnew/autorouter/spread_footprints.cpp:181
-msgid "Could not automatically place footprints. No board outlines detected."
-msgstr "フットプリントを自動配置できません。基板外形が検出できません。"
-
-#: pcbnew/dialogs/dialog_block_options_base.cpp:20
-#: pcbnew/dialogs/dialog_exchange_modules_base.cpp:48
-#: pcbnew/dialogs/dialog_fp_lib_table.cpp:209
-#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:98
-#: pcbnew/dialogs/dialog_plot_base.cpp:85
-#: pcbnew/dialogs/dialog_pns_settings_base.cpp:26
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:112
-#: eeschema/dialogs/dialog_erc_base.cpp:135
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:77
-#: bitmap2component/bitmap2cmp_gui_base.cpp:137
-msgid "Options"
-msgstr "オプション"
+"Selection of the pen size used to draw items which have no pen size "
+"specified."
+msgstr "太さが０にセットされているアイテムを描画する時の、標準ペン幅を選択"
+
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:75
+msgid "Print mode"
+msgstr "印刷モード"
+
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:81
+msgid "Full page with  frame ref"
+msgstr "図枠付きフルページ"
+
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:81
+msgid "Current page size"
+msgstr "現在の用紙サイズ"
+
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:81
+msgid "Board area only"
+msgstr "ボードの範囲のみ"
+
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:83
+msgid "SVG Page Size"
+msgstr "SVGページ サイズ"
+
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:87
+msgid "Print board edges"
+msgstr "基板外形を出力"
+
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:89
+msgid "Print (or not) the edges layer on others layers"
+msgstr "基板外形レイヤを他のレイヤに印刷する"
+
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:93
+msgid "Print mirrored"
+msgstr "反転印刷"
+
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:94
+msgid "Print the layer(s) horizontally mirrored"
+msgstr "水平反転してレイヤを印刷"
+
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:104
+msgid "One file per layer"
+msgstr "レイヤごとにファイルを出力する"
+
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:104
+msgid "All in one file"
+msgstr "全てを1つのファイルへまとめる"
+
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:106
+msgid "File option:"
+msgstr "ファイルオプション:"
+
+#: pcbnew/dialogs/dialog_SVG_print_base.cpp:110
+#: pcbnew/dialogs/dialog_plot_base.cpp:382
+#: pcbnew/dialogs/dialog_plot_base.h:132
+msgid "Plot"
+msgstr "製造ファイル出力"
 
 #: pcbnew/dialogs/dialog_block_options_base.cpp:25
 msgid "Include &footprints"
@@ -5872,26 +12764,26 @@ msgstr "未接続の配線を削除(&e)"
 msgid "delete track segment having a dangling end"
 msgstr "浮いている終端を持つ配線セグメントを削除"
 
-#: pcbnew/dialogs/dialog_copper_zones.cpp:407
+#: pcbnew/dialogs/dialog_copper_zones.cpp:408
 #, c-format
 msgid "Clearance must be smaller than %f\" / %f mm."
 msgstr "クリアランスは %f\" / %f mm より小さい必要があります。"
 
-#: pcbnew/dialogs/dialog_copper_zones.cpp:419
+#: pcbnew/dialogs/dialog_copper_zones.cpp:420
 #, c-format
 msgid "Minimum width must be larger than %f\" / %f mm."
 msgstr "最小幅は %f\" / %f mm より大い必要があります。"
 
-#: pcbnew/dialogs/dialog_copper_zones.cpp:457
+#: pcbnew/dialogs/dialog_copper_zones.cpp:458
 msgid "Thermal relief spoke must be greater than the minimum width."
 msgstr "サーマルリリーフのスポーク幅は最小幅より太い必要があります。"
 
-#: pcbnew/dialogs/dialog_copper_zones.cpp:470
-#: pcbnew/dialogs/dialog_keepout_area_properties.cpp:223
+#: pcbnew/dialogs/dialog_copper_zones.cpp:471
+#: pcbnew/dialogs/dialog_keepout_area_properties.cpp:227
 msgid "No layer selected."
 msgstr "レイヤが選択されていません"
 
-#: pcbnew/dialogs/dialog_copper_zones.cpp:481
+#: pcbnew/dialogs/dialog_copper_zones.cpp:482
 msgid "No net selected."
 msgstr "ネットが選択されていません"
 
@@ -5903,11 +12795,11 @@ msgstr ""
 "\"ネットなし\"オプションが選択されました。浮きパターンを作成します。宜しいで"
 "すか？"
 
-#: pcbnew/dialogs/dialog_copper_zones.cpp:521
+#: pcbnew/dialogs/dialog_copper_zones.cpp:523
 msgid "Chamfer distance"
 msgstr "面取り長さ"
 
-#: pcbnew/dialogs/dialog_copper_zones.cpp:527
+#: pcbnew/dialogs/dialog_copper_zones.cpp:529
 msgid "Fillet radius"
 msgstr "フィレット半径"
 
@@ -6004,17 +12896,6 @@ msgstr "塗りつぶしエリアの最小幅"
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:126
 msgid "Corner smoothing:"
 msgstr "コーナーのスムージング"
-
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:130
-#: pcbnew/dialogs/dialog_copper_zones_base.cpp:154
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:200
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:324
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:474
-#: pcbnew/dialogs/dialog_plot_base.cpp:144 eeschema/libedit.cpp:480
-#: eeschema/viewlibs.cpp:295
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:50
-msgid "None"
-msgstr "なし"
 
 #: pcbnew/dialogs/dialog_copper_zones_base.cpp:130
 msgid "Chamfer"
@@ -6175,27 +13056,6 @@ msgstr "縦(Y)方向の数："
 msgid "Horizontal spacing:"
 msgstr "横(X)方向の間隔："
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:50
-#: pcbnew/dialogs/dialog_create_array_base.cpp:61
-#: pcbnew/dialogs/dialog_create_array_base.cpp:72
-#: pcbnew/dialogs/dialog_create_array_base.cpp:83
-#: pcbnew/dialogs/dialog_create_array_base.cpp:187
-#: pcbnew/dialogs/dialog_create_array_base.cpp:198
-#: pcbnew/dialogs/dialog_export_idf_base.cpp:46
-#: pcbnew/dialogs/dialog_export_vrml_base.cpp:64
-#: pcbnew/dialogs/dialog_export_vrml_base.cpp:98
-#: pcbnew/dialogs/dialog_gen_module_position_file_base.cpp:55
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:35
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:49
-#: pcbnew/import_dxf/dialog_dxf_import_base.cpp:90
-#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:45 common/common.cpp:144
-#: common/common.cpp:202 common/draw_frame.cpp:485
-#: common/dialogs/dialog_page_settings.cpp:466
-#: bitmap2component/bitmap2cmp_gui_base.cpp:78
-#: pcb_calculator/UnitSelector.cpp:38 pagelayout_editor/pl_editor_frame.cpp:467
-msgid "mm"
-msgstr "mm"
-
 #: pcbnew/dialogs/dialog_create_array_base.cpp:54
 msgid "Vertical spacing:"
 msgstr "縦(Y)方向の間隔："
@@ -6203,24 +13063,6 @@ msgstr "縦(Y)方向の間隔："
 #: pcbnew/dialogs/dialog_create_array_base.cpp:65
 msgid "Horizontal offset:"
 msgstr "横(X)方向のオフセット："
-
-#: pcbnew/dialogs/dialog_create_array_base.cpp:69
-#: pcbnew/dialogs/dialog_create_array_base.cpp:80
-#: pcbnew/dialogs/dialog_create_array_base.cpp:184
-#: pcbnew/dialogs/dialog_create_array_base.cpp:195
-#: pcbnew/dialogs/dialog_create_array_base.cpp:214
-#: pcbnew/dialogs/dialog_export_idf_base.cpp:62
-#: pcbnew/dialogs/dialog_export_idf_base.cpp:76
-#: pcbnew/dialogs/dialog_export_vrml_base.cpp:74
-#: pcbnew/dialogs/dialog_export_vrml_base.cpp:82
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:32
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:46
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:60
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:135
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:237
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:48
-msgid "0"
-msgstr "0"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:76
 msgid "Vertical offset:"
@@ -6323,12 +13165,6 @@ msgid ""
 msgstr ""
 "正の角度は左回りを意味します。 角度 0 は完全な円を \"Count\" で等分割します。"
 
-#: pcbnew/dialogs/dialog_create_array_base.cpp:219
-#: pcbnew/dialogs/dialog_move_exact_base.cpp:63
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:141 common/common.cpp:209
-msgid "deg"
-msgstr "度"
-
 #: pcbnew/dialogs/dialog_create_array_base.cpp:223
 msgid "Count:"
 msgstr "数:"
@@ -6357,6 +13193,7 @@ msgid "Numbering type:"
 msgstr "ナンバリング方式:"
 
 #: pcbnew/dialogs/dialog_create_array_base.cpp:281
+#: pcbnew/dialogs/dialog_pad_properties_base.cpp:68
 msgid "Circular"
 msgstr "円"
 
@@ -6469,11 +13306,6 @@ msgstr "<b>エクストラ ビア %d 径</b> %s &gt; <b>1インチ!</b><br>"
 msgid "Net Classes:"
 msgstr "ネットクラス:"
 
-#: pcbnew/dialogs/dialog_design_rules_base.cpp:49
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:519
-msgid "Track Width"
-msgstr "配線幅"
-
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:50
 msgid "Via Dia"
 msgstr "ビア径"
@@ -6491,41 +13323,13 @@ msgstr "マイクロビア径"
 msgid "uVia Drill"
 msgstr "マイクロビア ドリル"
 
-#: pcbnew/dialogs/dialog_design_rules_base.cpp:59
-#: pcbnew/dialogs/dialog_global_edit_tracks_and_vias.cpp:102
-#: pcbnew/dialogs/dialog_global_edit_tracks_and_vias.cpp:116
-#: pcbnew/dialogs/dialog_global_edit_tracks_and_vias.cpp:126
-#: pcbnew/dialogs/dialog_global_edit_tracks_and_vias.cpp:136
-#: pcbnew/dialogs/dialog_global_edit_tracks_and_vias.cpp:148
-#: common/pgm_base.cpp:109
-msgid "Default"
-msgstr "標準"
-
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:66
 msgid "Net Class parameters"
 msgstr "ネット クラスのパラメータ"
 
-#: pcbnew/dialogs/dialog_design_rules_base.cpp:74
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:186
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:225
-#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:38
-#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:87
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:36
-#: common/dialogs/dialog_env_var_config_base.cpp:63
-msgid "Add"
-msgstr "追加"
-
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:75
 msgid "Add another Net Class"
 msgstr "別のネット クラスを追加"
-
-#: pcbnew/dialogs/dialog_design_rules_base.cpp:79
-#: pcbnew/tools/common_actions.cpp:129
-#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:48
-#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:93
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:39
-msgid "Remove"
-msgstr "削除"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:80
 msgid ""
@@ -6535,15 +13339,6 @@ msgstr ""
 "現在選択中のネットクラスを削除\n"
 "デフォルトのネットクラスは削除できません"
 
-#: pcbnew/dialogs/dialog_design_rules_base.cpp:84
-#: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:146
-#: pcbnew/dialogs/dialog_fp_plugin_options_base.cpp:67
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:134
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:40
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:44
-msgid "Move Up"
-msgstr "上に移動"
-
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:85
 msgid "Move the currently selected Net Class up one row"
 msgstr "現在選択中のネットを一行上のクラスに移動"
@@ -6551,11 +13346,6 @@ msgstr "現在選択中のネットを一行上のクラスに移動"
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:96
 msgid "Membership:"
 msgstr "メンバーシップ:"
-
-#: pcbnew/dialogs/dialog_design_rules_base.cpp:115
-#: common/dialogs/dialog_page_settings_base.cpp:153
-msgid "<<<"
-msgstr "<<<"
 
 #: pcbnew/dialogs/dialog_design_rules_base.cpp:116
 msgid "Move the selected nets in the right list to the left list"
@@ -6784,30 +13574,13 @@ msgstr "配線12"
 msgid "Global Design Rules"
 msgstr "グローバル デザインルール"
 
-#: pcbnew/dialogs/dialog_design_rules_base.cpp:368
-#: pcbnew/dialogs/dialog_drc_base.cpp:109
-#: pcbnew/dialogs/dialog_exchange_modules_base.cpp:89
-#: pcbnew/dialogs/dialog_gendrill_base.cpp:190
-#: eeschema/dialogs/dialog_erc_base.cpp:78
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:146
-#: common/dialogs/dialog_list_selector_base.cpp:37
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1172
-msgid "Messages:"
-msgstr "メッセージ: "
-
 #: pcbnew/dialogs/dialog_dimension_editor_base.cpp:37
-#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:79
 msgid "Text Width"
 msgstr "テキストの幅"
 
 #: pcbnew/dialogs/dialog_dimension_editor_base.cpp:45
 msgid "Text Height"
 msgstr "テキストの高さ"
-
-#: pcbnew/dialogs/dialog_dimension_editor_base.cpp:53
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:513
-msgid "Text Thickness"
-msgstr "テキストの太さ"
 
 #: pcbnew/dialogs/dialog_dimension_editor_base.cpp:61
 msgid "Text Position X"
@@ -6818,16 +13591,16 @@ msgid "Text Position Y"
 msgstr "テキストの位置 Y"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:23
-msgid "Tracks and vias:"
-msgstr "配線とビア"
+msgid "Tracks and Vias:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:25
-msgid "Tracks sketch mode"
-msgstr "配線をスケッチモードで表示"
+msgid "Show tracks in sketch mode"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:28
-msgid "Vias sketch mode"
-msgstr "ビアをスケッチモードで表示"
+msgid "Show vias in sketch mode"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:31
 #: pcbnew/dialogs/dialog_display_options_base.cpp:53
@@ -6853,15 +13626,13 @@ msgstr "ビア穴の表示"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:35
 msgid ""
-"Show (or not) via holes.\n"
+"Show or hide via holes.\n"
 "If Defined Holes is selected, only the non default size holes are shown"
 msgstr ""
-"ビア穴の表示設定\n"
-"\"定義された穴のみ\"を選択した場合、デフォルト径以外の穴のみ表示します"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:43
-msgid "Routing help:"
-msgstr "配線のヘルプ:"
+msgid "Routing Help:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:45
 msgid "Do not show"
@@ -6884,8 +13655,8 @@ msgid "Show Net Names:"
 msgstr "ネット名"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:49
-msgid "Show or not net names on pads and/or tracks"
-msgstr "パッド/配線のネット名を表示/非表示"
+msgid "Show or hide net names on pads and/or tracks"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:53
 msgid "New track"
@@ -6900,36 +13671,28 @@ msgid "New and edited tracks with via area"
 msgstr "新規および編集配線 (ビア領域を使用)"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:55
-msgid "Show Tracks Clearance:"
-msgstr "配線クリアランスの表示 "
+msgid "Show Track Clearance:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:57
 msgid ""
-"Show( or not) tracks clearance area.\n"
+"Show or hide the track and via clearance area.\n"
 "If New track is selected,  track clearance area is shown only when creating "
 "the track."
 msgstr ""
-"配線のクリアランス エリアの表示設定\n"
-"新しい配線が選択された場合、クリアランス エリアは配線が作成されたときのみ表示"
-"されます"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:68
 #: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:69
 msgid "Footprints:"
 msgstr "フットプリント"
 
-#: pcbnew/dialogs/dialog_display_options_base.cpp:70
-msgid "Outlines sketch mode"
-msgstr "外形をスケッチモードで表示"
-
 #: pcbnew/dialogs/dialog_display_options_base.cpp:74
-#: cvpcb/dialogs/dialog_display_options_base.cpp:28
-msgid "Texts sketch mode"
-msgstr "テキストをスケッチモードで表示"
+msgid "Show text in sketch mode"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:78
-msgid "Pads sketch mode"
-msgstr "パッドをスケッチモードで表示"
+msgid "Show pads in sketch mode"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:81
 msgid "Show pad clearance"
@@ -6940,17 +13703,16 @@ msgid "Show pad number"
 msgstr "パッド番号の表示"
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:88
-msgid "Show pad NoConnect"
-msgstr "未接続パッドの表示"
+msgid "Show pad no net connection indicator"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:96
-msgid "Others:"
-msgstr "その他"
+msgid "Other:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:98
-#: cvpcb/dialogs/dialog_display_options_base.cpp:25
-msgid "Graphic items sketch mode"
-msgstr "図形アイテムをスケッチモードで表示"
+msgid "Show graphic items in sketch mode"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_display_options_base.cpp:102
 msgid "Show page limits"
@@ -6972,13 +13734,6 @@ msgstr "DRCレポートファイル (.rpt)|*.rpt"
 #: pcbnew/dialogs/dialog_drc.cpp:238
 msgid "Save DRC Report File"
 msgstr "DRCレポートファイルの保存"
-
-#: pcbnew/dialogs/dialog_drc_base.cpp:25
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:82
-#: eeschema/dialogs/dialog_netlist.cpp:295
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:77
-msgid "Options:"
-msgstr "オプション:"
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:40
 msgid "By Netclass"
@@ -7015,13 +13770,6 @@ msgstr "このファイルにレポートを書き込みを許可"
 #: pcbnew/dialogs/dialog_drc_base.cpp:89
 msgid "Enter the report filename"
 msgstr "レポートファイル名の入力"
-
-#: pcbnew/dialogs/dialog_drc_base.cpp:94
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:656
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:667
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:680
-msgid "..."
-msgstr "..."
 
 #: pcbnew/dialogs/dialog_drc_base.cpp:124
 msgid "Start DRC"
@@ -7134,22 +13882,6 @@ msgstr "3Dシェイプ:"
 msgid "Use a path relative to '%s'?"
 msgstr "'%s' への相対パスを使用しますか？"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor.cpp:509
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit.cpp:380
-#: eeschema/dialogs/dialog_eeschema_config.cpp:417
-msgid "Path type"
-msgstr "パスのタイプ"
-
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:26
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:42
-#: pcbnew/dialogs/dialog_netlist_fbp.cpp:33 eeschema/lib_field.cpp:574
-#: eeschema/onrightclick.cpp:428 eeschema/sch_component.cpp:1514
-#: eeschema/template_fieldnames.cpp:39
-#: eeschema/dialogs/dialog_color_config.cpp:78
-#: eeschema/dialogs/dialog_rescue_each.cpp:107
-msgid "Reference"
-msgstr "リファレンス"
-
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:60
 msgid "Top side"
 msgstr "上側:"
@@ -7184,77 +13916,17 @@ msgstr "180.0"
 msgid "Other rotation"
 msgstr "他の回転角"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:68
-#: gerbview/class_gerber_draw_item.cpp:564
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:350
-msgid "Rotation"
-msgstr "回転"
-
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:72
 msgid "Rotation (in 0.1 degrees):"
 msgstr "回転角度 (0.1 度単位):"
-
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:90
-#: pcbnew/dialogs/dialog_target_properties_base.cpp:54 common/wxwineda.cpp:170
-msgid "X"
-msgstr "X"
-
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:98
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:110
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:234
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:257
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:271
-#: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:73
-#: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:85
-#: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:97
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:42
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:54
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:66
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:78
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:74
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:103
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:114
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.cpp:125
-#: pcbnew/dialogs/dialog_target_properties_base.cpp:35
-#: pcbnew/dialogs/dialog_target_properties_base.cpp:46
-#: pcbnew/dialogs/dialog_track_via_size_base.cpp:32
-#: pcbnew/dialogs/dialog_track_via_size_base.cpp:43
-#: pcbnew/dialogs/dialog_track_via_size_base.cpp:54
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:240
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:254
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:268
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:148
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:160
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:174
-msgid "unit"
-msgstr "単位"
-
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:102
-#: common/wxwineda.cpp:183
-msgid "Y"
-msgstr "Y"
 
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:117
 msgid "Sheet path:"
 msgstr "シートのパス:"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:122
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:98
-msgid ""
-"An unique ID (a time stamp) to identify the component.\n"
-"This is an alternate identifier to the reference."
-msgstr ""
-"コンポーネントを識別するために、固有ID (タイムスタンプ情報) を使用します。\n"
-"これはリファレンスを管理する際に使用される情報です。"
-
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:131
 msgid "Change Footprint(s)"
 msgstr "フットプリントの変更"
-
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:134
-#: eeschema/tool_sch.cpp:165
-msgid "Footprint Editor"
-msgstr "フットプリント エディタ"
 
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:140
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:98
@@ -7402,12 +14074,6 @@ msgstr ""
 msgid "%"
 msgstr "%"
 
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:302
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:236
-#: pagelayout_editor/pl_editor_frame.cpp:139
-msgid "Properties"
-msgstr "プロパティ"
-
 #: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.cpp:307
 msgid "3D Shape Name"
 msgstr "3Dシェイプ名"
@@ -7489,22 +14155,6 @@ msgstr ""
 "不正な文字 <%s> が見つかりました。\n"
 "(<%s>)"
 
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:24
-#: eeschema/dialogs/dialog_color_config.cpp:80
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:114
-msgid "Fields"
-msgstr "フィールド"
-
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:26
-#: eeschema/onrightclick.cpp:398
-msgid "Doc"
-msgstr "ドキュメント"
-
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:34
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:127
-msgid "Keywords"
-msgstr "キーワード"
-
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:79
 msgid "Footprint Name in Library"
 msgstr "ライブラリに登録されたフットプリント名"
@@ -7541,14 +14191,6 @@ msgstr "ローカル クリアランス値:"
 msgid "Inch"
 msgstr "インチ"
 
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:191
-#: pcbnew/dialogs/dialog_export_idf_base.cpp:46
-#: pcbnew/dialogs/dialog_export_vrml_base.cpp:64
-#: pcbnew/import_dxf/dialog_dxf_import_base.cpp:90
-#: pcb_calculator/UnitSelector.cpp:42
-msgid "inch"
-msgstr "インチ"
-
 #: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.cpp:241
 msgid "3D Shape Names"
 msgstr "3Dシェイプ名"
@@ -7561,6 +14203,11 @@ msgstr "定数:"
 #: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:24
 msgid "Text:"
 msgstr "テキスト:"
+
+#: pcbnew/dialogs/dialog_edit_module_text.cpp:130
+#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:40 pcbnew/modules.cpp:66
+msgid "Reference:"
+msgstr "リファレンス:"
 
 #: pcbnew/dialogs/dialog_edit_module_text.cpp:175
 msgid ""
@@ -7587,53 +14234,6 @@ msgstr "オフセット X"
 #: pcbnew/dialogs/dialog_edit_module_text_base.cpp:80
 msgid "Offset Y"
 msgstr "オフセット Y"
-
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:104
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:100
-#: eeschema/sch_text.cpp:758
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:182
-#: eeschema/dialogs/dialog_edit_label_base.cpp:76
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:92
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:97 common/eda_text.cpp:378
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:109
-msgid "Italic"
-msgstr "斜体字"
-
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:106
-#: eeschema/lib_field.cpp:746 eeschema/lib_pin.cpp:1997
-#: eeschema/sch_text.cpp:767 eeschema/dialogs/dialog_lib_edit_text_base.cpp:99
-msgid "Style"
-msgstr "スタイル"
-
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:110
-#: eeschema/sch_text.cpp:736
-msgid "Horizontal"
-msgstr "水平"
-
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:110
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:79
-msgid "Vertical"
-msgstr "垂直"
-
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:112
-#: eeschema/lib_pin.cpp:2011 eeschema/sch_text.cpp:756
-msgid "Orientation"
-msgstr "角度"
-
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:116
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:129
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:158 eeschema/lib_pin.cpp:2004
-#: eeschema/dialogs/dialog_eeschema_options.cpp:55
-#: eeschema/dialogs/dialog_eeschema_options.cpp:192
-msgid "Visible"
-msgstr "表示"
-
-#: pcbnew/dialogs/dialog_edit_module_text_base.cpp:116
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:129
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:158
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:91
-msgid "Invisible"
-msgstr "非表示"
 
 #: pcbnew/dialogs/dialog_enum_pads_base.cpp:19
 msgid "Pad names are restricted to 4 characters (including number)."
@@ -7695,28 +14295,7 @@ msgstr "新しいフットプリント名 (FPID)"
 msgid "Apply"
 msgstr "適用"
 
-#: pcbnew/dialogs/dialog_exchange_modules_base.cpp:107
-#: pcbnew/dialogs/dialog_find_base.cpp:45
-#: pcbnew/dialogs/dialog_gendrill_base.cpp:180
-#: pcbnew/dialogs/dialog_netlist_fbp.cpp:95
-#: pcbnew/dialogs/dialog_orient_footprints_base.cpp:58
-#: pcbnew/dialogs/dialog_plot_base.cpp:389
-#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:57
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:144
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:113
-#: eeschema/dialogs/dialog_annotate_base.cpp:212
-#: eeschema/dialogs/dialog_bom_base.cpp:62
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:134
-#: eeschema/dialogs/dialog_print_using_printer_base.cpp:53
-#: eeschema/dialogs/dialog_schematic_find_base.cpp:125
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:109 common/zoom.cpp:300
-#: common/dialogs/dialog_display_info_HTML_base.cpp:22
-#: common/dialogs/dialog_hotkeys_editor_base.cpp:33
-msgid "Close"
-msgstr "閉じる"
-
 #: pcbnew/dialogs/dialog_export_idf.cpp:228
-#: pcbnew/dialogs/dialog_export_vrml.cpp:235
 #: pcbnew/exporters/export_d356.cpp:373
 msgid "Unable to create "
 msgstr "作成できません"
@@ -7735,8 +14314,8 @@ msgid "Grid Reference Point:"
 msgstr "グリッドの基準点"
 
 #: pcbnew/dialogs/dialog_export_idf_base.cpp:36
-msgid "Auto Adjust"
-msgstr "自動設定"
+msgid "Adjust automatically"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_export_idf_base.cpp:42
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:60
@@ -7746,21 +14325,14 @@ msgid "Units:"
 msgstr "単位系:"
 
 #: pcbnew/dialogs/dialog_export_idf_base.cpp:58
-msgid "X ref:"
-msgstr "X ref:"
+#: pcbnew/import_dxf/dialog_dxf_import_base.cpp:54
+msgid "X Position:"
+msgstr "X 位置:"
 
 #: pcbnew/dialogs/dialog_export_idf_base.cpp:72
-#: pcbnew/dialogs/dialog_export_vrml_base.cpp:78
-msgid "Y Ref:"
-msgstr "Y Ref:"
-
-#: pcbnew/dialogs/dialog_export_idf_base.cpp:86
-#: pcbnew/dialogs/dialog_gendrill_base.cpp:44
-#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:33
-#: pcbnew/dialogs/dialog_set_grid_base.cpp:25
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:31
-msgid "Millimeters"
-msgstr "mm"
+#: pcbnew/import_dxf/dialog_dxf_import_base.cpp:70
+msgid "Y Position:"
+msgstr "Y 位置:"
 
 #: pcbnew/dialogs/dialog_export_idf_base.cpp:86
 msgid "Mils"
@@ -7770,6 +14342,11 @@ msgstr "Mil"
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:100
 msgid "Output Units:"
 msgstr "出力単位:"
+
+#: pcbnew/dialogs/dialog_export_vrml.cpp:246
+#, c-format
+msgid "Unable to create file '%s'"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:22
 msgid "File Name:"
@@ -7786,6 +14363,10 @@ msgstr "フットプリントの3Dモデルパス:"
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:70
 msgid "X Ref:"
 msgstr "X Ref:"
+
+#: pcbnew/dialogs/dialog_export_vrml_base.cpp:78
+msgid "Y Ref:"
+msgstr "Y Ref:"
 
 #: pcbnew/dialogs/dialog_export_vrml_base.cpp:98
 msgid "meter"
@@ -7845,17 +14426,9 @@ msgstr "アイテム検索"
 msgid "Find Marker"
 msgstr "マーカー検索"
 
-#: pcbnew/dialogs/dialog_footprint_wizard_list_base.cpp:34
-#: pcbnew/dialogs/dialog_layers_setup.cpp:342 eeschema/lib_pin.cpp:1977
-#: eeschema/libedit.cpp:477
-#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:183
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:181
-#: eeschema/dialogs/dialog_lib_edit_pin_table.cpp:151
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:82
-#: common/dialogs/dialog_env_var_config_base.cpp:35
-#: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:26
-msgid "Name"
-msgstr "名前"
+#: pcbnew/dialogs/dialog_fp_lib_table.cpp:204 pcbnew/librairi.cpp:773
+msgid "Nickname"
+msgstr "別名(ニックネーム)"
 
 #: pcbnew/dialogs/dialog_fp_lib_table.cpp:205
 msgid "Library Path"
@@ -7928,12 +14501,6 @@ msgstr "このライブラリ表からPCBライブラリを削除"
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:147
 msgid "Move the currently selected row up one position"
 msgstr "現在選択されている行をひとつ上の行と入れ替え"
-
-#: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:151
-#: pcbnew/dialogs/dialog_fp_plugin_options_base.cpp:72
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:47 3d-viewer/3d_canvas.cpp:438
-msgid "Move Down"
-msgstr "下へ移動"
 
 #: pcbnew/dialogs/dialog_fp_lib_table_base.cpp:152
 msgid "Move the currently selected row down one position"
@@ -8040,6 +14607,11 @@ msgstr ""
 msgid "Pcbnew Error"
 msgstr "Pcbnew エラー"
 
+#: pcbnew/dialogs/dialog_freeroute_exchange.cpp:194
+#: pcbnew/specctra_export.cpp:140
+msgid "Specctra DSN file:"
+msgstr "Specctra DSN ファイル:"
+
 #: pcbnew/dialogs/dialog_freeroute_exchange_base.cpp:25
 msgid "Export/Import to/from FreeRoute:"
 msgstr "FreeRoute へ/から エクスポート/インポート:"
@@ -8071,14 +14643,6 @@ msgstr "スペクトラ・セッション ファイル (*.ses) のバックイ�
 msgid "Merge a session file created by FreeRouter with the current board."
 msgstr "現在のボードにFreeRouterが作成したセッションファイルをマージします"
 
-#: pcbnew/dialogs/dialog_gen_module_position_file_base.cpp:26
-#: pcbnew/dialogs/dialog_gendrill_base.cpp:23
-#: pcbnew/dialogs/dialog_plot_base.cpp:45
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:21
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:24
-msgid "Output directory:"
-msgstr "出力ディレクトリ:"
-
 #: pcbnew/dialogs/dialog_gen_module_position_file_base.cpp:35
 #: pcbnew/dialogs/dialog_plot_base.cpp:54
 msgid ""
@@ -8087,25 +14651,6 @@ msgid ""
 msgstr ""
 "出図ファイルのターゲットディレクトリです。\n"
 "ボードファイルの位置に絶対パス、または相対パスが使用できます。"
-
-#: pcbnew/dialogs/dialog_gen_module_position_file_base.cpp:40
-#: pcbnew/dialogs/dialog_plot_base.cpp:58
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:35
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:37
-msgid "Browse..."
-msgstr "参照..."
-
-#: pcbnew/dialogs/dialog_gen_module_position_file_base.cpp:55
-#: pcbnew/dialogs/dialog_gendrill_base.cpp:44
-#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:33
-#: pcbnew/dialogs/dialog_set_grid_base.cpp:25
-#: pcbnew/dialogs/dialog_set_grid_base.cpp:79
-#: pcbnew/dialogs/dialog_set_grid_base.cpp:91
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:31
-#: common/draw_frame.cpp:164 common/draw_frame.cpp:481
-#: pagelayout_editor/pl_editor_frame.cpp:117
-msgid "Inches"
-msgstr "インチ"
 
 #: pcbnew/dialogs/dialog_gen_module_position_file_base.cpp:61
 msgid "One file per side"
@@ -8149,37 +14694,12 @@ msgstr ""
 "このオプションは表面実装パッドを持つ全てのフットプリントへ強制適用できます.\n"
 "警告: このオプションは基板へ変更を加えます."
 
-#: pcbnew/dialogs/dialog_gendrill.cpp:132
-#: pcbnew/dialogs/dialog_gendrill.cpp:133
+#: pcbnew/dialogs/dialog_gendrill.cpp:134
+#: pcbnew/dialogs/dialog_gendrill.cpp:135
 msgid "Use Netclasses values"
 msgstr "ネットクラスの値を使用する"
 
-#: pcbnew/dialogs/dialog_gendrill.cpp:293 pcbnew/dialogs/dialog_plot.cpp:311
-#: pcbnew/dialogs/dialog_SVG_print.cpp:215
-#: pcbnew/exporters/gen_modules_placefile.cpp:177
-#: pcbnew/exporters/gen_modules_placefile.cpp:566
-#: eeschema/dialogs/dialog_plot_schematic.cpp:171
-msgid "Select Output Directory"
-msgstr "出力するディレクトリの選択"
-
-#: pcbnew/dialogs/dialog_gendrill.cpp:300
-#: pcbnew/dialogs/dialog_SVG_print.cpp:222
-#: pcbnew/exporters/gen_modules_placefile.cpp:184
-msgid "Use a relative path? "
-msgstr "相対パスを使用しますか？"
-
-#: pcbnew/dialogs/dialog_gendrill.cpp:301
-#: pcbnew/dialogs/dialog_gendrill.cpp:312 pcbnew/dialogs/dialog_plot.cpp:324
-#: pcbnew/dialogs/dialog_plot.cpp:331 pcbnew/dialogs/dialog_SVG_print.cpp:223
-#: pcbnew/dialogs/dialog_SVG_print.cpp:234
-#: pcbnew/exporters/gen_modules_placefile.cpp:185
-#: pcbnew/exporters/gen_modules_placefile.cpp:194
-#: eeschema/dialogs/dialog_plot_schematic.cpp:186
-#: eeschema/dialogs/dialog_plot_schematic.cpp:194
-msgid "Plot Output Directory"
-msgstr "出力するディレクトリの選択"
-
-#: pcbnew/dialogs/dialog_gendrill.cpp:311
+#: pcbnew/dialogs/dialog_gendrill.cpp:313
 msgid ""
 "Cannot make path relative.  The target volume is different from board file "
 "volume!"
@@ -8187,18 +14707,18 @@ msgstr ""
 "パスの関連付けを作成できませんターゲットボリュームがボードファイルのボリュー"
 "ムと異なります!"
 
-#: pcbnew/dialogs/dialog_gendrill.cpp:396
+#: pcbnew/dialogs/dialog_gendrill.cpp:398
 msgid "Save Drill Report File"
 msgstr "ドリルレポートファイルの保存"
 
-#: pcbnew/dialogs/dialog_gendrill.cpp:415
+#: pcbnew/dialogs/dialog_gendrill.cpp:417
 #: pcbnew/exporters/gendrill_Excellon_writer.cpp:153
 #: pcbnew/exporters/gendrill_Excellon_writer.cpp:183
 #, c-format
 msgid "** Unable to create %s **\n"
 msgstr "** %s が作成できません **\n"
 
-#: pcbnew/dialogs/dialog_gendrill.cpp:420
+#: pcbnew/dialogs/dialog_gendrill.cpp:422
 #, c-format
 msgid "Report file %s created\n"
 msgstr "レポートファイル \"%s\" が作成されました\n"
@@ -8237,12 +14757,6 @@ msgid "Precision"
 msgstr "精度"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:74
-#: pcbnew/dialogs/dialog_plot_base.cpp:33
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:88
-msgid "HPGL"
-msgstr "HPGL"
-
-#: pcbnew/dialogs/dialog_gendrill_base.cpp:74
 msgid "PostScript"
 msgstr "PostScript"
 
@@ -8250,24 +14764,6 @@ msgstr "PostScript"
 #: pcbnew/dialogs/dialog_plot_base.cpp:33
 msgid "Gerber"
 msgstr "ガーバー"
-
-#: pcbnew/dialogs/dialog_gendrill_base.cpp:74
-#: pcbnew/dialogs/dialog_plot_base.cpp:33
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:88
-msgid "DXF"
-msgstr "DXF"
-
-#: pcbnew/dialogs/dialog_gendrill_base.cpp:74
-#: pcbnew/dialogs/dialog_plot_base.cpp:33
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:88
-msgid "SVG"
-msgstr "SVG"
-
-#: pcbnew/dialogs/dialog_gendrill_base.cpp:74
-#: pcbnew/dialogs/dialog_plot_base.cpp:33
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:88
-msgid "PDF"
-msgstr "PDF"
 
 #: pcbnew/dialogs/dialog_gendrill_base.cpp:76
 msgid "Drill Map File Format:"
@@ -8362,20 +14858,14 @@ msgstr "マップファイル"
 msgid "Report File"
 msgstr "レポートファイル"
 
-#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:25
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:25
-msgid "Cartesian coordinates"
-msgstr "直交座標"
+#: pcbnew/dialogs/dialog_general_options.cpp:232 pcbnew/pcbnew_config.cpp:90
+msgid "Hide Microwave Toolbar"
+msgstr "高周波設計支援ツールバーを隠す"
 
-#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:25
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:25
-msgid "Polar coordinates"
-msgstr "極座標"
-
-#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:27
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:27
-msgid "Coordinates"
-msgstr "座標"
+#: pcbnew/dialogs/dialog_general_options.cpp:232
+#: pcbnew/menubar_pcbframe.cpp:513 pcbnew/pcbnew_config.cpp:90
+msgid "Show Microwave Toolbar"
+msgstr "高周波設計支援ツールバーの表示"
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:29
 msgid ""
@@ -8389,21 +14879,6 @@ msgstr ""
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:37
 msgid "Selection of units used to display dimensions and positions of items"
 msgstr "ディメンジョンの表示やアイテムの配置に使用する単位の選択"
-
-#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:41
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:37
-msgid "Small cross"
-msgstr "小十字"
-
-#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:41
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:37
-msgid "Full screen cursor"
-msgstr "フルスクリーンカーソルに変更"
-
-#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:43
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:39
-msgid "Cursor"
-msgstr "カーソル"
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:45
 msgid "Main cursor shape selection (small cross or large cursor)"
@@ -8535,43 +15010,13 @@ msgid ""
 "Control the capture of the pcb cursor when the mouse cursor enters a track"
 msgstr "マウスカーソルが配線内に入った時にカーソルを配線に引き込みます。"
 
-#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:163
-#: cvpcb/dialogs/dialog_display_options_base.cpp:41
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:84
-msgid "Pan and Zoom"
-msgstr "拡大縮小"
-
-#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:165
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:193
-msgid "Ce&nter and warp cursor on zoom"
-msgstr "拡大縮小時にカーソルを中心へ移動(&n)"
-
-#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:167
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:194
-#: cvpcb/dialogs/dialog_display_options_base.cpp:44
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:87
-msgid "Keep the cursor at its current location when zooming"
-msgstr "拡大縮小時に現在のカーソル位置を保持する"
-
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:171
 msgid "Use middle mouse &button to pan"
 msgstr "画面のパンにマウスの中ボタンを使用(&b)"
 
-#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:172
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:199
-msgid "Use middle mouse button dragging to pan"
-msgstr "画面のパンにマウスの中ボタンのドラッグを使う"
-
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:176
 msgid "Limi&t panning to scroll size"
 msgstr "パン可能な領域を、スクロールバーサイズ範囲内に制限(&t)"
-
-#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:177
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:204
-msgid "Middle mouse button panning limited by current scrollbar size"
-msgstr ""
-"マウス中ボタンによる画面パン時に、移動領域サイズを現在のスクロールバーサイズ"
-"へ制限します"
 
 #: pcbnew/dialogs/dialog_general_options_BoardEditor_base.cpp:181
 msgid "&Pan while moving object"
@@ -8589,13 +15034,22 @@ msgstr "上級者/開発者向け"
 msgid "Dump zone geometry to files when filling"
 msgstr "塗りつぶす時にゾーンのジオメトリをファイルへダンプする"
 
-#: pcbnew/dialogs/dialog_global_deletion.cpp:103
+#: pcbnew/dialogs/dialog_global_deletion.cpp:101
+msgid "Are you sure you want to delete the entire board?"
+msgstr ""
+
+#: pcbnew/dialogs/dialog_global_deletion.cpp:106
 msgid "Are you sure you want to delete the selected items?"
 msgstr "選択されたアイテムを削除して宜しいですか？"
 
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:23
 msgid "Items to Delete"
 msgstr "削除するアイテム"
+
+#: pcbnew/dialogs/dialog_global_deletion_base.cpp:25
+#: pcbnew/onrightclick.cpp:724 pcbnew/tools/pcb_editor_control.cpp:121
+msgid "Zones"
+msgstr "ゾーン"
 
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:31
 msgid "Board outlines"
@@ -8604,11 +15058,6 @@ msgstr "ボードの外形"
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:34
 msgid "Drawings"
 msgstr "図形"
-
-#: pcbnew/dialogs/dialog_global_deletion_base.cpp:37
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:210
-msgid "Footprints"
-msgstr "フットプリント"
 
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:40
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:20
@@ -8620,8 +15069,8 @@ msgid "Markers"
 msgstr "マーカー"
 
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:46
-msgid "Clear Board"
-msgstr "ボードをクリア"
+msgid "Clear board"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_global_deletion_base.cpp:55
 msgid "Filter Settings"
@@ -8659,7 +15108,7 @@ msgstr "現在のレイヤのみ"
 msgid "Layer Filter"
 msgstr "レイヤの絞り込み"
 
-#: pcbnew/dialogs/dialog_global_deletion_base.cpp:88
+#: pcbnew/dialogs/dialog_global_deletion_base.cpp:100
 msgid "Current layer:"
 msgstr "現在のレイヤ:"
 
@@ -8780,20 +15229,6 @@ msgstr ""
 msgid "Current Text Dimensions"
 msgstr "現在のテキストの寸法"
 
-#: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:65
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:43
-#: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.cpp:25
-#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:86
-#: common/dialogs/dialog_page_settings_base.cpp:78
-msgid "Width:"
-msgstr "幅:"
-
-#: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:77
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:76
-#: common/dialogs/dialog_page_settings_base.cpp:62
-msgid "Height:"
-msgstr "高さ:"
-
 #: pcbnew/dialogs/dialog_global_modules_fields_edition_base.cpp:89
 #: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:112
 msgid "Thickness:"
@@ -8834,27 +15269,21 @@ msgstr "円のプロパティ"
 
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:133
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:144
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:144
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:155
-msgid "Center X"
-msgstr "X中央"
+msgid "Center X:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:134
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:145
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:145
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:156
-msgid "Center Y"
-msgstr "Y中央"
+msgid "Center Y:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:135
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:146
-msgid "Point X"
-msgstr "ポイント X"
+msgid "Point X:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:136
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:147
-msgid "Point Y"
-msgstr "ポイント Y"
+msgid "Point Y:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:143
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:154
@@ -8862,14 +15291,12 @@ msgid "Arc Properties"
 msgstr "円弧のプロパティ"
 
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:146
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:157
-msgid "Start Point X"
-msgstr "始点 X"
+msgid "Start Point X:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:147
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:158
-msgid "Start Point Y"
-msgstr "始点 Y"
+msgid "Start Point Y:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:155
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:167
@@ -8910,52 +15337,28 @@ msgid "The default thickness must be greater than zero."
 msgstr "デフォルトの太さは0以上である必要があります。"
 
 #: pcbnew/dialogs/dialog_graphic_item_properties.cpp:330
-#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:333
-msgid "Error list"
-msgstr "エラー一覧"
+msgid "Error List"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:30
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:27
-msgid "Start point X"
-msgstr "始点 X"
-
-#: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:38
-#: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:50
-#: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:62
-#: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:74
-#: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:113
-#: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:125
-#: pcbnew/dialogs/dialog_layers_setup_base.cpp:70
-#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:35
-#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:47
-#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:59
-#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:71
-#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:94
-#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:138
-#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:150
-#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:173
-#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:185
-#: eeschema/component_tree_search_container.cpp:203
-#: eeschema/lib_draw_item.cpp:72 eeschema/libedit.cpp:493
-#: eeschema/onrightclick.cpp:465
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:25
-msgid "Unit"
-msgstr "ユニット"
+msgid "Start point X:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:42
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:39
-msgid "Start point Y"
-msgstr "始点 Y"
+msgid "Start point Y:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:54
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:51
-msgid "End point X"
-msgstr "終点 X"
+msgid "End point X:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:66
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:63
-msgid "End point Y"
-msgstr "終点 Y"
+msgid "End point Y:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_graphic_item_properties_base.cpp:93
 msgid "Arc angle:"
@@ -8973,6 +15376,32 @@ msgstr "アイテムの太さ: "
 msgid "Default thickness:"
 msgstr "デフォルトの太さ: "
 
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:144
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:155
+msgid "Center X"
+msgstr "X中央"
+
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:145
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:156
+msgid "Center Y"
+msgstr "Y中央"
+
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:146
+msgid "Point X"
+msgstr "ポイント X"
+
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:147
+msgid "Point Y"
+msgstr "ポイント Y"
+
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:157
+msgid "Start Point X"
+msgstr "始点 X"
+
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:158
+msgid "Start Point Y"
+msgstr "始点 Y"
+
 #: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:197
 msgid ""
 "This item was on an unknown layer.\n"
@@ -8989,45 +15418,41 @@ msgstr ""
 "図形アイテムを導体層に配置しようとしています。これはとても危険です。宜しいで"
 "すか？"
 
+#: pcbnew/dialogs/dialog_graphic_item_properties_for_Modedit.cpp:333
+msgid "Error list"
+msgstr "エラー一覧"
+
 #: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:23
 msgid "Graphics:"
 msgstr "図形:"
 
 #: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:25
-msgid "Graphic segm Width"
-msgstr "図形セグメントの幅"
+msgid "Graphic segment width:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:33
-msgid "Board Edges Width"
-msgstr "ボード エッジの幅"
+msgid "Board edge width:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:41
-msgid "Copper Text Width"
-msgstr "テキストの幅"
-
-#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:49
-#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:87
-msgid "Text Size V"
-msgstr "テキストの縦幅"
-
-#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:57
-#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:95
-msgid "Text Size H"
-msgstr "テキストの横幅"
+msgid "Copper text thickness:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:71
-msgid "Edges Width"
-msgstr "エッジの幅"
+msgid "Edge width:"
+msgstr ""
+
+#: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:79
+msgid "Text thickness:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:107
 msgid "General:"
 msgstr "一般:"
 
 #: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:109
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:84
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:63
-msgid "Default pen size"
-msgstr "デフォルト ペン サイズ"
+msgid "Default pen size:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_graphic_items_options_base.cpp:111
 #: pcbnew/dialogs/dialog_plot_base.cpp:172
@@ -9040,9 +15465,9 @@ msgstr ""
 "す。\n"
 "主にスケッチモードで描画するアイテムに使われます。"
 
-#: pcbnew/dialogs/dialog_keepout_area_properties.cpp:214
-msgid "Tracks, vias and pads are allowed. The keepout is useless"
-msgstr "配線とビアの配置が可能です。禁止エリアではありません。"
+#: pcbnew/dialogs/dialog_keepout_area_properties.cpp:218
+msgid "Tracks, vias, and pads are allowed. The keepout is useless"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_keepout_area_properties_base.cpp:43
 msgid "Properties:"
@@ -9054,14 +15479,12 @@ msgid "Any"
 msgstr "* (全て)"
 
 #: pcbnew/dialogs/dialog_keepout_area_properties_base.cpp:47
-#: pcbnew/dialogs/dialog_non_copper_zones_properties_base.cpp:46
-msgid "H, V and 45 deg"
-msgstr "0 , 45 , 90度"
+msgid "180, 90, and 45 degrees"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_keepout_area_properties_base.cpp:49
-#: pcbnew/dialogs/dialog_non_copper_zones_properties_base.cpp:48
-msgid "Zone Edges Orient"
-msgstr "ゾーンの外形の角度"
+msgid "Zone Edge Orientation:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_keepout_area_properties_base.cpp:53
 #: pcbnew/dialogs/dialog_non_copper_zones_properties_base.cpp:52
@@ -9074,25 +15497,20 @@ msgid "Full Hatched"
 msgstr "全てハッチング"
 
 #: pcbnew/dialogs/dialog_keepout_area_properties_base.cpp:55
-#: pcbnew/dialogs/dialog_non_copper_zones_properties_base.cpp:54
-msgid "Outlines Appearence"
-msgstr "外形の形状"
+msgid "Outline Appearence:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_keepout_area_properties_base.cpp:60
 msgid "Keepout Options:"
 msgstr "キープアウト(禁止)エリアのオプション"
 
 #: pcbnew/dialogs/dialog_keepout_area_properties_base.cpp:62
-msgid "No Tracks"
-msgstr "配線禁止"
+msgid "No tracks"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_keepout_area_properties_base.cpp:65
-msgid "No Vias"
-msgstr "ビア禁止"
-
-#: pcbnew/dialogs/dialog_keepout_area_properties_base.cpp:68
-msgid "No Copper Pour"
-msgstr "塗りつぶし禁止"
+msgid "No vias"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_layer_selection_base.cpp:116
 msgid "Top/Front Layer"
@@ -9814,13 +16232,6 @@ msgstr "シルク"
 msgid "Fab. Layer"
 msgstr "Fab. レイヤ"
 
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:125
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:154
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:167
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:77
-msgid "Visibility"
-msgstr "表示"
-
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:135
 msgid "V&alue"
 msgstr "定数(&a)"
@@ -9836,18 +16247,6 @@ msgstr ""
 #: pcbnew/dialogs/dialog_modedit_options_base.cpp:170
 msgid "General options:"
 msgstr "全般 オプション:"
-
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:182
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:154
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:139
-msgid "Ma&ximum undo items (0 = unlimited):"
-msgstr "最大 undo アイテム数 (&x) (0 = 制限なし):"
-
-#: pcbnew/dialogs/dialog_modedit_options_base.cpp:189
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:161
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:146
-msgid "actions"
-msgstr "アクション"
 
 #: pcbnew/dialogs/dialog_move_exact.cpp:135
 msgid "Distance:"
@@ -9877,15 +16276,23 @@ msgstr "y:"
 msgid "Item rotation:"
 msgstr "アイテムの回転:"
 
-#: pcbnew/dialogs/dialog_netlist.cpp:81
+#: pcbnew/dialogs/dialog_netlist.cpp:85
 msgid "The project configuration has changed.  Do you want to save it?"
 msgstr "プロジェクトの設定が変更されました、保存しますか?"
 
-#: pcbnew/dialogs/dialog_netlist.cpp:144
+#: pcbnew/dialogs/dialog_netlist.cpp:148
 msgid "Select Netlist"
 msgstr "ネットリストの選択"
 
-#: pcbnew/dialogs/dialog_netlist.cpp:161
+#: pcbnew/dialogs/dialog_netlist.cpp:164
+msgid "Please, choose a valid netlist file"
+msgstr ""
+
+#: pcbnew/dialogs/dialog_netlist.cpp:170
+msgid "The netlist file does not exist"
+msgstr ""
+
+#: pcbnew/dialogs/dialog_netlist.cpp:177
 msgid ""
 "The changes made by reading the netlist cannot be undone.  Are you sure you "
 "want to read the netlist?"
@@ -9893,65 +16300,78 @@ msgstr ""
 "ネットリスト読込みによる変更は途中終了できません.  本当にネットリストを読み込"
 "みますか?"
 
-#: pcbnew/dialogs/dialog_netlist.cpp:170
+#: pcbnew/dialogs/dialog_netlist.cpp:187
 #, c-format
 msgid "Reading netlist file \"%s\".\n"
 msgstr "ネットリストファイル \"%s\"を読み込んでいます。\n"
 
-#: pcbnew/dialogs/dialog_netlist.cpp:174
+#: pcbnew/dialogs/dialog_netlist.cpp:191
 msgid "Using time stamps to match components and footprints.\n"
 msgstr "コンポーネントとフットプリントの関連付けにタイムスタンプを使用\n"
 
-#: pcbnew/dialogs/dialog_netlist.cpp:176
+#: pcbnew/dialogs/dialog_netlist.cpp:193
 msgid "Using references to match components and footprints.\n"
 msgstr "コンポーネントとフットプリントの関連付けにリファレンスを使用\n"
 
-#: pcbnew/dialogs/dialog_netlist.cpp:223
+#: pcbnew/dialogs/dialog_netlist.cpp:216 pcbnew/netlist.cpp:153
+msgid "No footprints"
+msgstr "フットプリント無し"
+
+#: pcbnew/dialogs/dialog_netlist.cpp:240
 msgid "No duplicate."
 msgstr "重複はありませんでした。"
 
-#: pcbnew/dialogs/dialog_netlist.cpp:226
+#: pcbnew/dialogs/dialog_netlist.cpp:243
 msgid "Duplicates:"
 msgstr "重複:"
 
-#: pcbnew/dialogs/dialog_netlist.cpp:250
+#: pcbnew/dialogs/dialog_netlist.cpp:267
 msgid "No missing footprints."
 msgstr "フットプリントが見つかりません！"
 
-#: pcbnew/dialogs/dialog_netlist.cpp:253
+#: pcbnew/dialogs/dialog_netlist.cpp:270
 msgid "Missing:"
 msgstr "欠落: "
 
-#: pcbnew/dialogs/dialog_netlist.cpp:269
+#: pcbnew/dialogs/dialog_netlist.cpp:286
 msgid "No extra footprints."
 msgstr "追加のフットプリントがありません。"
 
-#: pcbnew/dialogs/dialog_netlist.cpp:272
+#: pcbnew/dialogs/dialog_netlist.cpp:289
 msgid "Not in Netlist:"
 msgstr "ネットリストに含まれていません: "
 
-#: pcbnew/dialogs/dialog_netlist.cpp:297
+#: pcbnew/dialogs/dialog_netlist.cpp:314
 msgid "Too many errors: some are skipped"
 msgstr "大量のエラー: いくつか省略されました"
 
-#: pcbnew/dialogs/dialog_netlist.cpp:301
+#: pcbnew/dialogs/dialog_netlist.cpp:318
 msgid "Check footprints"
 msgstr "フットプリントのチェック"
 
-#: pcbnew/dialogs/dialog_netlist.cpp:345
+#: pcbnew/dialogs/dialog_netlist.cpp:362
 msgid "Save contents of message window"
 msgstr "メッセージウインドウ内のメッセージを保存する"
 
-#: pcbnew/dialogs/dialog_netlist.cpp:362
+#: pcbnew/dialogs/dialog_netlist.cpp:379
 #, c-format
 msgid "Cannot write message contents to file \"%s\"."
 msgstr "メッセージ内容をファイル \"%s\" へ書き出すことが出来ませんでした。"
 
-#: pcbnew/dialogs/dialog_netlist.cpp:364
+#: pcbnew/dialogs/dialog_netlist.cpp:381
 msgid "File Write Error"
 msgstr "ファイル書き出しエラー"
 
-#: pcbnew/dialogs/dialog_netlist.cpp:413
+#: pcbnew/dialogs/dialog_netlist.cpp:420 pcbnew/netlist.cpp:82
+#, c-format
+msgid "Cannot open netlist file \"%s\"."
+msgstr "ネットリストファイル \"%s\" が開けませんでした。"
+
+#: pcbnew/dialogs/dialog_netlist.cpp:421 pcbnew/netlist.cpp:83
+msgid "Netlist Load Error."
+msgstr "ネットリストの読み込みエラー"
+
+#: pcbnew/dialogs/dialog_netlist.cpp:430
 #, c-format
 msgid ""
 "Error loading netlist file:\n"
@@ -9959,11 +16379,6 @@ msgid ""
 msgstr ""
 "ネットリストファイルの読み込み時にエラーが発生しました:\n"
 "%s"
-
-#: pcbnew/dialogs/dialog_netlist_fbp.cpp:33
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:93
-msgid "Timestamp"
-msgstr "タイムスタンプ"
 
 #: pcbnew/dialogs/dialog_netlist_fbp.cpp:35
 msgid "Footprint Selection"
@@ -10109,6 +16524,18 @@ msgstr "レイヤの選択:"
 msgid "Outlines Options:"
 msgstr "アウトラインのオプション:"
 
+#: pcbnew/dialogs/dialog_non_copper_zones_properties_base.cpp:46
+msgid "H, V and 45 deg"
+msgstr "0 , 45 , 90度"
+
+#: pcbnew/dialogs/dialog_non_copper_zones_properties_base.cpp:48
+msgid "Zone Edges Orient"
+msgstr "ゾーンの外形の角度"
+
+#: pcbnew/dialogs/dialog_non_copper_zones_properties_base.cpp:54
+msgid "Outlines Appearence"
+msgstr "外形の形状"
+
 #: pcbnew/dialogs/dialog_non_copper_zones_properties_base.cpp:61
 msgid "Zone min thickness value"
 msgstr "ゾーンの最小幅"
@@ -10122,21 +16549,9 @@ msgstr "フットプリントの角度を %.1f 度にセットします。宜し
 msgid "Bad value for footprints orientation"
 msgstr "フットプリントの角度が不正です。"
 
-#: pcbnew/dialogs/dialog_orient_footprints_base.cpp:22
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:131
-#: common/dialogs/dialog_page_settings_base.cpp:42
-msgid "Orientation:"
-msgstr "角度:"
-
 #: pcbnew/dialogs/dialog_orient_footprints_base.cpp:27
 msgid "New orientation (0.1 degree resolution)"
 msgstr "新しい角度(0.1度単位)"
-
-#: pcbnew/dialogs/dialog_orient_footprints_base.cpp:31
-#: eeschema/dialogs/dialog_choose_component_base.cpp:22
-#: common/dialogs/dialog_list_selector_base.cpp:19
-msgid "Filter:"
-msgstr "フィルター: "
 
 #: pcbnew/dialogs/dialog_orient_footprints_base.cpp:36
 msgid "Filter to select footprints by reference"
@@ -10237,28 +16652,22 @@ msgid "Shape:"
 msgstr "形状:"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:68
-msgid "Circular shape"
-msgstr "円形シェイプ"
+msgid "Rectangular"
+msgstr "四角"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:68
-msgid "Oval shape"
-msgstr "楕円形シェイプ"
-
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:68
-msgid "Rectangular shape"
-msgstr "長方形シェイプ"
-
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:68
-msgid "Trapezoidal shape"
-msgstr "台形シェイプ"
+msgid "Trapezoidal"
+msgstr "台形"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:83
 #: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:47
+#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:130
 msgid "Position X:"
 msgstr "X位置:"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:95
 #: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:80
+#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:142
 msgid "Position Y:"
 msgstr "Y位置:"
 
@@ -10277,16 +16686,6 @@ msgstr "サイズ Y:"
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:135
 msgid "90"
 msgstr "90"
-
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:135
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:48
-msgid "-90"
-msgstr "-90"
-
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:135
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:48
-msgid "180"
-msgstr "180"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:153
 msgid "0.1 deg"
@@ -10310,20 +16709,12 @@ msgid ""
 msgstr "パッドからチップのダイまでの配線長(実配線長の計算に使用されます)"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:195
-msgid "Trap. delta dim:"
-msgstr "台形作成時の短辺長:"
+msgid "Trapezoid delta:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:207
-msgid "Trap. direction:"
-msgstr "台形作成時の方向:"
-
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:211 eeschema/sch_line.cpp:471
-msgid "Horiz."
-msgstr "水平"
-
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:211 eeschema/sch_line.cpp:469
-msgid "Vert."
-msgstr "垂直"
+msgid "Trapezoid direction:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:225
 msgid "Parent footprint orientation"
@@ -10385,19 +16776,9 @@ msgstr "表面層の半田ペースト"
 msgid "Back solder paste"
 msgstr "裏面層の半田ペースト"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:348
-#: bitmap2component/bitmap2cmp_gui_base.cpp:150
-msgid "Front silk screen"
-msgstr "表面層のシルク"
-
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:351
 msgid "Back silk screen"
 msgstr "裏面層のシルク"
-
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:354
-#: bitmap2component/bitmap2cmp_gui_base.cpp:150
-msgid "Front solder mask"
-msgstr "表面層のレジスト"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:357
 msgid "Back solder mask"
@@ -10414,13 +16795,6 @@ msgstr "E.C.O.1"
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:366
 msgid "E.C.O.2"
 msgstr "E.C.O.2"
-
-#: pcbnew/dialogs/dialog_pad_properties_base.cpp:382
-#: eeschema/dialogs/dialog_color_config.cpp:102
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:28
-#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:22
-msgid "General"
-msgstr "一般設定"
 
 #: pcbnew/dialogs/dialog_pad_properties_base.cpp:391
 msgid "Clearances"
@@ -10521,66 +16895,17 @@ msgstr "レイヤが選択されていません。テキストレイヤを選択
 msgid "Enter the text placed on selected layer."
 msgstr "選択されたレイヤ上に置くテキストを入力。"
 
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:84
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:184
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:94
-msgid "Style:"
-msgstr "スタイル:"
+#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:70 pcbnew/muonde.cpp:812
+msgid "Mirrored"
+msgstr "反転"
 
 #: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:88
 msgid "Justification:"
 msgstr "位置合わせ:"
 
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:106
-#: eeschema/lib_pin.cpp:167
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:148
-#: eeschema/dialogs/dialog_edit_label_base.cpp:70
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:54
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:84
-msgid "Left"
-msgstr "左"
-
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:106
-#: pcbnew/tools/common_actions.cpp:206
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:148
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:154
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:54
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:62
-#: gerbview/class_GERBER.cpp:363 gerbview/class_GERBER.cpp:366
-#: common/zoom.cpp:246 pagelayout_editor/dialogs/properties_frame_base.cpp:84
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:103
-msgid "Center"
-msgstr "中央"
-
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:106
-#: eeschema/lib_pin.cpp:166
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:148
-#: eeschema/dialogs/dialog_edit_label_base.cpp:70
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:54
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:84
-msgid "Right"
-msgstr "右"
-
 #: pcbnew/dialogs/dialog_pcb_text_properties_base.cpp:116
 msgid "Orientation (0.1 deg):"
 msgstr "角度 (0.1度単位)"
-
-#: pcbnew/dialogs/dialog_plot.cpp:321
-#: eeschema/dialogs/dialog_plot_schematic.cpp:183
-#, c-format
-msgid ""
-"Do you want to use a path relative to\n"
-"'%s'"
-msgstr ""
-"下記の相対パスを使用しますか?\n"
-"'%s'"
-
-#: pcbnew/dialogs/dialog_plot.cpp:330
-#: eeschema/dialogs/dialog_plot_schematic.cpp:193
-msgid "Cannot make path relative (target volume different from file volume)!"
-msgstr ""
-"パスの関連付けを作成できません (ターゲットボリュームがボードファイルのボ"
-"リュームと異なります"
 
 #: pcbnew/dialogs/dialog_plot.cpp:595
 msgid "HPGL pen size constrained."
@@ -10617,44 +16942,14 @@ msgstr ""
 msgid "Could not write plot files to folder \"%s\"."
 msgstr "フォルダー \"%s\" へプロットファイルを生成できませんでした。"
 
-#: pcbnew/dialogs/dialog_plot.cpp:772
-#: pcbnew/dialogs/dialog_print_using_printer.cpp:375
-#: gerbview/dialogs/dialog_print_using_printer.cpp:305
-msgid "Warning: Scale option set to a very small value"
-msgstr "警告: 拡大率が非常に小さく設定されています"
-
-#: pcbnew/dialogs/dialog_plot.cpp:776
-#: pcbnew/dialogs/dialog_print_using_printer.cpp:367
-#: gerbview/dialogs/dialog_print_using_printer.cpp:297
-msgid "Warning: Scale option set to a very large value"
-msgstr "警告: 拡大率が非常に大きく設定されています"
-
 #: pcbnew/dialogs/dialog_plot.cpp:814
 #, c-format
 msgid "Plot file '%s' created."
 msgstr "出図ファイル '%s' が作成されました."
 
-#: pcbnew/dialogs/dialog_plot.cpp:819 pcbnew/dialogs/dialog_SVG_print.cpp:312
-#: pcbnew/exporters/gen_modules_placefile.cpp:310
-#, c-format
-msgid "Unable to create file '%s'."
-msgstr "ファイル '%s' を作成できません"
-
-#: pcbnew/dialogs/dialog_plot.cpp:827
-#: pcbnew/dialogs/dialog_print_using_printer.cpp:441
-#: pcbnew/dialogs/dialog_print_using_printer.cpp:482
-#: gerbview/dialogs/dialog_print_using_printer.cpp:340
-msgid "No layer selected"
-msgstr "レイヤが選択されていません"
-
 #: pcbnew/dialogs/dialog_plot_base.cpp:29
 msgid "Plot format:"
 msgstr "出力フォーマット:"
-
-#: pcbnew/dialogs/dialog_plot_base.cpp:33
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:88
-msgid "Postscript"
-msgstr "PostScript"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:93
 msgid "Plot sheet reference on all layers"
@@ -10762,20 +17057,6 @@ msgstr "3:1"
 msgid "Plot mode:"
 msgstr "出力モード:"
 
-#: pcbnew/dialogs/dialog_plot_base.cpp:164
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:53
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:59
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:65
-msgid "Filled"
-msgstr "塗りつぶし"
-
-#: pcbnew/dialogs/dialog_plot_base.cpp:164
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:53
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:59
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:65
-msgid "Sketch"
-msgstr "スケッチ"
-
 #: pcbnew/dialogs/dialog_plot_base.cpp:170
 msgid "Default line width"
 msgstr "デフォルトの線幅"
@@ -10841,13 +17122,6 @@ msgstr "4.5 (単位 mm)"
 msgid "4.6 (unit mm)"
 msgstr "4.6 (mm)"
 
-#: pcbnew/dialogs/dialog_plot_base.cpp:250
-#: pcbnew/dialogs/wizard_add_fplib_base.cpp:187
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:90
-#: bitmap2component/bitmap2cmp_gui_base.cpp:131
-msgid "Format"
-msgstr "フォーマット"
-
 #: pcbnew/dialogs/dialog_plot_base.cpp:252
 msgid ""
 "Resolution of coordinates in Gerber files.\n"
@@ -10855,11 +17129,6 @@ msgid ""
 msgstr ""
 "ガーバー ファイル座標軸の解像度.\n"
 "できるだけ高い値を使うこと."
-
-#: pcbnew/dialogs/dialog_plot_base.cpp:259
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:56
-msgid "HPGL Options"
-msgstr "HPGL オプション"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:267
 msgid "Pen size"
@@ -10913,12 +17182,6 @@ msgstr ""
 #: pcbnew/dialogs/dialog_plot_base.cpp:356
 msgid "Force A4 output"
 msgstr "強制的にA4で出力"
-
-#: pcbnew/dialogs/dialog_plot_base.cpp:382
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:110
-#: pcbnew/dialogs/dialog_plot_base.h:132
-msgid "Plot"
-msgstr "製造ファイル出力"
 
 #: pcbnew/dialogs/dialog_plot_base.cpp:386
 msgid "Generate Drill File"
@@ -11054,11 +17317,6 @@ msgstr "速度優先探索"
 msgid "Figure out what's best"
 msgstr "最適化優先探索"
 
-#: pcbnew/dialogs/dialog_pns_settings_base.cpp:21
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:109
-msgid "Mode"
-msgstr "モード"
-
 #: pcbnew/dialogs/dialog_pns_settings_base.cpp:34
 msgid "Mouse drag behaviour:"
 msgstr "ドラッグ中のマウスモード:"
@@ -11115,74 +17373,13 @@ msgstr "低"
 msgid "high"
 msgstr "高"
 
-#: pcbnew/dialogs/dialog_print_for_modedit.cpp:87
-#: pcbnew/dialogs/dialog_print_using_printer.cpp:114
-#: gerbview/dialogs/dialog_print_using_printer.cpp:107
-#: pagelayout_editor/events_functions.cpp:516
-msgid "Error Init Printer info"
-msgstr "プリンタ情報の初期化エラー"
-
-#: pcbnew/dialogs/dialog_print_for_modedit.cpp:173
-#: pcbnew/dialogs/dialog_print_using_printer.cpp:446
-#: gerbview/dialogs/dialog_print_using_printer.cpp:354
-msgid "Print Preview"
-msgstr "印刷プレビュー"
-
 #: pcbnew/dialogs/dialog_print_for_modedit.cpp:216
 msgid "Print Footprint"
 msgstr "フットプリントの印刷"
 
-#: pcbnew/dialogs/dialog_print_for_modedit.cpp:221
-#: pcbnew/dialogs/dialog_print_using_printer.cpp:496
-#: gerbview/dialogs/dialog_print_using_printer.cpp:401
-msgid "There was a problem printing"
-msgstr "印刷中に問題が発生しました"
-
-#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:22
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:49
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
-msgid "fit in page"
-msgstr "ページに合わせる"
-
-#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:22
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:49
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
-msgid "Scale 0.5"
-msgstr "0.5倍"
-
-#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:22
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:49
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
-msgid "Scale 0.7"
-msgstr "0.7倍"
-
 #: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:22
 msgid "Scale 1"
 msgstr "等倍"
-
-#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:22
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:49
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
-msgid "Scale 1.4"
-msgstr "1.4倍"
-
-#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:22
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:49
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
-msgid "Scale 2"
-msgstr "2倍"
-
-#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:22
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:49
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
-msgid "Scale 3"
-msgstr "3倍"
-
-#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:22
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:49
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
-msgid "Scale 4"
-msgstr "4倍"
 
 #: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:22
 msgid "Scale 8"
@@ -11192,92 +17389,6 @@ msgstr "8倍"
 msgid "Scale 16"
 msgstr "16倍"
 
-#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:24
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:51
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:46
-msgid "Approx. Scale:"
-msgstr "概略スケール値:"
-
-#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:34
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:112
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:73
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:107
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:85
-msgid "Color"
-msgstr "カラー"
-
-#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:34
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:112
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:73
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:107
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:85
-msgid "Black and white"
-msgstr "モノクロ"
-
-#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:36
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:114
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:87
-msgid "Print Mode"
-msgstr "印刷モード"
-
-#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:38
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:116
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:77
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:111
-msgid ""
-"Choose if you want to draw the sheet like it appears on screen,\n"
-"or in black and white mode, better to print it when using  black and white "
-"printers"
-msgstr ""
-"スクリーン表示のような作画や、モノクロモードで\n"
-"モノクロのプリンター使用時に良い印刷をしたい場合に選択"
-
-#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:48
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:135
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:99
-msgid "Page Options"
-msgstr "ページ オプション"
-
-#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:51
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:138
-#: eeschema/dialogs/dialog_print_using_printer.cpp:263
-#: eeschema/dialogs/dialog_print_using_printer_base.cpp:47
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:102
-#: pagelayout_editor/dialogs/dialogs_for_printing.cpp:237
-msgid "Preview"
-msgstr "プレビュー"
-
-#: pcbnew/dialogs/dialog_print_for_modedit_base.cpp:54
-#: pcbnew/dialogs/dialog_print_using_printer.cpp:490
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:141
-#: eeschema/dialogs/dialog_print_using_printer_base.cpp:50
-#: gerbview/dialogs/dialog_print_using_printer.cpp:390
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:105
-#: pcbnew/dialogs/dialog_print_for_modedit_base.h:61
-#: pcbnew/dialogs/dialog_print_using_printer_base.h:81
-#: eeschema/dialogs/dialog_print_using_printer_base.h:56
-#: gerbview/dialogs/dialog_print_using_printer_base.h:73
-msgid "Print"
-msgstr "印刷"
-
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:20
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:45
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:20
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:25
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:30
-msgid "Layers:"
-msgstr "レイヤ:"
-
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:25
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:47
-msgid "Copper Layers:"
-msgstr "導体レイヤ:"
-
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:30
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:52
-msgid "Technical Layers:"
-msgstr "テクニカル レイヤ:"
-
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:38
 msgid "Exclude Edges_Pcb Layer"
 msgstr "基板外形レイヤの除外"
@@ -11286,45 +17397,9 @@ msgstr "基板外形レイヤの除外"
 msgid "Exclude contents of Edges_Pcb layer from all other layers"
 msgstr "全ての他のレイヤから基板外形レイヤのデータを除外します"
 
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:49
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
-msgid "Approx. Scale 1"
-msgstr "大まかな原寸"
-
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:49
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:44
-msgid "Accurate Scale 1"
-msgstr "正確な原寸"
-
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:55
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:50
-msgid "X Scale Adjust"
-msgstr "Xスケール値の調整"
-
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:61
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:56
-msgid "Set X scale adjust for exact scale plotting"
-msgstr "実際の作画倍率にXスケールを調整"
-
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:65
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:60
-msgid "Y Scale Adjust"
-msgstr "Yスケールの調整"
-
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:71
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:66
-msgid "Set Y scale adjust for exact scale plotting"
-msgstr "実際に作画倍率にYスケールを調整"
-
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:94
 msgid "Print frame ref"
 msgstr "フレームリファレンスを作画"
-
-#: pcbnew/dialogs/dialog_print_using_printer_base.cpp:96
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:117
-#: eeschema/dialogs/dialog_print_using_printer_base.cpp:30
-msgid "Print (or not) the Frame references."
-msgstr "図枠 リファレンスの印刷設定"
 
 #: pcbnew/dialogs/dialog_print_using_printer_base.cpp:106
 msgid "No drill mark"
@@ -11363,12 +17438,16 @@ msgstr ""
 "フットプリントは、そのフォルダに格納された .kicad_mod ファイルとなります。"
 
 #: pcbnew/dialogs/dialog_select_pretty_lib_base.cpp:25
+msgid "Path base:"
+msgstr ""
+
+#: pcbnew/dialogs/dialog_select_pretty_lib_base.cpp:29
 msgid "Select a folder"
 msgstr "フォルダを指定"
 
-#: pcbnew/dialogs/dialog_select_pretty_lib_base.cpp:30
-msgid "Library Path (.pretty will be appended to folder)"
-msgstr "ライブラリパス (.pretty フォルダ)"
+#: pcbnew/dialogs/dialog_select_pretty_lib_base.cpp:34
+msgid "Library folder (.pretty will be added to name, if missing)"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_set_grid.cpp:233
 #, c-format
@@ -11387,15 +17466,6 @@ msgstr ""
 #: pcbnew/dialogs/dialog_set_grid_base.cpp:23
 msgid "User Defined Grid"
 msgstr "ユーザ グリッド"
-
-#: pcbnew/dialogs/dialog_set_grid_base.cpp:63
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:70
-#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:48
-#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:92
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:247
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:302
-msgid "Origin"
-msgstr "原点"
 
 #: pcbnew/dialogs/dialog_set_grid_base.cpp:71
 msgid "X:"
@@ -11420,92 +17490,6 @@ msgstr "グリッド1:"
 #: pcbnew/dialogs/dialog_set_grid_base.cpp:120
 msgid "Grid 2:"
 msgstr "グリッド2:"
-
-#: pcbnew/dialogs/dialog_SVG_print.cpp:233
-#: pcbnew/exporters/gen_modules_placefile.cpp:193
-msgid ""
-"Cannot make path relative (target volume different from board file volume)!"
-msgstr ""
-"パスの関連付けを作成できません (ターゲットボリュームがボードファイルのボ"
-"リュームと異なります"
-
-#: pcbnew/dialogs/dialog_SVG_print.cpp:275
-#: eeschema/dialogs/dialog_plot_schematic.cpp:348
-#, c-format
-msgid "Could not write plot files to folder '%s'."
-msgstr "フォルダ '%s' へプロットファイルを生成できませんでした。"
-
-#: pcbnew/dialogs/dialog_SVG_print.cpp:306
-#, c-format
-msgid "Plot: '%s' OK."
-msgstr "プロット: '%s' OK."
-
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:30
-msgid ""
-"Enter a filename if you do not want to use default file names\n"
-"Can be used only when printing the current sheet"
-msgstr ""
-"デフォルトのファイル名でないものを使いたい場合、ファイル名を入力してくださ"
-"い。\n"
-"これは現在のシートを印刷するときにのみ使用されます。"
-
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:61
-msgid "Print SVG options:"
-msgstr "SVG印刷オプション:"
-
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:65
-msgid ""
-"Selection of the pen size used to draw items which have no pen size "
-"specified."
-msgstr "太さが０にセットされているアイテムを描画する時の、標準ペン幅を選択"
-
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:75
-msgid "Print mode"
-msgstr "印刷モード"
-
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:81
-msgid "Full page with  frame ref"
-msgstr "図枠付きフルページ"
-
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:81
-msgid "Current page size"
-msgstr "現在の用紙サイズ"
-
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:81
-msgid "Board area only"
-msgstr "ボードの範囲のみ"
-
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:83
-msgid "SVG Page Size"
-msgstr "SVGページ サイズ"
-
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:87
-msgid "Print board edges"
-msgstr "基板外形を出力"
-
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:89
-msgid "Print (or not) the edges layer on others layers"
-msgstr "基板外形レイヤを他のレイヤに印刷する"
-
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:93
-msgid "Print mirrored"
-msgstr "反転印刷"
-
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:94
-msgid "Print the layer(s) horizontally mirrored"
-msgstr "水平反転してレイヤを印刷"
-
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:104
-msgid "One file per layer"
-msgstr "レイヤごとにファイルを出力する"
-
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:104
-msgid "All in one file"
-msgstr "全てを1つのファイルへまとめる"
-
-#: pcbnew/dialogs/dialog_SVG_print_base.cpp:106
-msgid "File option:"
-msgstr "ファイルオプション:"
 
 #: pcbnew/dialogs/dialog_target_properties_base.cpp:54
 msgid "+"
@@ -11535,13 +17519,13 @@ msgstr "ビアのドリルサイズはビアの直径より小さくなければ
 msgid "Use net class width"
 msgstr "ネットクラスの幅を使用"
 
-#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:130
-msgid "Position X"
-msgstr "ポジション X"
+#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:165
+msgid "Diameter:"
+msgstr ""
 
-#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:142
-msgid "Position Y"
-msgstr "ポジション Y"
+#: pcbnew/dialogs/dialog_track_via_properties_base.cpp:177
+msgid "Drill:"
+msgstr ""
 
 #: pcbnew/dialogs/dialog_track_via_properties_base.cpp:192
 msgid "Use net class size"
@@ -11559,28 +17543,28 @@ msgstr "ビア径:"
 msgid "Via drill:"
 msgstr "ビア ドリル径:"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:208
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:209
 msgid "New"
 msgstr "新規"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:208
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:209
 msgid "Update"
 msgstr "更新"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:295
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:296
 #: pcbnew/dialogs/wizard_add_fplib.cpp:557
 msgid "Choose a folder to save the downloaded libraries"
 msgstr "ダウンロードしたライブラリの保存先を指定"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:317
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:318
 msgid "KISYS3DMOD path not defined , or not existing"
 msgstr "KISYS3DMOD のパスが設定されてないか、存在しません。"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:355
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:356
 msgid "Downloading 3D libraries"
 msgstr "3D ライブラリをダウンロード"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:459
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader.cpp:460
 msgid "Aborted by user"
 msgstr "ユーザーによる中断"
 
@@ -11593,19 +17577,18 @@ msgid "Please select the URL for the 3D libraries to download"
 msgstr "ダウンロードする 3D ライブラリの URL を選択して下さい。"
 
 #: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:39
-#: pcbnew/dialogs/wizard_add_fplib_base.cpp:49
 msgid "http://github.com/KiCad"
 msgstr "http://github.com/KiCad"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:53
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:56
 msgid "3D shape local folder:"
 msgstr "3D シェイプのローカル フォルダ:"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:69
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:72
 msgid "Default 3D Path"
 msgstr "デフォルトの 3D パス"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:81
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:84
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:82
 msgid ""
 "It is not possible to write in the selected directory.\n"
@@ -11614,63 +17597,37 @@ msgstr ""
 "選択されたディレクトリへは保存できません。\n"
 "別のディレクトリを指定してください。"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:99
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:111
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:106
 msgid "Visit our official Kicad repository on Github and get more libraries"
 msgstr ""
 "GithubのKicad公式リポジトリへアクセスすると、より多くのライブラリを入手できま"
 "す"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:114
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:126
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:140
 msgid "Select Github libraries to add:"
 msgstr "追加するGithubライブラリを選択:"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:125
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:137
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:151
 msgid "Select all"
 msgstr "全て選択"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:128
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:140
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:154
 msgid "Unselect all"
 msgstr "全て選択解除"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:154
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:166
 msgid "Local library folder:"
 msgstr "ローカル・ライブラリ・フォルダ:"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:158
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:373
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:385
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:397
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:409
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:462
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:474
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:486
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:498
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:966
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:970
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:974
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:978
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:982
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:986
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:990
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:994
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:998
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1002
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1006
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1010
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1014
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1018
-msgid "dummy"
-msgstr "ダミー"
-
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:162
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:174
 msgid "3D shape libraries to be downloaded:"
 msgstr "ダウンロードによる 3D シェイプ ライブラリ:"
 
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:180
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.cpp:192
 msgid "Libraries"
 msgstr "ライブラリ"
 
@@ -11739,6 +17696,10 @@ msgstr "このコンピュータにあるファイル"
 msgid "Github repository"
 msgstr "Githubリポジトリ"
 
+#: pcbnew/dialogs/wizard_add_fplib_base.cpp:49
+msgid "https://github.com/KiCad"
+msgstr ""
+
 #: pcbnew/dialogs/wizard_add_fplib_base.cpp:57
 msgid "Save a local copy to:"
 msgstr "ローカルの保存先："
@@ -11763,6 +17724,251 @@ msgstr "グローバルライブラリとして設定(全てのプロジェク�
 msgid "To the current project only"
 msgstr "現在のプロジェクトのみ"
 
+#: pcbnew/dimension.cpp:149
+msgid ""
+"This item has an illegal layer id.\n"
+"Now, forced on the drawings layer. Please, fix it"
+msgstr ""
+"このアイテム中には不正なレイヤIDがあります．\n"
+"現在は強制的に描画レイヤにしているため，適切に修正してください．"
+
+#: pcbnew/dimension.cpp:173
+msgid ""
+"The layer currently selected is not enabled for this board\n"
+"You cannot use it"
+msgstr ""
+"現在選択されているレイヤはこのボードで有効になっていません。\n"
+"現在使用することができません"
+
+#: pcbnew/dimension.cpp:217
+msgid "The text thickness is too large for the text size.  It will be clamped"
+msgstr "文字太さが文字サイズに比べて太過ぎるため、文字が潰れてしまいます。"
+
+#: pcbnew/drc.cpp:180
+msgid "Compile ratsnest...\n"
+msgstr "ラッツネストのコンパイル中...\n"
+
+#: pcbnew/drc.cpp:196
+msgid "Aborting\n"
+msgstr "停止割り込み中\n"
+
+#: pcbnew/drc.cpp:209
+msgid "Pad clearances...\n"
+msgstr "パッドのクリアランス...\n"
+
+#: pcbnew/drc.cpp:219
+msgid "Track clearances...\n"
+msgstr "配線のクリアランス...\n"
+
+#: pcbnew/drc.cpp:229
+msgid "Fill zones...\n"
+msgstr "ゾーンの塗りつぶし...\n"
+
+#: pcbnew/drc.cpp:239
+msgid "Test zones...\n"
+msgstr "ゾーンのテスト...\n"
+
+#: pcbnew/drc.cpp:250
+msgid "Unconnected pads...\n"
+msgstr "未接続パッド...\n"
+
+#: pcbnew/drc.cpp:262
+msgid "Keepout areas ...\n"
+msgstr "禁止エリア ...\n"
+
+#: pcbnew/drc.cpp:272
+msgid "Test texts...\n"
+msgstr "テストテキスト...\n"
+
+#: pcbnew/drc.cpp:285
+msgid "Finished"
+msgstr "終了"
+
+#: pcbnew/drc.cpp:323
+#, c-format
+msgid "NETCLASS: '%s' has Clearance:%s which is less than global:%s"
+msgstr ""
+"ネットクラス: '%s' のクリアランス:%s はグローバル クリアランス:%s よりも小さ"
+"いです"
+
+#: pcbnew/drc.cpp:339
+#, c-format
+msgid "NETCLASS: '%s' has TrackWidth:%s which is less than global:%s"
+msgstr "ネットクラス: '%s' の配線幅:%s はグローバル配線幅:%s より小さいです"
+
+#: pcbnew/drc.cpp:354
+#, c-format
+msgid "NETCLASS: '%s' has Via Dia:%s which is less than global:%s"
+msgstr "ネットクラス: '%s' のビア径:%s はグローバル ビア径:%s より小さいです"
+
+#: pcbnew/drc.cpp:369
+#, c-format
+msgid "NETCLASS: '%s' has Via Drill:%s which is less than global:%s"
+msgstr ""
+"ネットクラス: '%s' のビア ドリル径: %s はグローバル ビア ドリル径: %s より小"
+"さいです"
+
+#: pcbnew/drc.cpp:384
+#, c-format
+msgid "NETCLASS: '%s' has uVia Dia:%s which is less than global:%s"
+msgstr ""
+"ネットクラス: '%s' のマイクロビア径: %s はグローバル マイクロビア径: %s より"
+"小さいです"
+
+#: pcbnew/drc.cpp:399
+#, c-format
+msgid "NETCLASS: '%s' has uVia Drill:%s which is less than global:%s"
+msgstr ""
+"ネットクラス: '%s' のマイクロビア ドリル径 :%s はグローバル マイクロビア ドリ"
+"ル径 :%s より小さいです"
+
+#: pcbnew/drc.cpp:492
+msgid "Track clearances"
+msgstr "配線のクリアランス"
+
+#: pcbnew/eagle_plugin.cpp:1674
+#, c-format
+msgid "<package> name: '%s' duplicated in eagle <library>: '%s'"
+msgstr "<package> の名前:'%s' が，Eagleの <library> 名と重複しています:'%s'"
+
+#: pcbnew/eagle_plugin.cpp:1731
+#, c-format
+msgid "No '%s' package in library '%s'"
+msgstr "パッケージ '%s' がライブラリ '%s' 内に見つかりませんでした"
+
+#: pcbnew/eagle_plugin.cpp:2797
+#, c-format
+msgid "File '%s' is not readable."
+msgstr "ファイル '%s' が読み込めません。"
+
+#: pcbnew/edgemod.cpp:213
+msgid ""
+"The graphic item will be on a copper layer.\n"
+"This is very dangerous. Are you sure?"
+msgstr ""
+"図形アイテムが銅箔層の上に配置されます。\n"
+"これは非常に危険ですが、続行しますか？"
+
+#: pcbnew/edgemod.cpp:254
+msgid "New Width:"
+msgstr "新しい幅:"
+
+#: pcbnew/edgemod.cpp:254
+msgid "Edge Width"
+msgstr "エッジの幅"
+
+#: pcbnew/edit.cpp:693 pcbnew/edit.cpp:715 pcbnew/edit.cpp:741
+#: pcbnew/edit.cpp:769 pcbnew/edit.cpp:797 pcbnew/edit.cpp:825
+#, c-format
+msgid "Footprint %s found, but it is locked"
+msgstr "フットプリント %s はロックされています"
+
+#: pcbnew/edit.cpp:897 pcbnew/edit.cpp:916
+#, c-format
+msgid "The parent (%s) of the pad is locked"
+msgstr "パッドの親 (%s) はロックされています"
+
+#: pcbnew/edit.cpp:1433 pcbnew/edit.cpp:1435
+msgid "Add tracks"
+msgstr "配線の入力"
+
+#: pcbnew/edit.cpp:1445 pcbnew/edit.cpp:1492
+#: pcbnew/tools/pcb_editor_control.cpp:222
+msgid "Add module"
+msgstr "モジュールの入力"
+
+#: pcbnew/edit.cpp:1449 pcbnew/tools/drawing_tool.cpp:417
+msgid "Add zones"
+msgstr "ゾーンの入力"
+
+#: pcbnew/edit.cpp:1452
+msgid "Warning: zone display is OFF!!!"
+msgstr "警告: ゾーンの表示がOFFになっています!!!"
+
+#: pcbnew/edit.cpp:1460 pcbnew/tools/drawing_tool.cpp:425
+msgid "Add keepout"
+msgstr "キープアウト(禁止)エリアの追加"
+
+#: pcbnew/edit.cpp:1464 pcbnew/menubar_pcbframe.cpp:421
+#: pcbnew/tool_pcb.cpp:470 pcbnew/tools/common_actions.cpp:384
+#: pcbnew/tools/pcb_editor_control.cpp:371
+msgid "Add layer alignment target"
+msgstr "層合わせマーク(ターゲットマーク)の入力"
+
+#: pcbnew/edit.cpp:1468 pcbnew/tools/pcb_editor_control.cpp:670
+msgid "Adjust zero"
+msgstr "ゼロ設定"
+
+#: pcbnew/edit.cpp:1472 pcbnew/tools/pcbnew_control.cpp:657
+msgid "Adjust grid origin"
+msgstr "グリッドの原点設定"
+
+#: pcbnew/edit.cpp:1476 pcbnew/tools/drawing_tool.cpp:78
+#: pcbnew/tools/drawing_tool.cpp:103
+msgid "Add graphic line"
+msgstr "図形ライン入力"
+
+#: pcbnew/edit.cpp:1480 pcbnew/menubar_modedit.cpp:287
+#: pcbnew/menubar_pcbframe.cpp:403 pcbnew/tool_modedit.cpp:176
+#: pcbnew/tool_pcb.cpp:460 pcbnew/tools/drawing_tool.cpp:182
+#: pcbnew/tools/drawing_tool.cpp:202
+msgid "Add graphic arc"
+msgstr "円弧入力"
+
+#: pcbnew/edit.cpp:1484 pcbnew/menubar_modedit.cpp:276
+#: pcbnew/menubar_pcbframe.cpp:406 pcbnew/tool_modedit.cpp:173
+#: pcbnew/tool_pcb.cpp:457 pcbnew/tools/drawing_tool.cpp:135
+#: pcbnew/tools/drawing_tool.cpp:155
+msgid "Add graphic circle"
+msgstr "円入力"
+
+#: pcbnew/edit.cpp:1496 pcbnew/menubar_pcbframe.cpp:417
+#: pcbnew/tool_pcb.cpp:467 pcbnew/tools/drawing_tool.cpp:248
+msgid "Add dimension"
+msgstr "寸法線入力"
+
+#: pcbnew/edit.cpp:1504 pcbnew/tool_pcb.cpp:432
+#: pcbnew/tools/pcb_editor_control.cpp:730
+msgid "Highlight net"
+msgstr "ネットをハイライト"
+
+#: pcbnew/edit.cpp:1508
+msgid "Select rats nest"
+msgstr "ラッツネストを選択"
+
+#: pcbnew/editedge.cpp:152
+msgid "Copper layer global delete not allowed!"
+msgstr "導体層はグローバル削除できません！"
+
+#: pcbnew/editedge.cpp:157
+#, c-format
+msgid "Delete everything on layer %s?"
+msgstr "レイヤ %s 上の全てを削除する"
+
+#: pcbnew/editmod.cpp:115
+msgid "Cannot delete REFERENCE!"
+msgstr "リファレンスは削除できません!"
+
+#: pcbnew/editmod.cpp:119
+msgid "Cannot delete VALUE!"
+msgstr "部品定数は削除することが出来ません!"
+
+#: pcbnew/editrack.cpp:815
+msgid "Track Len"
+msgstr "配線長"
+
+#: pcbnew/editrack.cpp:819
+msgid "Full Len"
+msgstr "全長"
+
+#: pcbnew/editrack.cpp:821
+msgid "Pad to die"
+msgstr "パッドからダイ"
+
+#: pcbnew/editrack.cpp:826
+msgid "Segs Count"
+msgstr "セグメント数"
+
 #: pcbnew/exporters/export_d356.cpp:359
 msgid "IPC-D-356 Test Files (.d356)|*.d356"
 msgstr "IPC-D-356テストファイル (.d356)|*d356"
@@ -11779,18 +17985,12 @@ msgstr "GenCAD 1.4 ボード ファイル (.cad)|*.cad"
 msgid "Save GenCAD Board File"
 msgstr "GenCAD ボード ファイルの保存"
 
-#: pcbnew/exporters/export_gencad.cpp:267 pagelayout_editor/files.cpp:194
-#: pagelayout_editor/pl_editor_frame.cpp:255
-#, c-format
-msgid "Unable to create <%s>"
-msgstr "<%s> を作成できません"
-
 #: pcbnew/exporters/export_idf.cpp:585 pcbnew/exporters/export_idf.cpp:594
-#: pcbnew/exporters/export_idf.cpp:602 pcbnew/exporters/export_vrml.cpp:1394
+#: pcbnew/exporters/export_idf.cpp:602 pcbnew/exporters/export_vrml.cpp:1398
 msgid "IDF Export Failed:\n"
 msgstr "IDF出力エラー:\n"
 
-#: pcbnew/exporters/export_vrml.cpp:709
+#: pcbnew/exporters/export_vrml.cpp:713
 msgid ""
 "Unable to calculate the board outlines;\n"
 "fall back to using the board boundary box."
@@ -11798,7 +17998,7 @@ msgstr ""
 "基板の外形を計算できません;\n"
 "バウンダリボックスの使用に戻ります."
 
-#: pcbnew/exporters/export_vrml.cpp:742
+#: pcbnew/exporters/export_vrml.cpp:746
 msgid ""
 "VRML Export Failed:\n"
 "Could not add holes to contours."
@@ -11869,6 +18069,154 @@ msgstr "'%s' を作成できません"
 #, c-format
 msgid "Create file %s\n"
 msgstr "ファイルの作成 %s\n"
+
+#: pcbnew/files.cpp:123
+msgid "Open Board File"
+msgstr "ボード ファイルを開く"
+
+#: pcbnew/files.cpp:161
+msgid "Save Board File As"
+msgstr "ボード ファイルを名前を付けて保存"
+
+#: pcbnew/files.cpp:186
+#, c-format
+msgid ""
+"The file '%s' already exists.\n"
+"\n"
+"Do you want to overwrite it?"
+msgstr ""
+"'%s' のファイルは既に存在します．\n"
+"\n"
+"上書きしますか？"
+
+#: pcbnew/files.cpp:205
+msgid "Printed circuit board"
+msgstr "プリント基板"
+
+#: pcbnew/files.cpp:276
+#, c-format
+msgid "Recovery file '%s' not found."
+msgstr "リカバリファイル '%s' が見つかりません。"
+
+#: pcbnew/files.cpp:282
+#, c-format
+msgid "OK to load recovery or backup file '%s'"
+msgstr "リカバリー バックアップ ファイル \"%s\" を読み込みます、宜しいですか？"
+
+#: pcbnew/files.cpp:342
+msgid "noname"
+msgstr "名前なし"
+
+#: pcbnew/files.cpp:410
+#, c-format
+msgid "PCB file '%s' is already open."
+msgstr "PCBファイル '%s' は既に開かれています。"
+
+#: pcbnew/files.cpp:420
+msgid "The current board has been modified.  Do you wish to save the changes?"
+msgstr "現在のボードは変更されています。変更を保存しますか？"
+
+#: pcbnew/files.cpp:446
+#, c-format
+msgid "Board '%s' does not exist.  Do you wish to create it?"
+msgstr "ボード '%s' は存在しません。新規作成しますか?"
+
+#: pcbnew/files.cpp:542
+msgid ""
+"This file was created by an older version of Pcbnew.\n"
+"It will be stored in the new file format when you save this file again."
+msgstr ""
+"このファイルは古いバージョンの Pcbnew で作成されています。\n"
+"次に保存する際に、新しいフォーマットで保存し直されます。"
+
+#: pcbnew/files.cpp:643
+#, c-format
+msgid "Warning: unable to create backup file '%s'"
+msgstr "警告: バックアップ ファイル '%s' を作成できません"
+
+#: pcbnew/files.cpp:670 pcbnew/files.cpp:765
+#, c-format
+msgid "No access rights to write to file '%s'"
+msgstr "'%s' ファイルへの書き込み権限がありません。"
+
+#: pcbnew/files.cpp:711 pcbnew/files.cpp:791
+#, c-format
+msgid ""
+"Error saving board file '%s'.\n"
+"%s"
+msgstr ""
+"ボード保存中のエラー '%s'\n"
+"%s"
+
+#: pcbnew/files.cpp:717
+#, c-format
+msgid "Failed to create '%s'"
+msgstr "'%s' の作成に失敗しました"
+
+#: pcbnew/files.cpp:743
+#, c-format
+msgid "Backup file: '%s'"
+msgstr "バックアップファイル: '%s'"
+
+#: pcbnew/files.cpp:745
+#, c-format
+msgid "Wrote board file: '%s'"
+msgstr "ボードファイルに書き込みました: '%s'"
+
+#: pcbnew/files.cpp:800
+#, c-format
+msgid ""
+"Board copied to:\n"
+"'%s'"
+msgstr ""
+"次へボードをコピーしました:\n"
+"'%s'"
+
+#: pcbnew/footprint_wizard.cpp:78 pcbnew/footprint_wizard_frame.cpp:93
+msgid "Footprint Wizard"
+msgstr "フットプリントウィザード"
+
+#: pcbnew/footprint_wizard.cpp:84
+msgid "no wizard selected"
+msgstr "ウィザードが選択されていません"
+
+#: pcbnew/footprint_wizard.cpp:148
+msgid "Couldn't reload footprint wizard"
+msgstr "フットプリントウィザードの再読み込みに失敗しました"
+
+#: pcbnew/footprint_wizard_frame.cpp:268
+msgid "Parameter"
+msgstr "パラメータ"
+
+#: pcbnew/footprint_wizard_frame.cpp:549 pcbnew/modview_frame.cpp:644
+#, c-format
+msgid "ModView: 3D Viewer [%s]"
+msgstr "ModView: 3Dビューア [%s]"
+
+#: pcbnew/footprint_wizard_frame.cpp:575
+msgid "Select the wizard script to load and run"
+msgstr ""
+
+#: pcbnew/footprint_wizard_frame.cpp:580
+msgid "Select previous parameters page"
+msgstr ""
+
+#: pcbnew/footprint_wizard_frame.cpp:584
+msgid "Select next parameters page"
+msgstr ""
+
+#: pcbnew/footprint_wizard_frame.cpp:589 pcbnew/menubar_modedit.cpp:237
+#: pcbnew/tool_modview.cpp:76 pcbnew/tool_modview.cpp:178
+msgid "Show footprint in 3D viewer"
+msgstr "フットプリントを3Dビューアで表示"
+
+#: pcbnew/footprint_wizard_frame.cpp:616
+msgid "Export the footprint to the editor"
+msgstr ""
+
+#: pcbnew/footprint_wizard_frame.cpp:635
+msgid "Footprint Builder Messages"
+msgstr ""
 
 #: pcbnew/github/github_getliblist.cpp:132
 #, c-format
@@ -11955,14 +18303,96 @@ msgstr ""
 "データを取得することができませんでした: '%s'\n"
 "理由: '%s'"
 
+#: pcbnew/gpcb_plugin.cpp:85
+#, c-format
+msgid "Cannot convert \"%s\" to an integer"
+msgstr "\"%s\" を整数に変換できません"
+
+#: pcbnew/gpcb_plugin.cpp:269 pcbnew/gpcb_plugin.cpp:905
+#: pcbnew/kicad_plugin.cpp:1757
+#, c-format
+msgid "footprint library path '%s' does not exist"
+msgstr "フットプリントライブラリのパス '%s' は存在しません"
+
+#: pcbnew/gpcb_plugin.cpp:309
+#, c-format
+msgid "library <%s> has no footprint '%s' to delete"
+msgstr "ライブラリ <%s> には削除するフットプリント '%s' がありません"
+
+#: pcbnew/gpcb_plugin.cpp:411 pcbnew/pcb_parser.cpp:406
+#: pcbnew/pcb_parser.cpp:495
+#, c-format
+msgid "unknown token \"%s\""
+msgstr "未知のトークン \"%s\""
+
+#: pcbnew/gpcb_plugin.cpp:418
+#, c-format
+msgid "Element token contains %d parameters."
+msgstr "要素は%dのパラメータを持っています。"
+
+#: pcbnew/gpcb_plugin.cpp:973 pcbnew/kicad_plugin.cpp:1830
+#: pcbnew/kicad_plugin.cpp:1895 pcbnew/legacy_plugin.cpp:4648
+#: pcbnew/legacy_plugin.cpp:4693 pcbnew/librairi.cpp:476
+#, c-format
+msgid "Library '%s' is read only"
+msgstr "ライブラリ '%s' は読み込み専用です。"
+
+#: pcbnew/gpcb_plugin.cpp:992 pcbnew/kicad_plugin.cpp:1932
+#, c-format
+msgid "user does not have permission to delete directory '%s'"
+msgstr "現在のユーザは、ディレクトリ '%s' を削除する権限がありません"
+
+#: pcbnew/gpcb_plugin.cpp:1000 pcbnew/kicad_plugin.cpp:1940
+#, c-format
+msgid "library directory '%s' has unexpected sub-directories"
+msgstr ""
+"ライブラリのディレクトリ <%s> が予期しないサブディレクトリを含んでいます"
+
+#: pcbnew/gpcb_plugin.cpp:1019 pcbnew/kicad_plugin.cpp:1959
+#, c-format
+msgid "unexpected file '%s' was found in library path '%s'"
+msgstr "不正なファイル '%s' がライブラリパス '%s'から見つかりました"
+
+#: pcbnew/gpcb_plugin.cpp:1037 pcbnew/kicad_plugin.cpp:1977
+#, c-format
+msgid "footprint library '%s' cannot be deleted"
+msgstr "フットプリントライブラリ '%s' は削除できません"
+
+#: pcbnew/highlight.cpp:56
+msgid "Filter Net Names"
+msgstr "ネット名のフィルター"
+
+#: pcbnew/highlight.cpp:56
+msgid "Net Filter"
+msgstr "ネット フィルター"
+
+#: pcbnew/highlight.cpp:79
+msgid "Select Net"
+msgstr "ネットの選択"
+
+#: pcbnew/hotkeys_board_editor.cpp:63
+#, c-format
+msgid "Recording macro %d"
+msgstr "マクロの記録中 %d"
+
+#: pcbnew/hotkeys_board_editor.cpp:70
+#, c-format
+msgid "Macro %d recorded"
+msgstr "マクロ %d が記録されました"
+
+#: pcbnew/hotkeys_board_editor.cpp:82
+#, c-format
+msgid "Call macro %d"
+msgstr "マクロ %d の呼び出し"
+
+#: pcbnew/hotkeys_board_editor.cpp:160
+#, c-format
+msgid "Add key [%c] in macro %d"
+msgstr "[%c] キーをマクロ %d に追加"
+
 #: pcbnew/import_dxf/dialog_dxf_import.cpp:137
 msgid "Open File"
 msgstr "ファイルを開く"
-
-#: pcbnew/import_dxf/dialog_dxf_import_base.cpp:24
-#: gerbview/gerbview_frame.cpp:488
-msgid "File:"
-msgstr "ファイル:"
 
 #: pcbnew/import_dxf/dialog_dxf_import_base.cpp:42
 msgid "Center of page"
@@ -11988,17 +18418,9 @@ msgstr "ユーザ定義の位置"
 msgid "Place DXF origin (0,0) point:"
 msgstr "DXFの原点座標 (0,0) をセット:"
 
-#: pcbnew/import_dxf/dialog_dxf_import_base.cpp:54
-msgid "X Position:"
-msgstr "X 位置:"
-
 #: pcbnew/import_dxf/dialog_dxf_import_base.cpp:60
 msgid "DXF origin on PCB Grid, X Coordinate"
 msgstr "基板グリッドの DXF 原点、X 座標"
-
-#: pcbnew/import_dxf/dialog_dxf_import_base.cpp:70
-msgid "Y Position:"
-msgstr "Y 位置:"
 
 #: pcbnew/import_dxf/dialog_dxf_import_base.cpp:76
 msgid "DXF origin on PCB Grid, Y Coordinate"
@@ -12008,11 +18430,2354 @@ msgstr "基板グリッドの DXF 原点、Y 座標"
 msgid "Select PCB grid units"
 msgstr "基板グリッドの単位を選択"
 
-#: pcbnew/router/length_tuner_tool.cpp:51 pcbnew/router/router_tool.cpp:61
+#: pcbnew/initpcb.cpp:47
+msgid ""
+"Current Board will be lost and this operation cannot be undone. Continue ?"
+msgstr "現在のボードは失われます、この操作はやり直しできません。 続けますか？"
+
+#: pcbnew/initpcb.cpp:102 pcbnew/modedit.cpp:340
+msgid ""
+"Current Footprint will be lost and this operation cannot be undone. "
+"Continue ?"
+msgstr ""
+"現在のフットプリントは失われます、この操作はやり直しできません。 続けますか？"
+
+#: pcbnew/io_mgr.cpp:42 pcbnew/plugin.cpp:27
+#, c-format
+msgid "Plugin '%s' does not implement the '%s' function."
+msgstr "'%s' プラグインには '%s' 機能はありません．"
+
+#: pcbnew/io_mgr.cpp:43
+#, c-format
+msgid "Plugin type '%s' is not found."
+msgstr "プラグインタイプ \"%s\" が見つかりません。"
+
+#: pcbnew/io_mgr.cpp:126
+#, c-format
+msgid "Unknown PCB_FILE_T value: %d"
+msgstr "未知の PCB_FILE_T の値: %d"
+
+#: pcbnew/kicad_netlist_reader.cpp:255
+#, c-format
+msgid "Cannot find component with reference \"%s\" in netlist."
+msgstr ""
+"リファレンス \"%s\" のコンポーネントは、ネットリストから見つかりませんでし"
+"た。"
+
+#: pcbnew/kicad_netlist_reader.cpp:372 pcbnew/pcb_parser.cpp:1674
+#, c-format
+msgid ""
+"invalid footprint ID in\n"
+"file: <%s>\n"
+"line: %d\n"
+"offset: %d"
+msgstr ""
+
+#: pcbnew/kicad_plugin.cpp:215
+#, c-format
+msgid "Cannot create footprint library path '%s'"
+msgstr "フットプリントライブラリのパス '%s' が生成できません。"
+
+#: pcbnew/kicad_plugin.cpp:221
+#, c-format
+msgid "Footprint library path '%s' is read only"
+msgstr "フットプリントライブラリパス '%s' は読み込み専用です"
+
+#: pcbnew/kicad_plugin.cpp:260
+#, c-format
+msgid "Cannot rename temporary file '%s' to footprint library file '%s'"
+msgstr ""
+"一時ファイル '%s' をフットプリントライブラリ '%s' へファイル名変更できませ"
+"ん。"
+
+#: pcbnew/kicad_plugin.cpp:280
+#, c-format
+msgid "Footprint library path '%s' does not exist"
+msgstr "フットプリントライブラリのパス '%s' は存在しません"
+
+#: pcbnew/kicad_plugin.cpp:327 pcbnew/legacy_plugin.cpp:4703
+#, c-format
+msgid "library '%s' has no footprint '%s' to delete"
+msgstr "ライブラリ '%s' には削除するフットプリント '%s' がありません"
+
+#: pcbnew/kicad_plugin.cpp:1234 pcbnew/legacy_plugin.cpp:98
+#, c-format
+msgid "unknown pad type: %d"
+msgstr "未知のパッド形状です: %d"
+
+#: pcbnew/kicad_plugin.cpp:1247 pcbnew/legacy_plugin.cpp:99
+#, c-format
+msgid "unknown pad attribute: %d"
+msgstr "未知のパッド属性です: %d"
+
+#: pcbnew/kicad_plugin.cpp:1429
+#, c-format
+msgid "unknown via type %d"
+msgstr "未知のビア形状です: %d"
+
+#: pcbnew/kicad_plugin.cpp:1560
+#, c-format
+msgid "unknown zone corner smoothing type %d"
+msgstr "未知のゾーンの角の平滑化タイプ %d "
+
+#: pcbnew/kicad_plugin.cpp:1846
+#, c-format
+msgid "Footprint file name '%s' is not valid."
+msgstr "不正なフットプリントファイル名です '%s' 。"
+
+#: pcbnew/kicad_plugin.cpp:1852
+#, c-format
+msgid "user does not have write permission to delete file '%s' "
+msgstr "現在のユーザは '%s' を削除するための書き込み権限がありません"
+
+#: pcbnew/kicad_plugin.cpp:1907
+#, c-format
+msgid "cannot overwrite library path '%s'"
+msgstr "ライブラリパス '%s' は上書きできません"
+
+#: pcbnew/layer_widget.cpp:427
+msgid ""
+"Left click to select, middle click for color change, right click for menu"
+msgstr "左クリックで選択, 中クリックで色の変更, 右クリックでメニュー"
+
+#: pcbnew/layer_widget.cpp:435
+msgid "Enable this for visibility"
+msgstr "表示する"
+
+#: pcbnew/layer_widget.cpp:462
+msgid "Middle click for color change"
+msgstr "中クリックで色の変更"
+
+#: pcbnew/legacy_netlist_reader.cpp:121
+msgid "Cannot parse time stamp in component section of netlist."
+msgstr ""
+"ネットリスト中のコンポーネント情報内のタイムスタンプを解釈することが出来ませ"
+"んでした。"
+
+#: pcbnew/legacy_netlist_reader.cpp:131
+msgid "Cannot parse footprint name in component section of netlist."
+msgstr ""
+"ネットリスト中のコンポーネント情報内のフットプリント名を解釈することが出来ま"
+"せんでした。"
+
+#: pcbnew/legacy_netlist_reader.cpp:145
+msgid "Cannot parse reference designator in component section of netlist."
+msgstr ""
+"ネットリスト中のコンポーネント情報内のリファレンス情報を解釈することが出来ま"
+"せんでした。"
+
+#: pcbnew/legacy_netlist_reader.cpp:155
+msgid "Cannot parse value in component section of netlist."
+msgstr ""
+"ネットリスト中のコンポーネント情報内の定数を解釈することが出来ませんでした。"
+
+#: pcbnew/legacy_netlist_reader.cpp:192
+msgid "Cannot parse pin name in component net section of netlist."
+msgstr ""
+"ネットリスト中のコンポーネント情報内のピン名を解釈することが出来ませんでし"
+"た。"
+
+#: pcbnew/legacy_netlist_reader.cpp:201
+msgid "Cannot parse net name in component net section of netlist."
+msgstr ""
+"ネットリスト中のコンポーネント情報内のネット名を解釈することが出来ませんでし"
+"た。"
+
+#: pcbnew/legacy_netlist_reader.cpp:249
+#, c-format
+msgid "Cannot find component '%s' in footprint filter section of netlist."
+msgstr ""
+"コンポーネント '%s' はネットリストのフットプリント情報から見つかりませんでし"
+"た。"
+
+#: pcbnew/legacy_plugin.cpp:96
+#, c-format
+msgid ""
+"File '%s' is format version: %d.\n"
+"I only support format version <= %d.\n"
+"Please upgrade Pcbnew to load this file."
+msgstr ""
+"ファイル '%s' のフォーマットバージョン: %d\n"
+"このプログラムでは、%d 以下のフォーマットバージョンしかサポートしていません。"
+"新しいバージョンの Pcbnew を取得し、ロードし直してください。"
+
+#: pcbnew/legacy_plugin.cpp:97
+#, c-format
+msgid "unknown graphic type: %d"
+msgstr "未知のグラフィックタイプ: %d"
+
+#: pcbnew/legacy_plugin.cpp:761
+#, c-format
+msgid "Unknown sheet type '%s' on line:%d"
+msgstr "未知のシートタイプ \"%s\" : %d 行目"
+
+#: pcbnew/legacy_plugin.cpp:1457
+#, c-format
+msgid "Unknown padshape '%c=0x%02x' on line: %d of module: '%s'"
+msgstr "未知のパッド形状 '%c=0x%02x' %d 行目 (モジュール '%s')"
+
+#: pcbnew/legacy_plugin.cpp:2506
+#, c-format
+msgid "duplicate NETCLASS name '%s'"
+msgstr "重複したネットクラス名 '%s'"
+
+#: pcbnew/legacy_plugin.cpp:3033 pcbnew/legacy_plugin.cpp:3070
+#, c-format
+msgid ""
+"invalid float number in file: '%s'\n"
+"line: %d, offset: %d"
+msgstr ""
+"不正な浮動小数点数値が見つかりました: '%s' \n"
+"%d行目, %d文字目"
+
+#: pcbnew/legacy_plugin.cpp:3042 pcbnew/legacy_plugin.cpp:3078
+#, c-format
+msgid ""
+"missing float number in file: '%s'\n"
+"line: %d, offset: %d"
+msgstr ""
+"不正な浮動小数点数値が見つかりました: '%s' \n"
+"行番号: %d, 位置: %d"
+
+#: pcbnew/legacy_plugin.cpp:3243
+#, c-format
+msgid "Unable to open file '%s'"
+msgstr "ファイル '%s' が開けません"
+
+#: pcbnew/legacy_plugin.cpp:4350
+#, c-format
+msgid "File '%s' is empty or is not a legacy library"
+msgstr "ファイル \"%s\" は空であるか、古い形式のライブラリです"
+
+#: pcbnew/legacy_plugin.cpp:4488
+#, c-format
+msgid "Legacy library file '%s' is read only"
+msgstr "レガシーライブラリファイル '%s' は読み込み専用です"
+
+#: pcbnew/legacy_plugin.cpp:4507
+#, c-format
+msgid "Unable to open or create legacy library file '%s'"
+msgstr ""
+"レガシーフォーマットのライブラリファイル '%s' を読み込み/保存できませんでした"
+
+#: pcbnew/legacy_plugin.cpp:4533
+#, c-format
+msgid "Unable to rename tempfile '%s' to library file '%s'"
+msgstr ""
+"一時ファイル '%s' をライブラリファイル '%s' へファイル名の変更ができませんで"
+"した"
+
+#: pcbnew/legacy_plugin.cpp:4716
+#, c-format
+msgid "library '%s' already exists, will not create a new"
+msgstr "ライブラリ '%s' は既に存在します。新規作成できません。"
+
+#: pcbnew/legacy_plugin.cpp:4745
+#, c-format
+msgid "library '%s' cannot be deleted"
+msgstr "ライブラリ '%s' が削除できませんでした"
+
+#: pcbnew/librairi.cpp:61
+#, c-format
+msgid "Library '%s' exists, OK to replace ?"
+msgstr "ライブラリ '%s' は既に存在します。置換してよろしいですか？"
+
+#: pcbnew/librairi.cpp:62
+msgid "Create New Library Folder (the .pretty folder is the library)"
+msgstr "新しくライブラリのフォルダ (.prettyフォルダはライブラリ) を作成"
+
+#: pcbnew/librairi.cpp:63
+#, c-format
+msgid "OK to delete module %s in library '%s'"
+msgstr "モジュール '%s' をライブラリ '%s' から削除します、宜しいですか？"
+
+#: pcbnew/librairi.cpp:64
+msgid "Import Footprint"
+msgstr "フットプリントのインポート"
+
+#: pcbnew/librairi.cpp:65
+#, c-format
+msgid "File '%s' not found"
+msgstr "ファイル '%s' が見つかりません"
+
+#: pcbnew/librairi.cpp:66
+msgid "Not a footprint file"
+msgstr "フットプリントファイルではありません"
+
+#: pcbnew/librairi.cpp:67
+#, c-format
+msgid "Unable to find or load footprint %s from lib path '%s'"
+msgstr ""
+"フットプリント %s をライブラリパス '%s' から見つけることが出来ませんでした"
+
+#: pcbnew/librairi.cpp:68
+#, c-format
+msgid "Unable to find or load footprint from path '%s'"
+msgstr "フットプリントを '%s' からロードすることができませんでした"
+
+#: pcbnew/librairi.cpp:69
+#, c-format
+msgid ""
+"The footprint library '%s' could not be found in any of the search paths."
+msgstr "フットプリントライブラリ <%s> はデフォルト検索パス内に存在しません。"
+
+#: pcbnew/librairi.cpp:70
+#, c-format
+msgid "Library '%s' is read only, not writable"
+msgstr "ライブラリ '%s' は読み込み専用です。"
+
+#: pcbnew/librairi.cpp:72
+msgid "Export Footprint"
+msgstr "フットプリントのエクスポート"
+
+#: pcbnew/librairi.cpp:73
+msgid "Save Footprint"
+msgstr "フットプリントの保存"
+
+#: pcbnew/librairi.cpp:74
+msgid "Enter footprint name:"
+msgstr "フットプリント名:"
+
+#: pcbnew/librairi.cpp:75
+#, c-format
+msgid "Footprint exported to file '%s'"
+msgstr "フットプリントを '%s' へ出力しました"
+
+#: pcbnew/librairi.cpp:76
+#, c-format
+msgid "Footprint %s deleted from library '%s'"
+msgstr "フットプリント %s をライブラリ '%s' から削除しました"
+
+#: pcbnew/librairi.cpp:77
+msgid "New Footprint"
+msgstr "新規フットプリント"
+
+#: pcbnew/librairi.cpp:79
+#, c-format
+msgid "Footprint %s already exists in library '%s'"
+msgstr "フットプリント %s は既にライブラリ %s 内に既に存在します。"
+
+#: pcbnew/librairi.cpp:80
+msgid "No footprint name defined."
+msgstr "フットプリント名が定義されていません。"
+
+#: pcbnew/librairi.cpp:84
+msgid ""
+"Writing/modifying legacy libraries (.mod files) is not allowed\n"
+"Please save the current library to the new .pretty format\n"
+"and update your footprint lib table\n"
+"to save your footprint (a .kicad_mod file) in the .pretty library folder"
+msgstr ""
+"旧式のライブラリ (.mod ファイル) を作成したり編集したりすることはできませ"
+"ん．\n"
+"現在のライブラリを新しい .pretty フォーマットで保存して，\n"
+"フットプリント lib テーブルを更新するために，\n"
+"フットプリント (.kicad_mod ファイル) を .pretty ライブラリフォルダの中で保存"
+"してください．"
+
+#: pcbnew/librairi.cpp:90
+msgid ""
+"Modifying legacy libraries (.mod files) is not allowed\n"
+"Please save the current library under the new .pretty format\n"
+"and update your footprint lib table\n"
+"before deleting a footprint"
+msgstr ""
+"旧式のライブラリ (.mod ファイル) を編集することはできません．\n"
+"フットプリントを削除する前に，\n"
+"現在のライブラリを新しい .pretty フォーマットで保存して，\n"
+"フットプリント lib テーブルを更新してください．"
+
+#: pcbnew/librairi.cpp:95
+msgid "Legacy foot print export files (*.emp)|*.emp"
+msgstr "レガシー フットプリント ファイル (*.emp)|*.emp"
+
+#: pcbnew/librairi.cpp:96
+msgid "GPcb foot print files (*)|*"
+msgstr "GPcb フットプリント ファイル (*)|*"
+
+#: pcbnew/librairi.cpp:521
+msgid "No footprints to archive!"
+msgstr "アーカイブにフットプリントがありません！"
+
+#: pcbnew/librairi.cpp:622
+#, c-format
+msgid ""
+"Error:\n"
+"one of invalid chars '%s' found\n"
+"in '%s'"
+msgstr ""
+"エラー: \n"
+"不正な文字 '%s' が見つかりました。\n"
+"('%s')"
+
+#: pcbnew/librairi.cpp:683
+#, c-format
+msgid "Component [%s] replaced in '%s'"
+msgstr "コンポーネント [%s] を <%s> に置き換えました"
+
+#: pcbnew/librairi.cpp:684
+#, c-format
+msgid "Component [%s] added in  '%s'"
+msgstr "コンポーネント [%s] を <%s> に追加しました"
+
+#: pcbnew/loadcmp.cpp:175
+msgid "Load Footprint"
+msgstr "フットプリントの読み込み"
+
+#: pcbnew/loadcmp.cpp:386
+#, c-format
+msgid ""
+"No footprints could be read from library file(s):\n"
+"\n"
+"%s\n"
+"in any of the library search paths.  Verify your system is configured "
+"properly so the footprint libraries can be found."
+msgstr ""
+"ライブラリファイル中からフットプリントが見つかりませんでした：\n"
+"\n"
+"%s \n"
+"ライブラリの検索パス．フットプリントライブラリのパスがシステムで正しく設定さ"
+"れていることを確認してください．"
+
+#: pcbnew/loadcmp.cpp:439
+#, c-format
+msgid "Footprints [%d items]"
+msgstr "フットプリント一覧 [%d のアイテム]"
+
+#: pcbnew/loadcmp.cpp:456
+msgid "No footprint found."
+msgstr "フットプリントが見つかりません。"
+
+#: pcbnew/loadcmp.cpp:480
+msgid ""
+"\n"
+"Key words: "
+msgstr ""
+"\n"
+"キーワード:"
+
+#: pcbnew/loadcmp.cpp:496
+#, c-format
+msgid "Modules [%u items]"
+msgstr ""
+
+#: pcbnew/loadcmp.cpp:500
+msgid "Module"
+msgstr "モジュール"
+
+#: pcbnew/loadcmp.cpp:560
+#, c-format
+msgid "Footprint '%s' saved"
+msgstr "フットプリント '%s' を保存しました"
+
+#: pcbnew/loadcmp.cpp:574
+#, c-format
+msgid "Footprint library '%s' saved as '%s'."
+msgstr "フットプリントライブラリ '%s' を '%s' へ保存しました。"
+
+#: pcbnew/menubar_modedit.cpp:67
+msgid "Set Acti&ve Library"
+msgstr "アクティブなライブラリの設定(&V)"
+
+#: pcbnew/menubar_modedit.cpp:68 pcbnew/tool_modedit.cpp:55
+msgid "Select active library"
+msgstr "アクティブなライブラリを選択してください"
+
+#: pcbnew/menubar_modedit.cpp:74
+msgid "&New Footprint"
+msgstr "新規フットプリント(&N)"
+
+#: pcbnew/menubar_modedit.cpp:74
+msgid "Create new footprint"
+msgstr "新規フットプリントを作成"
+
+#: pcbnew/menubar_modedit.cpp:82
+msgid "&Import Footprint From File"
+msgstr "ファイルからフットプリントのインポート(&I)"
+
+#: pcbnew/menubar_modedit.cpp:83
+msgid "Import footprint from an existing file"
+msgstr "既存のファイルからフットプリントをインポート"
+
+#: pcbnew/menubar_modedit.cpp:88
+msgid "Load Footprint From Current Li&brary"
+msgstr "現在のライブラリからフットプリントを読み込み(&B)"
+
+#: pcbnew/menubar_modedit.cpp:89
+msgid "Open a footprint from library"
+msgstr "ライブラリからフットプリントを開く"
+
+#: pcbnew/menubar_modedit.cpp:94
+msgid "Load Footprint From &Current Board"
+msgstr "現在のボードからフットプリントを読み込む(&C)"
+
+#: pcbnew/menubar_modedit.cpp:95
+msgid "Load a footprint from the current board"
+msgstr "現在のボードからフットプリントを読み込む"
+
+#: pcbnew/menubar_modedit.cpp:100
+msgid "&Load Footprint"
+msgstr "フットプリントの読み出し(&L)"
+
+#: pcbnew/menubar_modedit.cpp:101
+msgid "Load footprint"
+msgstr "フットプリントの読み出し"
+
+#: pcbnew/menubar_modedit.cpp:107
+msgid "Save &Current Library As..."
+msgstr "現在のライブラリを名前をつけて保存(&C)"
+
+#: pcbnew/menubar_modedit.cpp:108
+msgid "Save entire current library under a new name."
+msgstr "現在のライブラリ全体を新規保存"
+
+#: pcbnew/menubar_modedit.cpp:112
+msgid "&Save Footprint in Active Library"
+msgstr "アクティブなライブラリにフットプリントを保存(&S)"
+
+#: pcbnew/menubar_modedit.cpp:116 pcbnew/tool_modedit.cpp:58
+msgid "Save footprint in active library"
+msgstr "アクティブなライブラリへフットプリントを保存"
+
+#: pcbnew/menubar_modedit.cpp:121
+msgid "S&ave Footprint in New Library"
+msgstr "フットプリントを新規ライブラリへ保存(&A)"
+
+#: pcbnew/menubar_modedit.cpp:122
+msgid "Create a new library and save current module into it"
+msgstr "新規ライブラリを作成して現在のモジュールを保存"
+
+#: pcbnew/menubar_modedit.cpp:127
+msgid "&Export Footprint"
+msgstr "フットプリントのエクスポート(&E)"
+
+#: pcbnew/menubar_modedit.cpp:128
+msgid "Save currently loaded footprint into file"
+msgstr "現在ロードされているフットプリントをファイルに保存"
+
+#: pcbnew/menubar_modedit.cpp:133
+msgid "&Import DXF File"
+msgstr "DXFファイルのインポート(&I)"
+
+#: pcbnew/menubar_modedit.cpp:134 pcbnew/menubar_pcbframe.cpp:196
+msgid "Import a 2D Drawing DXF file to Pcbnew on the Drawings layer"
+msgstr "2D図面を Pcbnew の図面描画レイヤ上へインポートする"
+
+#: pcbnew/menubar_modedit.cpp:142
+msgid "Print current footprint"
+msgstr "現在のフットプリントを印刷"
+
+#: pcbnew/menubar_modedit.cpp:151
+msgid "Close footprint editor"
+msgstr "フットプリントエディタを閉じる"
+
+#: pcbnew/menubar_modedit.cpp:160
+msgid "Undo last action"
+msgstr "一つ前の編集を元に戻す"
+
+#: pcbnew/menubar_modedit.cpp:166
+msgid "Redo last action"
+msgstr "一つ前のコマンドをやり直し"
+
+#: pcbnew/menubar_modedit.cpp:171
+msgid "Delete objects with eraser"
+msgstr "消しゴムでオブジェクトを削除"
+
+#: pcbnew/menubar_modedit.cpp:179
+msgid "Edit &Properties"
+msgstr "プロパティ(&P)"
+
+#: pcbnew/menubar_modedit.cpp:180
+msgid "Edit footprint properties"
+msgstr "フットプリント プロパティの編集"
+
+#: pcbnew/menubar_modedit.cpp:188
+msgid "&User Grid Size"
+msgstr "ユーザ グリッドのサイズ(&U)"
+
+#: pcbnew/menubar_modedit.cpp:188
+msgid "Adjust user grid"
+msgstr "ユーザ グリッドに合わせる"
+
+#: pcbnew/menubar_modedit.cpp:193
+msgid "&Size and Width"
+msgstr "サイズと幅(&S)"
+
+#: pcbnew/menubar_modedit.cpp:194
+msgid "Adjust width for texts and drawings"
+msgstr "テキストと図形の幅をアジャスト"
+
+#: pcbnew/menubar_modedit.cpp:199
+msgid "&Pad Setting"
+msgstr "パッドの設定(&P)"
+
+#: pcbnew/menubar_modedit.cpp:199
+msgid "Edit settings for new pads"
+msgstr "新規パッドの設定を編集"
+
+#: pcbnew/menubar_modedit.cpp:236 pcbnew/menubar_pcbframe.cpp:347
+msgid "&3D Viewer"
+msgstr "3Dビューア(&3)"
+
+#: pcbnew/menubar_modedit.cpp:243 pcbnew/menubar_pcbframe.cpp:358
+msgid "&Switch canvas to default"
+msgstr "キャンバスを標準へ切り替え(&S)"
+
+#: pcbnew/menubar_modedit.cpp:247 pcbnew/menubar_pcbframe.cpp:362
+msgid "Switch the canvas implementation to default"
+msgstr "描画ライブラリを標準へ切り替え"
+
+#: pcbnew/menubar_modedit.cpp:250 pcbnew/menubar_pcbframe.cpp:365
+msgid "Switch canvas to Open&GL"
+msgstr "描画キャンバスを OpenGL(3D) へ切替(&G)"
+
+#: pcbnew/menubar_modedit.cpp:254 pcbnew/menubar_pcbframe.cpp:369
+msgid "Switch the canvas implementation to OpenGL"
+msgstr "描画キャンバスをOpenGLへ切り替え"
+
+#: pcbnew/menubar_modedit.cpp:257 pcbnew/menubar_pcbframe.cpp:372
+msgid "Switch canvas to &Cairo"
+msgstr "描画キャンバスを Cairo(2D) へ切替(&C)"
+
+#: pcbnew/menubar_modedit.cpp:261 pcbnew/menubar_pcbframe.cpp:376
+msgid "Switch the canvas implementation to Cairo"
+msgstr "描画キャンバスをCairoへ切り替え"
+
+#: pcbnew/menubar_modedit.cpp:269
+msgid "&Pad"
+msgstr "パッド(&P)"
+
+#: pcbnew/menubar_modedit.cpp:269 pcbnew/modedit.cpp:965
+msgid "Add pad"
+msgstr "パッドの追加"
+
+#: pcbnew/menubar_modedit.cpp:282 pcbnew/menubar_pcbframe.cpp:411
+#: pcbnew/tool_modedit.cpp:170 pcbnew/tool_pcb.cpp:454
+msgid "Add graphic line or polygon"
+msgstr "図形ライン (またはポリゴン) を入力"
+
+#: pcbnew/menubar_modedit.cpp:292
+msgid "&Text"
+msgstr "テキスト(&T)"
+
+#: pcbnew/menubar_modedit.cpp:292
+msgid "Add graphic text"
+msgstr "図形テキスト入力"
+
+#: pcbnew/menubar_modedit.cpp:299
+msgid "A&nchor"
+msgstr "アンカー(&N)"
+
+#: pcbnew/menubar_modedit.cpp:300
+msgid "Place footprint reference anchor"
+msgstr "フットプリントのアンカー (基準点) を配置"
+
+#: pcbnew/menubar_modedit.cpp:308 pcbnew/menubar_pcbframe.cpp:483
+msgid "&Footprint Libraries Wizard"
+msgstr "フットプリント ライブラリ ウィザード(&F)"
+
+#: pcbnew/menubar_modedit.cpp:308 pcbnew/menubar_pcbframe.cpp:483
+msgid "Add footprint libraries with wizard"
+msgstr "ウィザード で フットプリント ライブラリ を追加"
+
+#: pcbnew/menubar_modedit.cpp:312 pcbnew/menubar_pcbframe.cpp:487
+msgid "Footprint Li&braries Manager"
+msgstr "フットプリント ライブラリの管理(&B)"
+
+#: pcbnew/menubar_modedit.cpp:324
+msgid "&Settings"
+msgstr "設定(&S)"
+
+#: pcbnew/menubar_modedit.cpp:324
+msgid "Select default parameters values in Footprint Editor"
+msgstr "フットプリント エディタでのデフォルト値を選択"
+
+#: pcbnew/menubar_modedit.cpp:341 pcbnew/menubar_pcbframe.cpp:646
+msgid "Pcbnew &Manual"
+msgstr ""
+
+#: pcbnew/menubar_modedit.cpp:342 pcbnew/menubar_pcbframe.cpp:647
+msgid "Open the Pcbnew Manual"
+msgstr ""
+
+#: pcbnew/menubar_modedit.cpp:363
+msgid "Di&mensions"
+msgstr "寸法(&M)"
+
+#: pcbnew/menubar_pcbframe.cpp:68
+msgid "&New"
+msgstr "新規(&N)"
+
+#: pcbnew/menubar_pcbframe.cpp:69
+msgid "Clear current board and initialize a new one"
+msgstr "現在のボードをクリアし，新規ボードに初期化"
+
+#: pcbnew/menubar_pcbframe.cpp:72
+msgid "&Open"
+msgstr "開く(&O)"
+
+#: pcbnew/menubar_pcbframe.cpp:74
+msgid "Delete current board and load new board"
+msgstr "現在のボードを破棄し．新規ボードを読み込む"
+
+#: pcbnew/menubar_pcbframe.cpp:95
+msgid "Open a recent opened board"
+msgstr "最近開いたボードを開く"
+
+#: pcbnew/menubar_pcbframe.cpp:100
+msgid "&Append Board"
+msgstr "ボードを追加(&A)"
+
+#: pcbnew/menubar_pcbframe.cpp:101
+msgid ""
+"Append another Pcbnew board to the current loaded board. Available only when "
+"Pcbnew runs in stand alone mode"
+msgstr ""
+"現在読み込まれているボードに別の Pcbnew ボードを付け加えます。これは Pcbnew "
+"がスタンドアロンモードで起動している時のみ有効です。"
+
+#: pcbnew/menubar_pcbframe.cpp:111
+msgid "Save current board"
+msgstr "現在のボードを保存"
+
+#: pcbnew/menubar_pcbframe.cpp:121
+msgid "Sa&ve As..."
+msgstr "名前をつけて保存...(&V)"
+
+#: pcbnew/menubar_pcbframe.cpp:123
+msgid "Save the current board as..."
+msgstr "現在ボードを名前をつけて保存"
+
+#: pcbnew/menubar_pcbframe.cpp:130
+msgid "Sa&ve Copy As..."
+msgstr "名前をつけて保存...(&V)"
+
+#: pcbnew/menubar_pcbframe.cpp:132
+msgid "Save a copy of the current board as..."
+msgstr "現在のボードを名前をつけて保存"
+
+#: pcbnew/menubar_pcbframe.cpp:139
+msgid "Revert to Las&t"
+msgstr "リカバリバックアップより復帰(&T)"
+
+#: pcbnew/menubar_pcbframe.cpp:140
+msgid "Clear board and get previous backup version of board"
+msgstr "ボードをクリアし，一つ前に保存されたバージョンのボードを取得"
+
+#: pcbnew/menubar_pcbframe.cpp:144
+msgid "Resc&ue"
+msgstr "レスキュー(&U)"
+
+#: pcbnew/menubar_pcbframe.cpp:145
+msgid "Clear board and get last rescue file automatically saved by Pcbnew"
+msgstr "ボードをクリアし，直近のレスキューファイルを取得"
+
+#: pcbnew/menubar_pcbframe.cpp:152
+msgid "Footprint &Position (.pos) File"
+msgstr "フットプリント位置情報ファイル(.pos) (&P)"
+
+#: pcbnew/menubar_pcbframe.cpp:153
+msgid "Generate footprint position file for pick and place"
+msgstr "部品実装用のフットプリント座標ファイルを生成します"
+
+#: pcbnew/menubar_pcbframe.cpp:157
+msgid "&Drill (.drl) File"
+msgstr "ドリル ファイル(.drl) (&D)"
+
+#: pcbnew/menubar_pcbframe.cpp:158
+msgid "Generate excellon2 drill file"
+msgstr "excellon2 ドリル ファイルの生成"
+
+#: pcbnew/menubar_pcbframe.cpp:162
+msgid "&Footprint (.rpt) Report"
+msgstr "フットプリントレポート(.rpt) (&F)"
+
+#: pcbnew/menubar_pcbframe.cpp:163
+msgid "Create a report of all footprints on the current board"
+msgstr "現在のボード中の全てのフットプリントのレポートを作成"
+
+#: pcbnew/menubar_pcbframe.cpp:167
+msgid "IPC-D-356 Netlist File"
+msgstr "IPC-D-356形式ネットリスト ファイル"
+
+#: pcbnew/menubar_pcbframe.cpp:168
+msgid "Generate IPC-D-356 netlist file"
+msgstr "IPC-D-356形式ネットリストの生成"
+
+#: pcbnew/menubar_pcbframe.cpp:172
+msgid "&Component (.cmp) File"
+msgstr "コンポーネント ファイル(.cmp) (&C)"
+
+#: pcbnew/menubar_pcbframe.cpp:173
+msgid "(Re)create components file (*.cmp) for CvPcb"
+msgstr "CvPcb用のコンポーネント ファイル(*.cmp)を(再)作成"
+
+#: pcbnew/menubar_pcbframe.cpp:177
+msgid "&BOM File"
+msgstr "BOM ファイル(&B)"
+
+#: pcbnew/menubar_pcbframe.cpp:178
+msgid "Create a bill of materials from schematic"
+msgstr "回路図からBom(部品表)を作成する"
+
+#: pcbnew/menubar_pcbframe.cpp:182
+msgid "&Fabrication Outputs"
+msgstr "製造用各種ファイル出力(&F)"
+
+#: pcbnew/menubar_pcbframe.cpp:183
+msgid "Generate files for fabrication"
+msgstr "製造用ファイルの生成"
+
+#: pcbnew/menubar_pcbframe.cpp:190
+msgid "&Specctra Session"
+msgstr "Specctra セッション(&S)"
+
+#: pcbnew/menubar_pcbframe.cpp:191
+msgid "Import a routed \"Specctra Session\" (*.ses) file"
+msgstr "配線済みのSpecctra セッション ファイル (*.ses) のインポート"
+
+#: pcbnew/menubar_pcbframe.cpp:195
+msgid "&DXF File"
+msgstr "DXFファイル(&D)"
+
+#: pcbnew/menubar_pcbframe.cpp:200
+msgid "&Import"
+msgstr "インポート(&I)"
+
+#: pcbnew/menubar_pcbframe.cpp:201
+msgid "Import files"
+msgstr "ファイルのインポート"
+
+#: pcbnew/menubar_pcbframe.cpp:208
+msgid "&Specctra DSN"
+msgstr "Specctra DSN ファイル(&S)"
+
+#: pcbnew/menubar_pcbframe.cpp:209
+msgid "Export the current board to a \"Specctra DSN\" file"
+msgstr "現在のボードを \"Specctra DSN\" ファイルへエクスポート"
+
+#: pcbnew/menubar_pcbframe.cpp:213
+msgid "&GenCAD"
+msgstr "GenCAD(&G)"
+
+#: pcbnew/menubar_pcbframe.cpp:213
+msgid "Export GenCAD format"
+msgstr "GenCADフォーマット"
+
+#: pcbnew/menubar_pcbframe.cpp:217
+msgid "&VRML"
+msgstr "VRML(&V)"
+
+#: pcbnew/menubar_pcbframe.cpp:218
+msgid "Export a VRML board representation"
+msgstr "VRMLボード"
+
+#: pcbnew/menubar_pcbframe.cpp:222
+msgid "I&DFv3 Export"
+msgstr "IDFv3 エクスポート(&D)"
+
+#: pcbnew/menubar_pcbframe.cpp:222
+msgid "IDFv3 board and component export"
+msgstr "IDFv3 ボードフォーマットのエクスポート"
+
+#: pcbnew/menubar_pcbframe.cpp:226
+msgid "E&xport"
+msgstr "エクスポート(&X)"
+
+#: pcbnew/menubar_pcbframe.cpp:227
+msgid "Export board"
+msgstr "ボードのエクスポート"
+
+#: pcbnew/menubar_pcbframe.cpp:232
+msgid "Page s&ettings"
+msgstr "ページ設定(&E)"
+
+#: pcbnew/menubar_pcbframe.cpp:233 pcbnew/tool_pcb.cpp:230
+msgid "Page settings for paper size and texts"
+msgstr "ページ設定 (用紙サイズ 及び テキスト)"
+
+#: pcbnew/menubar_pcbframe.cpp:237 pcbnew/tool_pcb.cpp:249
+msgid "Print board"
+msgstr "ボードの印刷"
+
+#: pcbnew/menubar_pcbframe.cpp:241
+msgid "Export SV&G"
+msgstr "SVGファイルのエクスポート(&G)"
+
+#: pcbnew/menubar_pcbframe.cpp:242
+msgid "Export a board file in Scalable Vector Graphics format"
+msgstr "SVG(Scalable Vector Graphics) 形式でエクスポート"
+
+#: pcbnew/menubar_pcbframe.cpp:246
+msgid "P&lot"
+msgstr "プロット(&L)"
+
+#: pcbnew/menubar_pcbframe.cpp:247
+msgid "Plot board in HPGL, PostScript or Gerber RS-274X format)"
+msgstr "ボードをHPGLかPostScript, ガーバー(RS-274Xフォーマット)で出図"
+
+#: pcbnew/menubar_pcbframe.cpp:256
+msgid "&Archive New Footprints"
+msgstr "フットプリントを新規にアーカイブ(&A)"
+
+#: pcbnew/menubar_pcbframe.cpp:257
+msgid ""
+"Archive new footprints only in a library (keep other footprints in this lib)"
+msgstr ""
+"(このライブラリ中の他のフットプリントを維持したまま) ライブラリ中の新規フット"
+"プリントをアーカイブ"
+
+#: pcbnew/menubar_pcbframe.cpp:261
+msgid "&Create Footprint Archive"
+msgstr "フットプリント アーカイブの作成(&C)"
+
+#: pcbnew/menubar_pcbframe.cpp:262
+msgid "Archive all footprints in a library (old library will be deleted)"
+msgstr ""
+"ライブラリ中の全てのフットプリントをアーカイブ (古いライブラリは削除されます)"
+
+#: pcbnew/menubar_pcbframe.cpp:267
+msgid "Arc&hive Footprints"
+msgstr "フットプリントのアーカイブ(&H)"
+
+#: pcbnew/menubar_pcbframe.cpp:268
+msgid "Archive or add footprints in a library file"
+msgstr "ライブラリ ファイル中のフットプリントをアーカイブか追加"
+
+#: pcbnew/menubar_pcbframe.cpp:272
+msgid "Close Pcbnew"
+msgstr "Pcbnew の終了"
+
+#: pcbnew/menubar_pcbframe.cpp:284 pcbnew/tool_modedit.cpp:188
+#: pcbnew/tool_pcb.cpp:474
+msgid "Delete items"
+msgstr "アイテム削除"
+
+#: pcbnew/menubar_pcbframe.cpp:295
+msgid "&Global Deletions"
+msgstr "広域削除(&G)"
+
+#: pcbnew/menubar_pcbframe.cpp:296
+msgid "Delete tracks, footprints, texts... on board"
+msgstr "ボードの配線・フットプリント・テキストなどを削除"
+
+#: pcbnew/menubar_pcbframe.cpp:300
+msgid "&Cleanup Tracks and Vias"
+msgstr "配線とビアのクリーンアップ(&C)"
+
+#: pcbnew/menubar_pcbframe.cpp:301
+msgid ""
+"Clean stubs, vias, delete break points, or unconnected tracks to pads and "
+"vias"
+msgstr ""
+
+#: pcbnew/menubar_pcbframe.cpp:305
+msgid "&Swap Layers"
+msgstr "レイヤの入替え(&S)"
+
+#: pcbnew/menubar_pcbframe.cpp:306
+msgid "Swap tracks on copper layers or drawings on other layers"
+msgstr "配線層や他の図形層をスワップします"
+
+#: pcbnew/menubar_pcbframe.cpp:310
+msgid "Set Footp&rint Field Sizes"
+msgstr ""
+
+#: pcbnew/menubar_pcbframe.cpp:311
+msgid "Set text size and width of footprint fields."
+msgstr ""
+
+#: pcbnew/menubar_pcbframe.cpp:349
+msgid "Show board in 3D viewer"
+msgstr "ボードを3Dビューアで表示"
+
+#: pcbnew/menubar_pcbframe.cpp:353
+msgid "&List Nets"
+msgstr "ネットの一覧を表示(&L)"
+
+#: pcbnew/menubar_pcbframe.cpp:353
+msgid "View a list of nets with names and id's"
+msgstr "名前とIDでネットのリストを見る"
+
+#: pcbnew/menubar_pcbframe.cpp:382
+msgid "&Footprint"
+msgstr "フットプリント(&F)"
+
+#: pcbnew/menubar_pcbframe.cpp:385 pcbnew/tool_pcb.cpp:440
+msgid "Add footprints"
+msgstr "フットプリントの追加"
+
+#: pcbnew/menubar_pcbframe.cpp:387
+msgid "&Track"
+msgstr "配線(&T)"
+
+#: pcbnew/menubar_pcbframe.cpp:390 pcbnew/tool_pcb.cpp:443
+msgid "Add tracks and vias"
+msgstr "配線とビアの追加"
+
+#: pcbnew/menubar_pcbframe.cpp:393
+msgid "&Zone"
+msgstr "塗りつぶしゾーン(&Z)"
+
+#: pcbnew/menubar_pcbframe.cpp:393 pcbnew/tool_pcb.cpp:446
+msgid "Add filled zones"
+msgstr "塗りつぶしゾーンの追加"
+
+#: pcbnew/menubar_pcbframe.cpp:396
+msgid "&Keepout Area"
+msgstr "キープアウト(禁止)エリア(&K)"
+
+#: pcbnew/menubar_pcbframe.cpp:396 pcbnew/tool_pcb.cpp:450
+msgid "Add keepout areas"
+msgstr "キープアウト(禁止)エリアの追加"
+
+#: pcbnew/menubar_pcbframe.cpp:399
+msgid "Te&xt"
+msgstr "テキスト(&x)"
+
+#: pcbnew/menubar_pcbframe.cpp:399 pcbnew/tool_pcb.cpp:463
+msgid "Add text on copper layers or graphic text"
+msgstr "導体層または図形層にテキスト入力"
+
+#: pcbnew/menubar_pcbframe.cpp:417
+msgid "&Dimension"
+msgstr "寸法線(&D)"
+
+#: pcbnew/menubar_pcbframe.cpp:421
+msgid "La&yer alignment target"
+msgstr "層合わせターゲット(&Y)"
+
+#: pcbnew/menubar_pcbframe.cpp:427
+msgid "Drill and &Place Offset"
+msgstr "ドリルと配置のオフセット(&F)"
+
+#: pcbnew/menubar_pcbframe.cpp:428 pcbnew/tool_pcb.cpp:479
+msgid "Place the origin point for drill and place files"
+msgstr "ドリルファイル、実装ファイル用の原点を設定"
+
+#: pcbnew/menubar_pcbframe.cpp:432
+msgid "&Grid Origin"
+msgstr "グリッド原点(&G)"
+
+#: pcbnew/menubar_pcbframe.cpp:433 pcbnew/tool_modedit.cpp:192
+#: pcbnew/tool_pcb.cpp:484
+msgid "Set the origin point for the grid"
+msgstr "グリッドの原点をセット"
+
+#: pcbnew/menubar_pcbframe.cpp:439
+msgid "&Single Track"
+msgstr "単線(シングル) (&S)"
+
+#: pcbnew/menubar_pcbframe.cpp:440
+msgid "Interactively route a single track"
+msgstr "単線(シングル)のインタラクティブ配線"
+
+#: pcbnew/menubar_pcbframe.cpp:444
+msgid "&Differential Pair"
+msgstr "差動ペア(&D)"
+
+#: pcbnew/menubar_pcbframe.cpp:445
+msgid "Interactively route a differential pair"
+msgstr "差動ペアのインタラクティブ配線"
+
+#: pcbnew/menubar_pcbframe.cpp:451
+msgid "&Tune Track Length"
+msgstr "配線長の調整(&T)"
+
+#: pcbnew/menubar_pcbframe.cpp:452 pcbnew/tools/common_actions.cpp:530
+msgid "Tune length of a single track"
+msgstr "単線の配線長を調整"
+
+#: pcbnew/menubar_pcbframe.cpp:456
+msgid "Tune Differential Pair &Length"
+msgstr "差動ペアの配線長の調整(&L)"
+
+#: pcbnew/menubar_pcbframe.cpp:457 pcbnew/tools/common_actions.cpp:534
+msgid "Tune length of a differential pair"
+msgstr "差動ペア配線の配線長を調整"
+
+#: pcbnew/menubar_pcbframe.cpp:461
+msgid "Tune Differential Pair &Skew/Phase"
+msgstr "差動ペアの遅延/位相の調整(&S)"
+
+#: pcbnew/menubar_pcbframe.cpp:462
+msgid "Tune skew/phase of a differential pair"
+msgstr "差動ペア配線の遅延(スキュー)/位相を調整"
+
+#: pcbnew/menubar_pcbframe.cpp:499
+msgid "&3D Shapes Libraries Downloader"
+msgstr "&3D シェイプ ライブラリ ダウンローダ"
+
+#: pcbnew/menubar_pcbframe.cpp:500
+msgid "Download from Github the 3D shape libraries with wizard"
+msgstr "ウィザードで 3D シェイプ ライブラリを Github からダウンロード"
+
+#: pcbnew/menubar_pcbframe.cpp:507
+msgid "Hide La&yers Manager"
+msgstr "レイヤマネージャを非表示(&Y)"
+
+#: pcbnew/menubar_pcbframe.cpp:507
+msgid "Show La&yers Manager"
+msgstr "レイヤマネージャを表示(&Y)"
+
+#: pcbnew/menubar_pcbframe.cpp:513
+msgid "Hide Microwa&ve Toolbar"
+msgstr "高周波支援設計のツールバーの表示/非表示(&v)"
+
+#: pcbnew/menubar_pcbframe.cpp:522
+msgid "&General"
+msgstr "一般設定(&G)"
+
+#: pcbnew/menubar_pcbframe.cpp:522
+msgid "Select general options for Pcbnew"
+msgstr "Pcbnew の一般オプションを選択"
+
+#: pcbnew/menubar_pcbframe.cpp:527
+msgid "&Display"
+msgstr "表示設定(&D)"
+
+#: pcbnew/menubar_pcbframe.cpp:528
+msgid "Select how items (pads, tracks texts ... ) are displayed"
+msgstr "表示するアイテム (パッド・配線・テキストなど) を選択"
+
+#: pcbnew/menubar_pcbframe.cpp:532
+msgid "&Interactive Routing"
+msgstr "インタラクティブルーター(&I)"
+
+#: pcbnew/menubar_pcbframe.cpp:533
+msgid "Configure Interactive Routing."
+msgstr "インタラクティブルーターの設定"
+
+#: pcbnew/menubar_pcbframe.cpp:540
+msgid "G&rid"
+msgstr "グリッド(&R)"
+
+#: pcbnew/menubar_pcbframe.cpp:540
+msgid "Adjust user grid dimensions"
+msgstr "ユーザ グリッドのディメンジョンを合わせる"
+
+#: pcbnew/menubar_pcbframe.cpp:544
+msgid "Te&xts and Drawings"
+msgstr "テキストと図形(&X)"
+
+#: pcbnew/menubar_pcbframe.cpp:545
+msgid "Adjust dimensions for texts and drawings"
+msgstr "テキストと図形の寸法を調整"
+
+#: pcbnew/menubar_pcbframe.cpp:549
+msgid "&Pads"
+msgstr "パッド(&P)"
+
+#: pcbnew/menubar_pcbframe.cpp:549
+msgid "Adjust default pad characteristics"
+msgstr "デフォルトのパッドキャラクタを設定"
+
+#: pcbnew/menubar_pcbframe.cpp:553
+msgid "Pads &Mask Clearance"
+msgstr "パッド-マスク (レジスト) のクリアランス(&M)"
+
+#: pcbnew/menubar_pcbframe.cpp:554
+msgid "Adjust the global clearance between pads and the solder resist mask"
+msgstr "パッドに対するレジストのグローバルクリアランス(逃げ寸法)を調整します。"
+
+#: pcbnew/menubar_pcbframe.cpp:558
+msgid "&Differential Pairs"
+msgstr "差動ペア(&D)"
+
+#: pcbnew/menubar_pcbframe.cpp:559
+msgid "Define the global gap/width for differential pairs."
+msgstr "差動ペア配線のギャップ/幅のグローバル設定"
+
+#: pcbnew/menubar_pcbframe.cpp:564
+msgid "Save dimension preferences"
+msgstr "寸法設定の保存"
+
+#: pcbnew/menubar_pcbframe.cpp:577
+msgid "&Save macros"
+msgstr "マクロの保存(&S)"
+
+#: pcbnew/menubar_pcbframe.cpp:578
+msgid "Save macros to file"
+msgstr "マクロをファイルに保存"
+
+#: pcbnew/menubar_pcbframe.cpp:582
+msgid "&Read macros"
+msgstr "マクロ読み込み(&R)"
+
+#: pcbnew/menubar_pcbframe.cpp:583
+msgid "Read macros from file"
+msgstr "マクロをファイルから読み込む"
+
+#: pcbnew/menubar_pcbframe.cpp:587
+msgid "Ma&cros"
+msgstr "マクロ(&C)"
+
+#: pcbnew/menubar_pcbframe.cpp:588
+msgid "Macros save/read operations"
+msgstr "マクロの保存/読み込み"
+
+#: pcbnew/menubar_pcbframe.cpp:607
+msgid "&Netlist"
+msgstr "ネットリスト(&N)"
+
+#: pcbnew/menubar_pcbframe.cpp:608
+msgid "Read the netlist and update board connectivity"
+msgstr "ネットリストを読み込み、ボードの結線情報を更新する"
+
+#: pcbnew/menubar_pcbframe.cpp:612
+msgid "&Layer Pair"
+msgstr "レイヤペア(&L)"
+
+#: pcbnew/menubar_pcbframe.cpp:612
+msgid "Change the active layer pair"
+msgstr "アクティブなレイヤペアを変更"
+
+#: pcbnew/menubar_pcbframe.cpp:616
+msgid "&DRC"
+msgstr "デザインルール チェック (&D)"
+
+#: pcbnew/menubar_pcbframe.cpp:617 pcbnew/tool_pcb.cpp:275
+msgid "Perform design rules check"
+msgstr "デザインルール チェックの実行"
+
+#: pcbnew/menubar_pcbframe.cpp:620
+msgid "&FreeRoute"
+msgstr "&FreeRoute"
+
+#: pcbnew/menubar_pcbframe.cpp:621
+msgid "Fast access to the Web Based FreeROUTE advanced router"
+msgstr "上級なルータであるウェブベースの FreeROUTE へのクイックアクセス"
+
+#: pcbnew/menubar_pcbframe.cpp:626
+msgid "&Scripting Console"
+msgstr "スクリプト コンソール(&S)"
+
+#: pcbnew/menubar_pcbframe.cpp:627 pcbnew/tool_pcb.cpp:314
+msgid "Show/Hide the Python Scripting console"
+msgstr "Python スクリプト コンソールの表示/非表示"
+
+#: pcbnew/menubar_pcbframe.cpp:634 pcbnew/menubar_pcbframe.cpp:670
+msgid "&Design Rules"
+msgstr "デザインルール(&D)"
+
+#: pcbnew/menubar_pcbframe.cpp:635
+msgid "Open the design rules editor"
+msgstr "デザインルール エディタを開く"
+
+#: pcbnew/menubar_pcbframe.cpp:638
+msgid "&Layers Setup"
+msgstr "レイヤのセットアップ(&L)"
+
+#: pcbnew/menubar_pcbframe.cpp:638
+msgid "Enable and set layer properties"
+msgstr "レイヤのプロパティを設定して有効化"
+
+#: pcbnew/menubar_pcbframe.cpp:666
+msgid "Ro&ute"
+msgstr "配線(&u)"
+
+#: pcbnew/menubar_pcbframe.cpp:668
+msgid "D&imensions"
+msgstr "寸法(&I)"
+
+#: pcbnew/modedit.cpp:185
+msgid ""
+"Current footprint changes will be lost and this operation cannot be undone. "
+"Continue?"
+msgstr ""
+"現在のフットプリントの変更は破棄されます。 この操作はやり直しできません。続け"
+"ますか？"
+
+#: pcbnew/modedit.cpp:400
+msgid "No board currently edited"
+msgstr "編集中のボードがありません"
+
+#: pcbnew/modedit.cpp:425
+msgid "Unable to find the footprint source on the main board"
+msgstr "メインボードからフットプリントのソースを見つけられません"
+
+#: pcbnew/modedit.cpp:426
+msgid ""
+"\n"
+"Cannot update the footprint"
+msgstr ""
+"\n"
+"フットプリントを更新できません"
+
+#: pcbnew/modedit.cpp:435
+msgid "A footprint source was found on the main board"
+msgstr "メインボード上からフットプリントのソースを見つけました"
+
+#: pcbnew/modedit.cpp:436
+msgid ""
+"\n"
+"Cannot insert this footprint"
+msgstr ""
+"\n"
+"このフットプリントを挿入できません"
+
+#: pcbnew/modedit.cpp:955
+msgid "Place anchor"
+msgstr "アンカーの配置"
+
+#: pcbnew/modedit.cpp:959
+msgid "Set grid origin"
+msgstr "グリッド原点のセット"
+
+#: pcbnew/modedit.cpp:969 pcbnew/tool_modedit.cpp:138
+msgid "Pad settings"
+msgstr "パッドの設定"
+
+#: pcbnew/modedit_onclick.cpp:252
+msgid "Copy Block (shift + drag mouse)"
+msgstr "ブロックのコピー(Shift + マウスドラッグ)"
+
+#: pcbnew/modedit_onclick.cpp:255
+msgid "Mirror Block (alt + drag mouse)"
+msgstr "ブロックのミラー(alt + マウスドラッグ)"
+
+#: pcbnew/modedit_onclick.cpp:258
+msgid "Rotate Block (ctrl + drag mouse)"
+msgstr "ブロックの回転(ctrl + マウスドラッグ)"
+
+#: pcbnew/modedit_onclick.cpp:261
+msgid "Delete Block (shift+ctrl + drag mouse)"
+msgstr "ブロックの削除(shift + ctrl + マウスドラッグ)"
+
+#: pcbnew/modedit_onclick.cpp:264
+msgid "Move Block Exactly"
+msgstr "数値を指定してブロックを移動"
+
+#: pcbnew/modedit_onclick.cpp:294
+msgid "Move Exactly"
+msgstr "数値を指定して移動"
+
+#: pcbnew/modedit_onclick.cpp:297
+msgid "Edit Footprint"
+msgstr "フットプリントの編集"
+
+#: pcbnew/modedit_onclick.cpp:300
+msgid "Transform Footprint"
+msgstr "フットプリントの変形"
+
+#: pcbnew/modedit_onclick.cpp:308 pcbnew/onrightclick.cpp:943
+msgid "Move Pad"
+msgstr "パッドの移動"
+
+#: pcbnew/modedit_onclick.cpp:312 pcbnew/onrightclick.cpp:948
+msgid "Edit Pad"
+msgstr "パッドの編集"
+
+#: pcbnew/modedit_onclick.cpp:315
+msgid "New Pad Settings"
+msgstr "パッド設定の更新"
+
+#: pcbnew/modedit_onclick.cpp:317
+msgid "Export Pad Settings"
+msgstr "パッド設定のエクスポート"
+
+#: pcbnew/modedit_onclick.cpp:318
+msgid "Delete Pad"
+msgstr "パッド削除"
+
+#: pcbnew/modedit_onclick.cpp:321
+msgid "Duplicate Pad"
+msgstr "パッドの複製"
+
+#: pcbnew/modedit_onclick.cpp:324
+msgid "Move Pad Exactly"
+msgstr "数値を指定してパッドを移動"
+
+#: pcbnew/modedit_onclick.cpp:327
+msgid "Create Pad Array"
+msgstr "パッド配列の作成"
+
+#: pcbnew/modedit_onclick.cpp:335
+msgid "Global Pad Settings"
+msgstr "グローバルパッド設定"
+
+#: pcbnew/modedit_onclick.cpp:362
+msgid "Duplicate Text"
+msgstr "テキストの複製"
+
+#: pcbnew/modedit_onclick.cpp:367
+msgid "Create Text Array"
+msgstr "テキスト配列の作成"
+
+#: pcbnew/modedit_onclick.cpp:374 pcbnew/onrightclick.cpp:886
+msgid "Move Text Exactly"
+msgstr "数値を指定してテキストをコピー"
+
+#: pcbnew/modedit_onclick.cpp:396
+msgid "End edge"
+msgstr "エッジの終了"
+
+#: pcbnew/modedit_onclick.cpp:401
+msgid "Move Edge"
+msgstr "エッジの移動"
+
+#: pcbnew/modedit_onclick.cpp:405
+msgid "Duplicate Edge"
+msgstr "エッジの複製"
+
+#: pcbnew/modedit_onclick.cpp:408
+msgid "Move Edge Exactly"
+msgstr "数値を指定してエッジを移動"
+
+#: pcbnew/modedit_onclick.cpp:411
+msgid "Create Edge Array"
+msgstr "エッジ配列の作成"
+
+#: pcbnew/modedit_onclick.cpp:415
+msgid "Place edge"
+msgstr "エッジの配置"
+
+#: pcbnew/modedit_onclick.cpp:422
+msgid "Delete Edge"
+msgstr "エッジの削除"
+
+#: pcbnew/modedit_onclick.cpp:427
+msgid "Global Changes"
+msgstr "広域変更"
+
+#: pcbnew/modedit_onclick.cpp:429
+msgid "Change Body Items Width"
+msgstr "アイテムの幅を変更"
+
+#: pcbnew/modedit_onclick.cpp:431
+msgid "Change Body Items Layer"
+msgstr "アイテムのレイヤを変更"
+
+#: pcbnew/modedit_onclick.cpp:469
+msgid "Set Line Width"
+msgstr "線幅の設定"
+
+#: pcbnew/moduleframe.cpp:501
+msgid "Save the changes to the footprint before closing?"
+msgstr "フットプリントの変更を終了前に保存しますか？"
+
+#: pcbnew/moduleframe.cpp:522
+msgid "Library is not set, the footprint could not be saved."
+msgstr "ライブラリが選択されていないため，フットプリントを保存できません．"
+
+#: pcbnew/moduleframe.cpp:744
+msgid "Footprint Editor "
+msgstr "フットプリントエディタ"
+
+#: pcbnew/moduleframe.cpp:751
+msgid "(no active library)"
+msgstr "(アクティブなライブラリがありません)"
+
+#: pcbnew/moduleframe.cpp:760
+msgid "Footprint Editor (active library: "
+msgstr "フットプリントエディタ (アクティブなライブラリ:"
+
+#: pcbnew/moduleframe.cpp:859 pcbnew/pcbnew_config.cpp:138
+#, c-format
+msgid ""
+"Error occurred saving the global footprint library table:\n"
+"\n"
+"%s"
+msgstr ""
+"グローバルフットプリントライブラリの一覧の保存中にエラーが発生しました:\n"
+"\n"
+"%s"
+
+#: pcbnew/moduleframe.cpp:879 pcbnew/pcbnew_config.cpp:160
+#, c-format
+msgid ""
+"Error occurred saving project specific footprint library table:\n"
+"\n"
+"%s"
+msgstr ""
+"フットプリントライブラリの一覧の保存中にエラーが発生しました:\n"
+"\n"
+"%s"
+
+#: pcbnew/modules.cpp:66
+msgid "Search for footprint"
+msgstr "フットプリントの検索"
+
+#: pcbnew/modules.cpp:264
+#, c-format
+msgid "Delete Footprint %s (value %s) ?"
+msgstr "フットプリント %s (値 %s) を削除しますか？"
+
+#: pcbnew/modview_frame.cpp:120
+msgid "Footprint Library Browser"
+msgstr "フットプリント ライブラリ ブラウザ"
+
+#: pcbnew/modview_frame.cpp:448
+#, c-format
+msgid ""
+"Could not load footprint \"%s\" from library \"%s\".\n"
+"\n"
+"Error %s."
+msgstr ""
+"次のライブラリからフットプリントを読み出すことができませんでした \"%s\" / ラ"
+"イブラリ \"%s\".\n"
+"\n"
+"エラー %s."
+
+#: pcbnew/move_or_drag_track.cpp:714
+msgid "Unable to drag this segment: too many segments connected"
+msgstr "セグメントをドラッグできません: 多くのセグメントが接続しています"
+
+#: pcbnew/move_or_drag_track.cpp:785
+msgid "Unable to drag this segment: two collinear segments"
+msgstr "セグメントをドラッグできません: ２つの直線セグメントです"
+
+#: pcbnew/muonde.cpp:201
+msgid "Length of Trace:"
+msgstr "配線長:"
+
+#: pcbnew/muonde.cpp:212
+msgid "Requested length < minimum length"
+msgstr "指定された長さ < 最小長さ"
+
+#: pcbnew/muonde.cpp:226
+msgid "Requested length too large"
+msgstr "指定された長さは長過ぎます"
+
+#: pcbnew/muonde.cpp:232
+msgid "Component Value:"
+msgstr "コンポーネントの値:"
+
+#: pcbnew/muonde.cpp:587
+msgid "Gap"
+msgstr "ギャップ"
+
+#: pcbnew/muonde.cpp:593
+msgid "Stub"
+msgstr "スタブ"
+
+#: pcbnew/muonde.cpp:600
+msgid "Arc Stub"
+msgstr "円弧スタブ"
+
+#: pcbnew/muonde.cpp:611 pcbnew/muonde.cpp:629
+msgid "Create microwave module"
+msgstr "高周波モジュールの作成"
+
+#: pcbnew/muonde.cpp:628
+msgid "Angle in degrees:"
+msgstr "角度:"
+
+#: pcbnew/muonde.cpp:641
+msgid "Incorrect number, abort"
+msgstr "無効な数, 中止"
+
+#: pcbnew/muonde.cpp:786
+msgid "Complex shape"
+msgstr "複雑なシェイプ"
+
+#: pcbnew/muonde.cpp:807
+msgid "Read Shape Description File..."
+msgstr "シェイプの説明を読む"
+
+#: pcbnew/muonde.cpp:812
+msgid "Symmetrical"
+msgstr "対称"
+
+#: pcbnew/muonde.cpp:815
+msgid "Shape Option"
+msgstr "シェイプのオプション"
+
+#: pcbnew/muonde.cpp:847
+msgid "Read descr shape file"
+msgstr "シェイプの説明を読む"
+
+#: pcbnew/muonde.cpp:862
+msgid "File not found"
+msgstr "ファイルが見つかりません"
+
+#: pcbnew/muonde.cpp:950
+msgid "Shape has a null size!"
+msgstr "シェイプが無効なサイズです！"
+
+#: pcbnew/muonde.cpp:956
+msgid "Shape has no points!"
+msgstr "シェイプに点がありません！"
+
+#: pcbnew/muonde.cpp:1050
+msgid "No pad for this footprint"
+msgstr "このフットプリントにはパッドがありません"
+
+#: pcbnew/muonde.cpp:1058
+msgid "Only one pad for this footprint"
+msgstr "このフットプリントには1つだけパッドがあります"
+
+#: pcbnew/muonde.cpp:1069
+msgid "Gap:"
+msgstr "ギャップ:"
+
+#: pcbnew/muonde.cpp:1069
+msgid "Create Microwave Gap"
+msgstr "高周波用ギャップの作成"
+
+#: pcbnew/muwave_command.cpp:64
+msgid "Add Gap"
+msgstr "ギャップの追加"
+
+#: pcbnew/muwave_command.cpp:68
+msgid "Add Stub"
+msgstr "スタブの追加"
+
+#: pcbnew/muwave_command.cpp:72
+msgid "Add Arc Stub"
+msgstr "円弧スタブの追加"
+
+#: pcbnew/muwave_command.cpp:76
+msgid "Add Polynomial Shape"
+msgstr "ポリノミナル シェイプの追加"
+
+#: pcbnew/netlist.cpp:176
+msgid "Components"
+msgstr "コンポーネント"
+
+#: pcbnew/netlist.cpp:223
+#, c-format
+msgid "No footprint defined for component '%s'.\n"
+msgstr ""
+"コンポーネント '%s' に対して、フットプリントが割り当てられていません。\n"
+
+#: pcbnew/netlist.cpp:245
+#, c-format
+msgid ""
+"* Warning: component '%s': board footprint '%s', netlist footprint '%s'\n"
+msgstr ""
+"* 警告: コンポーネント '%s' ：ボードのフットプリント '%s' ：ネットリストの"
+"フットプリント '%s'\n"
+
+#: pcbnew/netlist.cpp:274
+#, c-format
+msgid "Component '%s' footprint ID '%s' is not valid.\n"
+msgstr "コンポーネント '%s' のフットプリントID '%s' が不正です。\n"
+
+#: pcbnew/netlist.cpp:296
+#, c-format
+msgid ""
+"Component '%s' footprint '%s' was not found in any libraries in the "
+"footprint library table.\n"
+msgstr ""
+"コンポーネント '%s' フットプリント '%s' はどのライブラリからも見つけることが"
+"できませんでした。\n"
+
+#: pcbnew/netlist_reader.cpp:182
+#, c-format
+msgid ""
+"invalid footprint ID in\n"
+"file: <%s>\n"
+"line: %d"
+msgstr ""
+
+#: pcbnew/onleftclick.cpp:252 pcbnew/tools/drawing_tool.cpp:721
+#: pcbnew/tools/drawing_tool.cpp:873
+msgid "Graphic not allowed on Copper layers"
+msgstr "図形は導体レイヤに配置できません"
+
+#: pcbnew/onleftclick.cpp:276
+msgid "Tracks on Copper layers only "
+msgstr "配線は導体レイヤのみです"
+
+#: pcbnew/onleftclick.cpp:335
+msgid "Texts not allowed on Edge Cut layer"
+msgstr "基板外形レイヤに文字列を配置するこはできません"
+
+#: pcbnew/onleftclick.cpp:384 pcbnew/tools/drawing_tool.cpp:308
+msgid "Dimension not allowed on Copper or Edge Cut layers"
+msgstr "寸法線は導体レイヤまたは外形線レイヤに配置できません"
+
+#: pcbnew/onrightclick.cpp:151
+msgid "Lock Footprint"
+msgstr "フットプリントをロック"
+
+#: pcbnew/onrightclick.cpp:158
+msgid "Unlock Footprint"
+msgstr "フットプリントをロック解除"
+
+#: pcbnew/onrightclick.cpp:166
+msgid "Automatically Place Footprint"
+msgstr "フットプリントを自動配置"
+
+#: pcbnew/onrightclick.cpp:173
+msgid "Automatically Route Footprint"
+msgstr "フットプリントの自動配線"
+
+#: pcbnew/onrightclick.cpp:194
+msgid "Move Drawing"
+msgstr "図形の移動"
+
+#: pcbnew/onrightclick.cpp:199
+msgid "Duplicate Drawing"
+msgstr "図形の複製"
+
+#: pcbnew/onrightclick.cpp:204
+msgid "Move Drawing Exactly"
+msgstr "数値を指定して図形を移動"
+
+#: pcbnew/onrightclick.cpp:209
+msgid "Create Drawing Array"
+msgstr "図形配列の作成"
+
+#: pcbnew/onrightclick.cpp:214
+msgid "Edit Drawing"
+msgstr "図形の編集"
+
+#: pcbnew/onrightclick.cpp:224
+msgid "Delete All Drawings on Layer"
+msgstr "レイヤ上の全ての図形描画を削除する"
+
+#: pcbnew/onrightclick.cpp:231
+msgid "Delete Zone Filling"
+msgstr "ゾーン塗りつぶしを削除"
+
+#: pcbnew/onrightclick.cpp:238
+msgid "Close Zone Outline"
+msgstr "ゾーンの外枠を閉じる"
+
+#: pcbnew/onrightclick.cpp:240
+msgid "Delete Last Corner"
+msgstr "一つ前の角を削除"
+
+#: pcbnew/onrightclick.cpp:266
+msgid "Edit Dimension"
+msgstr "寸法線の編集"
+
+#: pcbnew/onrightclick.cpp:270
+msgid "Move Dimension Text"
+msgstr "寸法線テキストの移動"
+
+#: pcbnew/onrightclick.cpp:275
+msgid "Duplicate Dimension"
+msgstr "寸法線の複製"
+
+#: pcbnew/onrightclick.cpp:280
+msgid "Move Dimension Exactly"
+msgstr "数値を指定して寸法線を移動"
+
+#: pcbnew/onrightclick.cpp:285
+msgid "Delete Dimension"
+msgstr "寸法線の削除"
+
+#: pcbnew/onrightclick.cpp:296
+msgid "Move Target"
+msgstr "ターゲットの移動"
+
+#: pcbnew/onrightclick.cpp:301
+msgid "Move Target Exactly"
+msgstr "数値を指定してターゲットの移動"
+
+#: pcbnew/onrightclick.cpp:306
+msgid "Duplicate Target"
+msgstr "ターゲットの複製"
+
+#: pcbnew/onrightclick.cpp:311
+msgid "Create Target Array"
+msgstr "ターゲット配列の作成"
+
+#: pcbnew/onrightclick.cpp:316
+msgid "Edit Target"
+msgstr "ターゲットの編集"
+
+#: pcbnew/onrightclick.cpp:320
+msgid "Delete Target"
+msgstr "ターゲットの削除"
+
+#: pcbnew/onrightclick.cpp:354
+msgid "Get and Move Footprint"
+msgstr "フットプリントの検索と移動"
+
+#: pcbnew/onrightclick.cpp:367
+msgid "Fill or Refill All Zones"
+msgstr "全てのゾーンを塗りつぶす"
+
+#: pcbnew/onrightclick.cpp:371
+msgid "Remove Filled Areas in All Zones"
+msgstr "全てのゾーンの塗りつぶしエリアを削除"
+
+#: pcbnew/onrightclick.cpp:379 pcbnew/onrightclick.cpp:385
+#: pcbnew/onrightclick.cpp:403 pcbnew/onrightclick.cpp:416
+#: pcbnew/onrightclick.cpp:481 pcbnew/onrightclick.cpp:574
+msgid "Select Working Layer"
+msgstr "作業レイヤの選択"
+
+#: pcbnew/onrightclick.cpp:393 pcbnew/onrightclick.cpp:473
+#: pcbnew/onrightclick.cpp:521
+msgid "Begin Track"
+msgstr "配線の開始"
+
+#: pcbnew/onrightclick.cpp:399 pcbnew/onrightclick.cpp:477
+#: pcbnew/onrightclick.cpp:645
+msgid "Select Track Width"
+msgstr "配線幅の選択"
+
+#: pcbnew/onrightclick.cpp:405
+msgid "Select Layer Pair for Vias"
+msgstr "ビアのレイヤペアを選択"
+
+#: pcbnew/onrightclick.cpp:424
+msgid "Footprint Documentation"
+msgstr "フットプリントのドキュメントを見る"
+
+#: pcbnew/onrightclick.cpp:434
+msgid "Global Spread and Place"
+msgstr "グローバル移動/配置"
+
+#: pcbnew/onrightclick.cpp:436
+msgid "Unlock All Footprints"
+msgstr "全てのフットプリントをアンロック"
+
+#: pcbnew/onrightclick.cpp:438
+msgid "Lock All Footprints"
+msgstr "全てのフットプリントをロック"
+
+#: pcbnew/onrightclick.cpp:441
+msgid "Spread out All Footprints"
+msgstr "全てのフットプリントを展開"
+
+#: pcbnew/onrightclick.cpp:443
+msgid "Spread out Footprints not Already on Board"
+msgstr "ボード上に無い全てのフットプリントを展開"
+
+#: pcbnew/onrightclick.cpp:446
+msgid "Automatically Place All Footprints"
+msgstr "全てのフットプリントを自動配置"
+
+#: pcbnew/onrightclick.cpp:448
+msgid "Automatically Place New Footprints"
+msgstr "新しいフットプリントを自動配置"
+
+#: pcbnew/onrightclick.cpp:450
+msgid "Automatically Place Next Footprints"
+msgstr "次のフットプリントを自動配置"
+
+#: pcbnew/onrightclick.cpp:453
+msgid "Orient All Footprints"
+msgstr "全てのフットプリントの方向を揃える"
+
+#: pcbnew/onrightclick.cpp:460
+msgid "Autoroute"
+msgstr "自動配線"
+
+#: pcbnew/onrightclick.cpp:462
+msgid "Select Layer Pair"
+msgstr "レイヤ ペアの選択"
+
+#: pcbnew/onrightclick.cpp:465
+msgid "Automatically Route All Footprints"
+msgstr "全てのフットプリントを自動配置"
+
+#: pcbnew/onrightclick.cpp:467
+msgid "Reset Unrouted"
+msgstr "未配線をリセット"
+
+#: pcbnew/onrightclick.cpp:497
+msgid "Zoom Block"
+msgstr "ブロックの拡大"
+
+#: pcbnew/onrightclick.cpp:501
+msgid "Flip Block"
+msgstr "ブロックを裏返す"
+
+#: pcbnew/onrightclick.cpp:502
+msgid "Rotate Block"
+msgstr "ブロックの回転"
+
+#: pcbnew/onrightclick.cpp:528
+msgid "Drag Via"
+msgstr "ビアの移動"
+
+#: pcbnew/onrightclick.cpp:537
+msgid "Move Node"
+msgstr "ノードの移動"
+
+#: pcbnew/onrightclick.cpp:543
+msgid "Drag Segments, Keep Slope"
+msgstr "セグメントのドラッグ移動 (角度保持)"
+
+#: pcbnew/onrightclick.cpp:548
+msgid "Drag Segment"
+msgstr "セグメントのドラッグ移動"
+
+#: pcbnew/onrightclick.cpp:553
+msgid "Duplicate Track"
+msgstr "配線の複製"
+
+#: pcbnew/onrightclick.cpp:558
+msgid "Move Track Exactly"
+msgstr "数値を指定してトラックを移動"
+
+#: pcbnew/onrightclick.cpp:563
+msgid "Create Track Array"
+msgstr "配線配列の作成"
+
+#: pcbnew/onrightclick.cpp:569
+msgid "Break Track"
+msgstr "配線の切断"
+
+#: pcbnew/onrightclick.cpp:579
+msgid "Place Node"
+msgstr "ノード配置"
+
+#: pcbnew/onrightclick.cpp:586 pcbnew/router/length_tuner_tool.cpp:54
+#: pcbnew/router/router_tool.cpp:65
+msgid "End Track"
+msgstr "配線の終了"
+
+#: pcbnew/onrightclick.cpp:590 pcbnew/router/router_tool.cpp:76
+msgid "Place Through Via"
+msgstr "貫通ビアの配置"
+
+#: pcbnew/onrightclick.cpp:593
+msgid "Select Layer and Place Through Via"
+msgstr "スルーホールを配置するレイヤの選択"
+
+#: pcbnew/onrightclick.cpp:600 pcbnew/router/router_tool.cpp:82
+msgid "Place Blind/Buried Via"
+msgstr "ブラインドビア(BVH)/ベリッドホール(BH)の配置"
+
+#: pcbnew/onrightclick.cpp:604
+msgid "Select Layer and Place Blind/Buried Via"
+msgstr "レイヤを指定してブラインド/ベリッドビアを配置"
+
+#: pcbnew/onrightclick.cpp:610 pcbnew/router/router_tool.cpp:99
+msgid "Switch Track Posture"
+msgstr "配線の形を変える"
+
+#: pcbnew/onrightclick.cpp:618
+msgid "Place Micro Via"
+msgstr "マイクロビアを配置"
+
+#: pcbnew/onrightclick.cpp:629
+msgid "Change Via Size and Drill"
+msgstr "ビア径/ドリル径の変更"
+
+#: pcbnew/onrightclick.cpp:635
+msgid "Change Segment Width"
+msgstr "セグメント幅の変更"
+
+#: pcbnew/onrightclick.cpp:639
+msgid "Change Track Width"
+msgstr "配線幅の変更"
+
+#: pcbnew/onrightclick.cpp:654
+msgid "Delete Via"
+msgstr "ビア削除"
+
+#: pcbnew/onrightclick.cpp:661
+msgid "Delete Track"
+msgstr "配線削除"
+
+#: pcbnew/onrightclick.cpp:663
+msgid "Delete Net"
+msgstr "ネット削除"
+
+#: pcbnew/onrightclick.cpp:672
+msgid "Edit All Tracks and Vias"
+msgstr "配線とビアのグローバル編集"
+
+#: pcbnew/onrightclick.cpp:678
+msgid "Set Flags"
+msgstr "フラグのセット"
+
+#: pcbnew/onrightclick.cpp:680
+msgid "Locked: Yes"
+msgstr "セグメントロック: Yes"
+
+#: pcbnew/onrightclick.cpp:681
+msgid "Locked: No"
+msgstr "セグメントロック: No"
+
+#: pcbnew/onrightclick.cpp:690
+msgid "Track Locked: Yes"
+msgstr "配線のロック: Yes"
+
+#: pcbnew/onrightclick.cpp:691
+msgid "Track Locked: No"
+msgstr "配線のロック: No"
+
+#: pcbnew/onrightclick.cpp:693
+msgid "Net Locked: Yes"
+msgstr "ネットのロック: Yes"
+
+#: pcbnew/onrightclick.cpp:694
+msgid "Net Locked: No"
+msgstr "ネットのロック: No"
+
+#: pcbnew/onrightclick.cpp:708
+msgid "Place Edge Outline"
+msgstr "エッジの配置"
+
+#: pcbnew/onrightclick.cpp:714
+msgid "Place Corner"
+msgstr "角の入力"
+
+#: pcbnew/onrightclick.cpp:717
+msgid "Place Zone"
+msgstr "ゾーンの入力"
+
+#: pcbnew/onrightclick.cpp:724
+msgid "Keepout Area"
+msgstr "キープアウト(禁止)エリア"
+
+#: pcbnew/onrightclick.cpp:730
+msgid "Move Corner"
+msgstr "角の移動"
+
+#: pcbnew/onrightclick.cpp:732
+msgid "Delete Corner"
+msgstr "角の削除"
+
+#: pcbnew/onrightclick.cpp:737
+msgid "Create Corner"
+msgstr "角の作成"
+
+#: pcbnew/onrightclick.cpp:738
+msgid "Drag Outline Segment"
+msgstr "外枠セグメントの移動"
+
+#: pcbnew/onrightclick.cpp:746
+msgid "Add Similar Zone"
+msgstr "同様のゾーンの追加"
+
+#: pcbnew/onrightclick.cpp:749
+msgid "Add Cutout Area"
+msgstr "切り抜きの追加"
+
+#: pcbnew/onrightclick.cpp:752
+msgid "Duplicate Zone Onto Layer"
+msgstr "レイヤ上にゾーンを複製"
+
+#: pcbnew/onrightclick.cpp:757
+msgid "Fill Zone"
+msgstr "ゾーンの塗りつぶし"
+
+#: pcbnew/onrightclick.cpp:763
+msgid "Remove Filled Areas in Zone"
+msgstr "ゾーンの塗りつぶしを削除"
+
+#: pcbnew/onrightclick.cpp:766
+msgid "Move Zone"
+msgstr "ゾーンの移動"
+
+#: pcbnew/onrightclick.cpp:769
+msgid "Move Zone Exactly"
+msgstr "数値を指定してゾーンを移動"
+
+#: pcbnew/onrightclick.cpp:774
+msgid "Edit Zone Properties"
+msgstr "ゾーンプロパティの編集"
+
+#: pcbnew/onrightclick.cpp:784
+msgid "Delete Cutout"
+msgstr "切り抜きの削除"
+
+#: pcbnew/onrightclick.cpp:787
+msgid "Delete Zone Outline"
+msgstr "ゾーン外枠の削除"
+
+#: pcbnew/onrightclick.cpp:807 pcbnew/onrightclick.cpp:999
+#: pcbnew/tools/common_actions.cpp:100
+msgid "Move"
+msgstr "移動"
+
+#: pcbnew/onrightclick.cpp:811
+msgid "Drag"
+msgstr "ドラッグ"
+
+#: pcbnew/onrightclick.cpp:816
+msgid "Rotate +"
+msgstr "左に回転"
+
+#: pcbnew/onrightclick.cpp:820
+msgid "Rotate -"
+msgstr "右に回転"
+
+#: pcbnew/onrightclick.cpp:821 pcbnew/onrightclick.cpp:1009
+#: pcbnew/tools/common_actions.cpp:125
+msgid "Flip"
+msgstr "裏返す"
+
+#: pcbnew/onrightclick.cpp:827
+msgid "Edit Parameters"
+msgstr "パラメータの編集"
+
+#: pcbnew/onrightclick.cpp:832
+msgid "Edit with Footprint Editor"
+msgstr "フットプリントエディタで編集"
+
+#: pcbnew/onrightclick.cpp:839
+msgid "Delete Footprint"
+msgstr "フットプリントの削除"
+
+#: pcbnew/onrightclick.cpp:846
+msgid "Move Footprint Exactly"
+msgstr "数値を指定してフットプリントを移動"
+
+#: pcbnew/onrightclick.cpp:851
+msgid "Duplicate Footprint"
+msgstr "フットプリントの複製"
+
+#: pcbnew/onrightclick.cpp:856
+msgid "Create Footprint Array"
+msgstr "フットプリント配列の作成"
+
+#: pcbnew/onrightclick.cpp:862
+msgid "Exchange Footprint(s)"
+msgstr "フットプリントの入れ替え"
+
+#: pcbnew/onrightclick.cpp:902 pcbnew/onrightclick.cpp:1016
+msgid "Reset Size"
+msgstr "サイズをリセット"
+
+#: pcbnew/onrightclick.cpp:945
+msgid "Drag Pad"
+msgstr "パッドの移動"
+
+#: pcbnew/onrightclick.cpp:953
+msgid "Copy Current Settings to this Pad"
+msgstr "このパッドに現在の設定をコピー"
+
+#: pcbnew/onrightclick.cpp:957
+msgid "Copy this Pad Settings to Current Settings"
+msgstr "このパッドの設定を現在の設定にコピー"
+
+#: pcbnew/onrightclick.cpp:962
+msgid "Edit All Pads"
+msgstr "パッドのグローバル編集"
+
+#: pcbnew/onrightclick.cpp:963
+msgid ""
+"Copy this pad's settings to all pads in this footprint (or similar "
+"footprints)"
+msgstr ""
+"このパッドの設定をこのフットプリント (及び同様のフットプリント) 内の全ての"
+"パッドにコピー"
+
+#: pcbnew/onrightclick.cpp:971
+msgid "Automatically Route Pad"
+msgstr "パッドの自動配線"
+
+#: pcbnew/onrightclick.cpp:972
+msgid "Automatically Route Net"
+msgstr "ネットの自動配線"
+
+#: pcbnew/onrightclick.cpp:1002
+msgid "Copy"
+msgstr "コピー"
+
+#: pcbnew/onrightclick.cpp:1047
+msgid "Auto Width"
+msgstr "自動幅"
+
+#: pcbnew/onrightclick.cpp:1048
+msgid ""
+"Use the track width when starting on a track, otherwise the current track "
+"width"
+msgstr "現在の配線幅ではなく、配線時の幅を使用する"
+
+#: pcbnew/onrightclick.cpp:1058
+msgid "Use Netclass Values"
+msgstr "ネットクラスの値を使用する"
+
+#: pcbnew/onrightclick.cpp:1059
+msgid "Use track and via sizes from their Netclass values"
+msgstr "ネットクラスの値の配線とビア径を使う"
+
+#: pcbnew/onrightclick.cpp:1065
+#, c-format
+msgid "Track %s"
+msgstr "配線 %s"
+
+#: pcbnew/onrightclick.cpp:1068 pcbnew/onrightclick.cpp:1094
+msgid " uses NetClass"
+msgstr "ネットクラスを使う"
+
+#: pcbnew/onrightclick.cpp:1086
+#, c-format
+msgid "Via %s"
+msgstr "ビア %s"
+
+#: pcbnew/onrightclick.cpp:1090
+#, c-format
+msgid "Via %s, drill %s"
+msgstr "ビア %s (%s)"
+
+#: pcbnew/pad_edition_functions.cpp:211
+#, c-format
+msgid "Delete Pad (footprint %s %s) ?"
+msgstr "パッドを削除しますか(フットプリント %s %s) ?"
+
+#: pcbnew/pcb_parser.cpp:138
+#, c-format
+msgid ""
+"invalid floating point number in\n"
+"file: <%s>\n"
+"line: %d\n"
+"offset: %d"
+msgstr ""
+"不正な浮動小数点数値が見つかりました:\n"
+"ファイル: <%s>\n"
+"行数: %d\n"
+"文字: %d"
+
+#: pcbnew/pcb_parser.cpp:147
+#, c-format
+msgid ""
+"missing floating point number in\n"
+"file: <%s>\n"
+"line: %d\n"
+"offset: %d"
+msgstr ""
+"不正な浮動小数点数値が見つかりました:\n"
+"ファイル: '%s'\n"
+"行数: %d\n"
+"文字: %d"
+
+#: pcbnew/pcb_parser.cpp:591
+#, c-format
+msgid "page type \"%s\" is not valid "
+msgstr "ページタイプ \"%s\" は不正です! "
+
+#: pcbnew/pcb_parser.cpp:823
+#, c-format
+msgid "Layer '%s' in file '%s' at line %d, is not in fixed layer hash"
+msgstr ""
+"レイヤ '%s' (ファイル: '%s' %d行) はこのレイヤハッシュで定義されていません。"
+
+#: pcbnew/pcb_parser.cpp:856
+#, c-format
+msgid "%d is not a valid layer count"
+msgstr "%d は有効なレイヤ番号ではありません"
+
+#: pcbnew/pcb_parser.cpp:887
+#, c-format
+msgid ""
+"Layer '%s' in file\n"
+"'%s'\n"
+"at line %d, position %d\n"
+"was not defined in the layers section"
+msgstr ""
+"レイヤ '%s' (ファイル:\n"
+"'%s'\n"
+", %d行, %d文字目) \n"
+"はこのレイヤセクションで定義されていません。"
+
+#: pcbnew/pcb_parser.cpp:1265
+#, c-format
+msgid "duplicate NETCLASS name '%s' in file <%s> at line %d, offset %d"
+msgstr ""
+"重複したネットクラス '%s' がファイル <%s>  %d 行目, 位置 %d に見つかりました"
+
+#: pcbnew/pcb_parser.cpp:1908
+#, c-format
+msgid "cannot handle module text type %s"
+msgstr "モジュールのテキストタイプ %s は扱うことが出来ません。"
+
+#: pcbnew/pcb_parser.cpp:2316 pcbnew/pcb_parser.cpp:2322
+#: pcbnew/pcb_parser.cpp:2422 pcbnew/pcb_parser.cpp:2504
+#: pcbnew/pcb_parser.cpp:2568
+#, c-format
+msgid ""
+"invalid net ID in\n"
+"file: <%s>\n"
+"line: %d\n"
+"offset: %d"
+msgstr ""
+"不正な net ID が見つかりました: \n"
+"ファイル:<%s>\n"
+"%d行目\n"
+"%d文字目"
+
+#: pcbnew/pcb_parser.cpp:2880
+#, c-format
+msgid ""
+"There is a zone that belongs to a not existing net\n"
+"\"%s\"\n"
+"you should verify and edit it (run DRC test)."
+msgstr ""
+"ゾーンは存在しないネット\n"
+"\"%s\"\n"
+"に属しています。確認して修正して下さい。(DRC テストを実施)"
+
+#: pcbnew/pcbframe.cpp:619
+#, c-format
+msgid "The auto save file '%s' could not be removed!"
+msgstr "自動保存ファイル '%s' は削除できませんでした!"
+
+#: pcbnew/pcbframe.cpp:981
+msgid " [new file]"
+msgstr " [新規ファイル]"
+
+#: pcbnew/pcbnew.cpp:326
+msgid ""
+"You have run Pcbnew for the first time using the new footprint library table "
+"method for finding footprints.\n"
+"Pcbnew has either copied the default table or created an empty table in the "
+"kicad configuration folder.\n"
+"You must first configure the library table to include all footprint "
+"libraries you want to use.\n"
+"See the \"Footprint Library  Table\" section of the CvPcb or Pcbnew "
+"documentation for more information."
+msgstr ""
+"Pcbnew は、最初の起動から新しいフットプリント ライブラリ テーブルを使う方法で"
+"実行されます。.\n"
+"Pcbnew はまた、KiCad 設定 フォルダにデフォルト テーブルのコピーまたは空のテー"
+"ブルを作ります。\n"
+"まず初めに、使いたい全てのフットプリントライブラリを含むようにライブラリ テー"
+"ブルを設定しなければなりません。\n"
+"詳細は、CvPcb か Pcbnew のドキュメントにある \"フットプリント ライブラリ テー"
+"ブル\" の章を参照してください."
+
+#: pcbnew/pcbnew_config.cpp:446
+msgid "Save Macros File"
+msgstr "マクロ ファイルの保存"
+
+#: pcbnew/pcbnew_config.cpp:494
+msgid "Read Macros File"
+msgstr "マクロ ファイルの読込み"
+
+#: pcbnew/plot_board_layers.cpp:116 pcbnew/plot_board_layers.cpp:301
+#, c-format
+msgid "Your BOARD has a bad layer number for module %s"
+msgstr "ボードがモジュール %s に対して不正なレイヤ番号を持っています"
+
+#: pcbnew/plugin.cpp:118
+msgid "Enable <b>debug</b> logging for Footprint*() functions in this PLUGIN."
+msgstr "このプラグインで Footprint*() 関数の<b>デバッグ</b>を有効にします"
+
+#: pcbnew/plugin.cpp:122
+msgid "Regular expression <b>footprint name</b> filter."
+msgstr "正規表現で<b>フットプリント名</b>を絞込み。"
+
+#: pcbnew/plugin.cpp:126
+msgid ""
+"Enable transaction logging. The mere presence of this option turns on the "
+"logging, no need to set a Value."
+msgstr ""
+"トランザクションのログを許可する。このオプションを有効にするだけでログを開始"
+"します。値のセットは必要ありません。"
+
+#: pcbnew/plugin.cpp:131
+msgid "User name for <b>login</b> to some special library server."
+msgstr "特別なライブラリサーバーへ <b>ログイン</b> するためのユーザー名."
+
+#: pcbnew/plugin.cpp:135
+msgid "Password for <b>login</b> to some special library server."
+msgstr "特別なライブラリサーバーへ <b>ログイン</b> するためのパスワード."
+
+#: pcbnew/plugin.cpp:143
+msgid ""
+"Enter the python module which implements the PLUGIN::Footprint*() functions."
+msgstr ""
+"PLUGIN::Footprint*() 関数が定義されている Python モジュールを入力して下さい。"
+
+#: pcbnew/router/length_tuner_tool.cpp:51 pcbnew/router/router_tool.cpp:62
 msgid "New Track"
 msgstr "新規配線"
 
-#: pcbnew/router/length_tuner_tool.cpp:51 pcbnew/router/router_tool.cpp:61
+#: pcbnew/router/length_tuner_tool.cpp:51 pcbnew/router/router_tool.cpp:62
 msgid "Starts laying a new track."
 msgstr "新規配線を開始"
 
@@ -12156,97 +20921,552 @@ msgstr "配線オプション..."
 msgid "Shows a dialog containing router options."
 msgstr "ルーター オプションのダイアログを表示"
 
-#: pcbnew/router/router_tool.cpp:64
+#: pcbnew/router/router_tool.cpp:65
 msgid "Stops laying the current track."
 msgstr "現在の配線を終了"
 
-#: pcbnew/router/router_tool.cpp:67
+#: pcbnew/router/router_tool.cpp:68
 msgid "Auto-end Track"
 msgstr "配線を自動的に終了"
 
-#: pcbnew/router/router_tool.cpp:67
+#: pcbnew/router/router_tool.cpp:68
 msgid "Automagically finishes currently routed track."
 msgstr "現在の配線を自動的に終了する."
 
-#: pcbnew/router/router_tool.cpp:71
+#: pcbnew/router/router_tool.cpp:72
 msgid "Drag Track/Via"
 msgstr "配線/ビアのドラッグ"
 
-#: pcbnew/router/router_tool.cpp:71
+#: pcbnew/router/router_tool.cpp:72
 msgid "Drags a track or a via."
 msgstr "配線/ビアのドラッグ"
 
-#: pcbnew/router/router_tool.cpp:76
+#: pcbnew/router/router_tool.cpp:77
 msgid "Adds a through-hole via at the end of currently routed track."
 msgstr "配線の最後に貫通ビアを追加する"
 
-#: pcbnew/router/router_tool.cpp:82
+#: pcbnew/router/router_tool.cpp:83
 msgid "Adds a blind or buried via at the end of currently routed track."
 msgstr "配線の最後にブラインド/ベリッドビアを追加する"
 
-#: pcbnew/router/router_tool.cpp:87
+#: pcbnew/router/router_tool.cpp:88
 msgid "Place Microvia"
 msgstr "マイクロビアの配置"
 
-#: pcbnew/router/router_tool.cpp:87
+#: pcbnew/router/router_tool.cpp:88
 msgid "Adds a microvia at the end of currently routed track."
 msgstr "配線の最後にマイクロビアを追加する"
 
-#: pcbnew/router/router_tool.cpp:92
+#: pcbnew/router/router_tool.cpp:93
 msgid "Custom Track/Via Size"
 msgstr "カスタム配線幅とビアサイズ"
 
-#: pcbnew/router/router_tool.cpp:93
+#: pcbnew/router/router_tool.cpp:94
 msgid "Shows a dialog for changing the track width and via size."
 msgstr "配線幅とビア サイズ設定のダイアログを表示"
 
-#: pcbnew/router/router_tool.cpp:99
+#: pcbnew/router/router_tool.cpp:100
 msgid "Switches posture of the currenly routed track."
 msgstr "作業中の配線の形を変更する。"
 
-#: pcbnew/router/router_tool.cpp:104
+#: pcbnew/router/router_tool.cpp:105
 msgid "Differential Pair Dimensions..."
 msgstr "差動ペアの寸法"
 
-#: pcbnew/router/router_tool.cpp:105
+#: pcbnew/router/router_tool.cpp:106
 msgid "Sets the width and gap of the currently routed differential pair."
 msgstr "差動ペア配線の幅とギャップを設定する"
 
-#: pcbnew/router/router_tool.cpp:128
+#: pcbnew/router/router_tool.cpp:129
 msgid "Custom size"
 msgstr "ユーザ定義サイズ"
 
-#: pcbnew/router/router_tool.cpp:131
+#: pcbnew/router/router_tool.cpp:132
 msgid "Use the starting track width"
 msgstr "開始トラック幅を使用"
 
-#: pcbnew/router/router_tool.cpp:132
+#: pcbnew/router/router_tool.cpp:133
 msgid "Route using the width of the starting track."
 msgstr "配線開始時の配線幅でルーティングを行う。"
 
-#: pcbnew/router/router_tool.cpp:134
+#: pcbnew/router/router_tool.cpp:135
 msgid "Use net class values"
 msgstr "ネットクラスの値を使う"
 
-#: pcbnew/router/router_tool.cpp:135
+#: pcbnew/router/router_tool.cpp:136
 msgid "Use track and via sizes from the net class"
 msgstr "ネットクラスの値の配線とビア径を使う"
 
-#: pcbnew/router/router_tool.cpp:202
+#: pcbnew/router/router_tool.cpp:203
 msgid "Interactive Router"
 msgstr "インタラクティブ配線"
 
-#: pcbnew/router/router_tool.cpp:215
+#: pcbnew/router/router_tool.cpp:216
 msgid "Select Track/Via Width"
 msgstr "配線/ビア幅の選択"
 
-#: pcbnew/router/router_tool.cpp:595
+#: pcbnew/router/router_tool.cpp:402
+msgid "Blind/buried vias have to be enabled in the design settings."
+msgstr ""
+
+#: pcbnew/router/router_tool.cpp:408
+msgid "Microvias have to be enabled in the design settings."
+msgstr ""
+
+#: pcbnew/router/router_tool.cpp:415
+msgid "Only through vias are allowed on 2 layer boards."
+msgstr ""
+
+#: pcbnew/router/router_tool.cpp:422
+msgid ""
+"Microvias can be placed only between the outer layers (F.Cu/B.Cu) and the "
+"ones directly adjacent to them."
+msgstr ""
+
+#: pcbnew/router/router_tool.cpp:643
 msgid "Route Track"
 msgstr "配線"
 
-#: pcbnew/router/router_tool.cpp:602
+#: pcbnew/router/router_tool.cpp:650
 msgid "Router Differential Pair"
 msgstr "差動ペアの配線"
+
+# この訳は本当？
+# 2014.03.08 Zenyouji
+#: pcbnew/sel_layer.cpp:301
+msgid "Warning: The Top Layer and Bottom Layer are same."
+msgstr "警告: ペア層に同じレイヤが指定されています。"
+
+#: pcbnew/specctra_export.cpp:202
+msgid "BOARD exported OK."
+msgstr "ボードは正しくエクスポートされました。"
+
+#: pcbnew/specctra_export.cpp:207
+msgid "Unable to export, please fix and try again."
+msgstr "エクスポートできません。問題点を修正してやり直してください。"
+
+#: pcbnew/specctra_export.cpp:1025 pcbnew/specctra_export.cpp:1132
+#: pcbnew/specctra_export.cpp:1268
+#, c-format
+msgid "Unsupported DRAWSEGMENT type %s"
+msgstr "%s はサポートされていないDRAWSEGMENTタイプです"
+
+#: pcbnew/specctra_export.cpp:1157
+#, c-format
+msgid ""
+"Unable to find the next boundary segment with an endpoint of (%s mm, %s "
+"mm).\n"
+"Edit Edge.Cuts perimeter graphics, making them contiguous polygons each."
+msgstr ""
+"終点 (%s mm, %s mm) で次の境界線が見つかりませんでした.\n"
+"基板外形図で、外形線を互いに隣接するように編集してください."
+
+#: pcbnew/specctra_export.cpp:1293
+#, c-format
+msgid ""
+"Unable to find the next keepout segment with an endpoint of (%s mm, %s mm).\n"
+"Edit Edge.Cuts interior graphics, making them contiguous polygons each."
+msgstr ""
+"終点 (%s mm, %s mm) で次の禁止領域の境界線が見つかりませんでした.\n"
+"基板外形図で、内部の境界線を互いに隣接するように編集してください."
+
+#: pcbnew/specctra_export.cpp:1454
+#, c-format
+msgid "Component with value of '%s' has empty reference id."
+msgstr "定数 \"%s\" のコンポーネントのリファレンスIDが空です。"
+
+#: pcbnew/specctra_export.cpp:1462
+#, c-format
+msgid "Multiple components have identical reference IDs of '%s'."
+msgstr "複数のコンポーネントが同一のリファレンスID '%s' を持っています。"
+
+#: pcbnew/specctra_import.cpp:84
+msgid "Merge Specctra Session file:"
+msgstr "Spectra セッションファイルのマージ"
+
+#: pcbnew/specctra_import.cpp:108
+msgid "BOARD may be corrupted, do not save it."
+msgstr "ボードが壊れているかもしれません、保存しないでください。"
+
+#: pcbnew/specctra_import.cpp:110
+msgid "Fix problem and try again."
+msgstr "問題を修正してやり直してください。"
+
+#: pcbnew/specctra_import.cpp:128
+msgid "Session file imported and merged OK."
+msgstr "セッション ファイルはインポートされ、正常にマージできました。"
+
+#: pcbnew/specctra_import.cpp:200 pcbnew/specctra_import.cpp:312
+#, c-format
+msgid "Session file uses invalid layer id \"%s\""
+msgstr "セッションファイルで不正なレイヤID \"%s\" が使用されています"
+
+#: pcbnew/specctra_import.cpp:253
+msgid "Session via padstack has no shapes"
+msgstr "セッション ビアのパッドスタックの形状がありません"
+
+#: pcbnew/specctra_import.cpp:260 pcbnew/specctra_import.cpp:278
+#: pcbnew/specctra_import.cpp:303
+#, c-format
+msgid "Unsupported via shape: %s"
+msgstr "サポートされていないビアの形: %s"
+
+#: pcbnew/specctra_import.cpp:359
+msgid "Session file is missing the \"session\" section"
+msgstr "セッションファイルに \"session\" セクションが見つかりません"
+
+#: pcbnew/specctra_import.cpp:367
+msgid "Session file is missing the \"routes\" section"
+msgstr "セッションファイルに \"routes\" セクションが見つかりません"
+
+#: pcbnew/specctra_import.cpp:370
+msgid "Session file is missing the \"library_out\" section"
+msgstr "セッションファイルに \"library_out\" セクションが見つかりません"
+
+#: pcbnew/specctra_import.cpp:397
+#, c-format
+msgid "Session file has 'reference' to non-existent component \"%s\""
+msgstr "セッションファイルが存在しないコンポーネント \"%s\" を参照しています。"
+
+#: pcbnew/specctra_import.cpp:545
+#, c-format
+msgid "A wire_via references a missing padstack \"%s\""
+msgstr "wire_via が失われたパッドスタック \"%s\" を参照しています"
+
+#: pcbnew/swap_layers.cpp:94
+msgid "Swap Layers:"
+msgstr "レイヤの入替え:"
+
+#: pcbnew/swap_layers.cpp:245 pcbnew/swap_layers.cpp:252
+#: pcbnew/swap_layers.cpp:330
+msgid "No Change"
+msgstr "変更なし"
+
+#: pcbnew/swap_layers.cpp:285
+msgid "&OK"
+msgstr "&OK"
+
+#: pcbnew/swap_layers.cpp:289
+msgid "&Cancel"
+msgstr "キャンセル(&C)"
+
+#: pcbnew/tool_modedit.cpp:62
+msgid "Create new library and save current footprint"
+msgstr "新規ライブラリを作成して現在のフットプリントを保存"
+
+#: pcbnew/tool_modedit.cpp:65 pcbnew/tool_pcb.cpp:239
+msgid "Open footprint viewer"
+msgstr "フットプリントビューアを開く"
+
+#: pcbnew/tool_modedit.cpp:69
+msgid "Delete part from active library"
+msgstr "アクティブなライブラリからパーツを削除"
+
+#: pcbnew/tool_modedit.cpp:73
+msgid "New footprint"
+msgstr "新規フットプリント"
+
+#: pcbnew/tool_modedit.cpp:78
+msgid "New footprint using the footprint wizard"
+msgstr ""
+
+#: pcbnew/tool_modedit.cpp:84
+msgid "Load footprint from library"
+msgstr "ライブラリからフットプリントを開く"
+
+#: pcbnew/tool_modedit.cpp:89
+msgid "Load footprint from current board"
+msgstr "現在のボードからフットプリントを読み込む"
+
+#: pcbnew/tool_modedit.cpp:93
+msgid "Update footprint in current board"
+msgstr "現在のボードのフットプリントを更新"
+
+#: pcbnew/tool_modedit.cpp:97
+msgid "Insert footprint into current board"
+msgstr "現在のボードへフットプリントを挿入"
+
+#: pcbnew/tool_modedit.cpp:101
+msgid "Import footprint"
+msgstr "フットプリントのインポート"
+
+#: pcbnew/tool_modedit.cpp:104
+msgid "Export footprint"
+msgstr "フットプリントのエクスポート"
+
+#: pcbnew/tool_modedit.cpp:109 pcbnew/help_common_strings.h:15
+msgid "Undo last edition"
+msgstr "一つ前の編集を元に戻す"
+
+#: pcbnew/tool_modedit.cpp:116
+msgid "Footprint properties"
+msgstr "フットプリントのプロパティ"
+
+#: pcbnew/tool_modedit.cpp:120
+msgid "Print footprint"
+msgstr "フットプリントの印刷"
+
+#: pcbnew/tool_modedit.cpp:144
+msgid "Check footprint"
+msgstr "フットプリントの確認"
+
+#: pcbnew/tool_modedit.cpp:166 pcbnew/tools/common_actions.cpp:418
+#: pcbnew/tools/module_tools.cpp:106
+msgid "Add pads"
+msgstr "パッド入力"
+
+#: pcbnew/tool_modedit.cpp:183
+msgid "Place the footprint reference anchor"
+msgstr "フットプリントのアンカー (基準点) を配置"
+
+#: pcbnew/tool_modedit.cpp:212
+msgid "Display Polar Coord ON"
+msgstr "極座標表示 ON"
+
+#: pcbnew/tool_modedit.cpp:224
+msgid "Change Cursor Shape"
+msgstr "カーソルの形を変える"
+
+#: pcbnew/tool_modedit.cpp:229
+msgid "Show Pads Sketch"
+msgstr "パッドのスケッチ表示"
+
+#: pcbnew/tool_modedit.cpp:233
+msgid "Show Texts Sketch"
+msgstr "テキストのスケッチ表示"
+
+#: pcbnew/tool_modedit.cpp:237
+msgid "Show Edges Sketch"
+msgstr "エッジのスケッチ表示"
+
+#: pcbnew/tool_modedit.cpp:241 pcbnew/tool_pcb.cpp:392
+msgid "Enable high contrast display mode"
+msgstr "ハイコントラスト表示モードを有効化"
+
+#: pcbnew/tool_modview.cpp:62
+msgid "Select footprint to browse"
+msgstr "参照するパーツの選択"
+
+#: pcbnew/tool_modview.cpp:67
+msgid "Display previous footprint"
+msgstr "前のフットプリントの表示"
+
+#: pcbnew/tool_modview.cpp:71
+msgid "Display next footprint"
+msgstr "次のフットプリントを表示"
+
+#: pcbnew/tool_modview.cpp:104
+msgid "Insert footprint in board"
+msgstr "ボードへフットプリントを挿入"
+
+#: pcbnew/tool_modview.cpp:151
+msgid "Close footprint viewer"
+msgstr "フットプリントビューアを閉じる"
+
+#: pcbnew/tool_modview.cpp:177
+msgid "3&D Viewer"
+msgstr "3Dビューア(&3)"
+
+#: pcbnew/tool_modview.cpp:189
+msgid "P&cbnew Manual"
+msgstr "Pcbnew マニュアル(&c)"
+
+#: pcbnew/tool_modview.cpp:190
+msgid "Open the Pcbnew manual"
+msgstr "Pcbnew のマニュアルを開く"
+
+#: pcbnew/tool_modview.cpp:201
+msgid "&About Pcbnew"
+msgstr "Pcbnew について(&A)"
+
+#: pcbnew/tool_modview.cpp:202
+msgid "About Pcbnew PCB designer"
+msgstr "Pcbnew PCBデザイナーについて"
+
+#: pcbnew/tool_pcb.cpp:52
+msgid ""
+"Show active layer selections\n"
+"and select layer pair for route and place via"
+msgstr ""
+"ペアレイヤの設定\n"
+"配線及びビア配置に使用するペア層を選択します。"
+
+#: pcbnew/tool_pcb.cpp:220
+msgid "New board"
+msgstr "新規ボード"
+
+#: pcbnew/tool_pcb.cpp:222
+msgid "Open existing board"
+msgstr "既存のボードを開く"
+
+#: pcbnew/tool_pcb.cpp:226
+msgid "Save board"
+msgstr "ボードの保存"
+
+#: pcbnew/tool_pcb.cpp:235
+msgid "Open footprint editor"
+msgstr "フットプリントエディタを開く"
+
+#: pcbnew/tool_pcb.cpp:251
+msgid "Plot (HPGL, PostScript, or GERBER format)"
+msgstr "プロット (HGPL, PostScript, GERBER フォーマット)"
+
+#: pcbnew/tool_pcb.cpp:273
+msgid "Read netlist"
+msgstr "ネットリストの読込み"
+
+#: pcbnew/tool_pcb.cpp:295
+msgid "Mode footprint: manual and automatic movement and placement"
+msgstr "フットプリントモード：手動/自動での配置と移動 "
+
+#: pcbnew/tool_pcb.cpp:298
+msgid "Mode track: autorouting"
+msgstr ""
+"トラック モード\n"
+"自動配線"
+
+#: pcbnew/tool_pcb.cpp:304
+msgid "Fast access to the FreeROUTE external advanced router"
+msgstr "上級なルータであるウェブベースの FreeROUTE へのクイックアクセス"
+
+#: pcbnew/tool_pcb.cpp:335 pcbnew/toolbars_update_user_interface.cpp:136
+msgid "Enable design rule checking"
+msgstr "デザインルール チェックを有効化"
+
+#: pcbnew/tool_pcb.cpp:354 pcbnew/toolbars_update_user_interface.cpp:145
+msgid "Show board ratsnest"
+msgstr "ボードのラッツネストを表示"
+
+#: pcbnew/tool_pcb.cpp:357
+msgid "Show footprint ratsnest when moving"
+msgstr "移動時にフットプリントのラッツネストを表示する"
+
+#: pcbnew/tool_pcb.cpp:363
+msgid "Enable automatic track deletion"
+msgstr "自動的な配線削除を有効化"
+
+#: pcbnew/tool_pcb.cpp:371
+msgid "Do not show filled areas in zones"
+msgstr "ゾーンの塗りつぶし領域を非表示"
+
+#: pcbnew/tool_pcb.cpp:374
+msgid "Show outlines of filled areas only in zones"
+msgstr "ゾーンの塗りつぶし領域をアウトラインで表示"
+
+#: pcbnew/tool_pcb.cpp:383 pcbnew/toolbars_update_user_interface.cpp:176
+msgid "Show vias in outline mode"
+msgstr "アウトライン モードでビアを表示"
+
+#: pcbnew/tool_pcb.cpp:387 pcbnew/toolbars_update_user_interface.cpp:187
+msgid "Show tracks in outline mode"
+msgstr "アウトライン モードで配線を表示"
+
+#: pcbnew/tool_pcb.cpp:436
+msgid "Display local ratsnest"
+msgstr "ローカル ラッツネストの表示"
+
+#: pcbnew/tool_pcb.cpp:507
+msgid "Create line of specified length for microwave applications"
+msgstr "高周波設計用の指定長の線を作成"
+
+#: pcbnew/tool_pcb.cpp:512
+msgid "Create gap of specified length for microwave applications"
+msgstr "高周波設計用の指定長のギャップを作成"
+
+#: pcbnew/tool_pcb.cpp:519
+msgid "Create stub of specified length for microwave applications"
+msgstr "高周波設計用の指定長のスタブを作成"
+
+#: pcbnew/tool_pcb.cpp:524
+msgid "Create stub (arc) of specified length for microwave applications"
+msgstr "高周波設計用の指定長のスタブ (円弧) を作成"
+
+#: pcbnew/tool_pcb.cpp:529
+msgid "Create a polynomial shape for microwave applications"
+msgstr "高周波設計用の多節形を作成"
+
+#: pcbnew/tool_pcb.cpp:593
+msgid ""
+"Auto track width: when starting on an existing track use its width\n"
+"otherwise, use current width setting"
+msgstr ""
+"自動配線幅: \n"
+"既に存在する配線がある場合には、その配線幅を使用します。\n"
+"それ以外の場合には、現在の幅の設定値を使用します。"
+
+#: pcbnew/tool_pcb.cpp:639
+#, c-format
+msgid "Track: %.3f mm (%.2f mils)"
+msgstr "配線: %.3f mm (%.2f mils)"
+
+#: pcbnew/tool_pcb.cpp:642
+#, c-format
+msgid "Track: %.2f mils (%.3f mm)"
+msgstr "配線: %.2f mils (%.3f mm)"
+
+#: pcbnew/tool_pcb.cpp:677
+#, c-format
+msgid "Via: %.2f mm (%.1f mils)"
+msgstr "ビア: %.2f mm (%.1f mils)"
+
+#: pcbnew/tool_pcb.cpp:680
+#, c-format
+msgid "Via: %.1f mils (%.2f mm)"
+msgstr "ビア: %.1f mils (%.2f mm)"
+
+#: pcbnew/tool_pcb.cpp:693
+#, c-format
+msgid "%.2f mm (%.1f mils)"
+msgstr "%.2f mm (%.1f mils)"
+
+#: pcbnew/tool_pcb.cpp:696
+#, c-format
+msgid "%.1f mils (%.2f mm)"
+msgstr "%.1f mils (%.2f mm)"
+
+#: pcbnew/tool_pcb.cpp:721
+msgid "+/- to switch"
+msgstr "+/- でスイッチします"
+
+#: pcbnew/toolbars_update_user_interface.cpp:135
+msgid "Disable design rule checking"
+msgstr "デザインルール チェックを無効化"
+
+#: pcbnew/toolbars_update_user_interface.cpp:144
+msgid "Hide board ratsnest"
+msgstr "ボードのラッツネストを非表示"
+
+#: pcbnew/toolbars_update_user_interface.cpp:155
+msgid "Hide footprint ratsnest"
+msgstr "フットプリントのラッツネストを隠す"
+
+#: pcbnew/toolbars_update_user_interface.cpp:156
+msgid "Show footprint ratsnest"
+msgstr "フットプリントに接続されたラッツネストを表示"
+
+#: pcbnew/toolbars_update_user_interface.cpp:165
+msgid "Disable auto delete old track"
+msgstr "古い配線の自動削除を無効化"
+
+#: pcbnew/toolbars_update_user_interface.cpp:166
+msgid "Enable auto delete old track"
+msgstr "古い配線の自動削除を有効化"
+
+#: pcbnew/toolbars_update_user_interface.cpp:177
+msgid "Show vias in fill mode"
+msgstr "フィル モードでビアを表示"
+
+#: pcbnew/toolbars_update_user_interface.cpp:188
+msgid "Show tracks in fill mode"
+msgstr "フィル モードで配線を表示"
+
+#: pcbnew/toolbars_update_user_interface.cpp:198
+msgid "Normal contrast display mode"
+msgstr "ノーマル コントラスト表示モード"
+
+#: pcbnew/toolbars_update_user_interface.cpp:199
+msgid "High contrast display mode"
+msgstr "ハイコントラスト表示モード"
 
 #: pcbnew/tools/common_actions.cpp:58
 msgid "trivial connection"
@@ -12390,7 +21610,7 @@ msgstr "塗りつぶしゾーンの追加"
 msgid "Add a keepout area"
 msgstr "キープアウト(禁止)エリアの追加"
 
-#: pcbnew/tools/common_actions.cpp:171 pcbnew/tools/drawing_tool.cpp:593
+#: pcbnew/tools/common_actions.cpp:171 pcbnew/tools/drawing_tool.cpp:596
 msgid "Place the footprint anchor"
 msgstr "フットプリントのアンカー (基準点) 入力"
 
@@ -12454,91 +21674,91 @@ msgstr "ゾーンの結合"
 msgid "Add modules"
 msgstr "モジュールの追加"
 
-#: pcbnew/tools/common_actions.cpp:418
+#: pcbnew/tools/common_actions.cpp:422
 msgid "Enumerate pads"
 msgstr "パッドの列挙"
 
-#: pcbnew/tools/common_actions.cpp:422
+#: pcbnew/tools/common_actions.cpp:426
 msgid "Copy items"
 msgstr "アイテムのコピー"
 
-#: pcbnew/tools/common_actions.cpp:426
+#: pcbnew/tools/common_actions.cpp:430
 msgid "Paste items"
 msgstr "アイテムのペースト"
 
-#: pcbnew/tools/common_actions.cpp:506 pcbnew/tools/common_actions.cpp:507
+#: pcbnew/tools/common_actions.cpp:510 pcbnew/tools/common_actions.cpp:511
 msgid "Run push & shove router (single tracks)"
 msgstr "押しのけ配線の実行(単線(シングル))"
 
-#: pcbnew/tools/common_actions.cpp:511 pcbnew/tools/common_actions.cpp:512
+#: pcbnew/tools/common_actions.cpp:515 pcbnew/tools/common_actions.cpp:516
 msgid "Run push & shove router (differential pairs)"
 msgstr "押しのけ配線の実行(差動ペア)"
 
-#: pcbnew/tools/common_actions.cpp:516 pcbnew/tools/common_actions.cpp:517
+#: pcbnew/tools/common_actions.cpp:520 pcbnew/tools/common_actions.cpp:521
 msgid "Open Interactive Router settings"
 msgstr "インタラクティブ配線の設定"
 
-#: pcbnew/tools/common_actions.cpp:521 pcbnew/tools/common_actions.cpp:522
+#: pcbnew/tools/common_actions.cpp:525 pcbnew/tools/common_actions.cpp:526
 msgid "Open Differential Pair Dimension settings"
 msgstr "差動ペアの寸法設定を開く"
 
-#: pcbnew/tools/common_actions.cpp:534
+#: pcbnew/tools/common_actions.cpp:538
 msgid "Tune skew of a differential pair"
 msgstr "差動ペアの遅延(スキュー)調整"
 
-#: pcbnew/tools/common_actions.cpp:547
+#: pcbnew/tools/common_actions.cpp:551
 msgid "Create corner"
 msgstr "角の作成"
 
-#: pcbnew/tools/common_actions.cpp:551
+#: pcbnew/tools/common_actions.cpp:555
 msgid "Remove corner"
 msgstr "角を削除"
 
-#: pcbnew/tools/common_actions.cpp:556
+#: pcbnew/tools/common_actions.cpp:560
 msgid "Align items to the top"
 msgstr "アイテムを上へ整列"
 
-#: pcbnew/tools/common_actions.cpp:557
+#: pcbnew/tools/common_actions.cpp:561
 msgid "Aligns selected items to the top edge"
 msgstr "選択したアイテムを上辺へ整列"
 
-#: pcbnew/tools/common_actions.cpp:561
+#: pcbnew/tools/common_actions.cpp:565
 msgid "Align items to the bottom"
 msgstr "アイテムを下へ整列"
 
-#: pcbnew/tools/common_actions.cpp:562
+#: pcbnew/tools/common_actions.cpp:566
 msgid "Aligns selected items to the bottom edge"
 msgstr "選択したアイテムを下辺へ整列"
 
-#: pcbnew/tools/common_actions.cpp:566
+#: pcbnew/tools/common_actions.cpp:570
 msgid "Align items to the left"
 msgstr "アイテムを左へ整列"
 
-#: pcbnew/tools/common_actions.cpp:567
+#: pcbnew/tools/common_actions.cpp:571
 msgid "Aligns selected items to the left edge"
 msgstr "選択したアイテムを左辺へ整列"
 
-#: pcbnew/tools/common_actions.cpp:571
+#: pcbnew/tools/common_actions.cpp:575
 msgid "Align items to the right"
 msgstr "アイテムを右へ整列"
 
-#: pcbnew/tools/common_actions.cpp:572
+#: pcbnew/tools/common_actions.cpp:576
 msgid "Aligns selected items to the right edge"
 msgstr "選択したアイテムを右辺へ整列"
 
-#: pcbnew/tools/common_actions.cpp:576
+#: pcbnew/tools/common_actions.cpp:580
 msgid "Distribute horizontally"
 msgstr "水平方向に配置"
 
-#: pcbnew/tools/common_actions.cpp:577
+#: pcbnew/tools/common_actions.cpp:581
 msgid "Distributes selected items along the horizontal axis"
 msgstr "選択したアイテムを水平方向に配置"
 
-#: pcbnew/tools/common_actions.cpp:581
+#: pcbnew/tools/common_actions.cpp:585
 msgid "Distribute vertically"
 msgstr "垂直方向に配置"
 
-#: pcbnew/tools/common_actions.cpp:582
+#: pcbnew/tools/common_actions.cpp:586
 msgid "Distributes selected items along the vertical axis"
 msgstr "選択したアイテムを垂直方向に配置"
 
@@ -12555,28 +21775,28 @@ msgstr "コンポーネントの値が削除出来ませんでした。"
 msgid "Duplicated %d item(s)"
 msgstr "重複した%dアイテム"
 
-#: pcbnew/tools/module_tools.cpp:209
+#: pcbnew/tools/module_tools.cpp:229
 msgid "Hold left mouse button and move cursor over pads to enumerate them"
 msgstr "列挙するためにマウスの左ボタンを押したままパッド上へカーソルを動かす"
 
-#: pcbnew/tools/module_tools.cpp:326
+#: pcbnew/tools/module_tools.cpp:346
 msgid "Select reference point"
 msgstr "基準点を選択する"
 
-#: pcbnew/tools/module_tools.cpp:377
+#: pcbnew/tools/module_tools.cpp:397
 #, c-format
 msgid "Copied %d item(s)"
 msgstr "%d のアイテムをコピーしました"
 
-#: pcbnew/tools/module_tools.cpp:401
+#: pcbnew/tools/module_tools.cpp:421
 msgid "Invalid clipboard contents"
 msgstr "不正なクリップボードのデータ"
 
-#: pcbnew/tools/pcbnew_control.cpp:731
+#: pcbnew/tools/pcbnew_control.cpp:735
 msgid "Are you sure you want to delete item?"
 msgstr "本当にアイテムを削除して宜しいですか？"
 
-#: pcbnew/tools/pcbnew_control.cpp:914
+#: pcbnew/tools/pcbnew_control.cpp:918
 msgid "Not available in OpenGL/Cairo canvases."
 msgstr "OpenGL(3D)/Cairo(2D) キャンバスでは無効."
 
@@ -12629,9457 +21849,221 @@ msgstr ", ドリル: "
 msgid "Zoom: %.2f"
 msgstr "ズーム: %.2f"
 
-#: eeschema/annotate.cpp:89
+#: pcbnew/xchgmod.cpp:123
 #, c-format
-msgid "%d duplicate time stamps were found and replaced."
-msgstr "%d 重複したタイムスタンプが見つかり、置き換えられました。"
+msgid "Change footprint of '%s'"
+msgstr "フットプリント '%s' の変更"
 
-#: eeschema/backanno.cpp:225
-msgid "Load Component Footprint Link File"
-msgstr "コンポーネントとフットプリントの関連付けファイルの読み込み"
-
-#: eeschema/backanno.cpp:239
-msgid "Keep existing footprint field visibility"
-msgstr "既存フットプリントのフィールドの表示設定を変更しない"
-
-#: eeschema/backanno.cpp:240
-msgid "Show all footprint fields"
-msgstr "全てのフットプリントフィールドを表示"
-
-#: eeschema/backanno.cpp:241
-msgid "Hide all footprint fields"
-msgstr "全てのフットプリントフィールドを隠す"
-
-#: eeschema/backanno.cpp:243
-msgid "Select the footprint field visibility setting."
-msgstr "フットプリントのフィールドの表示設定を選択する."
-
-#: eeschema/backanno.cpp:244
-msgid "Change Visibility"
-msgstr "表示設定の変更"
-
-#: eeschema/backanno.cpp:255
+#: pcbnew/xchgmod.cpp:131
 #, c-format
-msgid "Failed to open component-footprint link file '%s'"
-msgstr ""
-"コンポーネントとフットプリントの関連付けファイル '%s' が開けませんでした"
+msgid "Change footprints '%s'"
+msgstr "フットプリント '%s' の変更"
 
-#: eeschema/block.cpp:458
-msgid "No item to paste."
-msgstr "ペーストするアイテムがありません！"
-
-#: eeschema/block.cpp:488 eeschema/sheet.cpp:249
+#: pcbnew/xchgmod.cpp:217
 #, c-format
+msgid "File '%s' created\n"
+msgstr "ファイル '%s' が生成されました。\n"
+
+#: pcbnew/xchgmod.cpp:222
+#, c-format
+msgid "** Could not create file '%s' ***\n"
+msgstr "** ファイル '%s' が生成できませんでした ***\n"
+
+#: pcbnew/xchgmod.cpp:282
+#, c-format
+msgid "Change footprint %s -> %s (for value = %s)?"
+msgstr "フットプリントを変更しますか？ %s → %s (値 = %s)"
+
+#: pcbnew/xchgmod.cpp:289
+#, c-format
+msgid "Change footprint %s -> %s ?"
+msgstr "フットプリントを変更しますか？ %s → %s"
+
+#: pcbnew/xchgmod.cpp:344
+msgid "Are you sure you want to change all footprints?"
+msgstr "本当に全てのフットプリントを変更して宜しいですか？"
+
+#: pcbnew/xchgmod.cpp:394
+#, c-format
+msgid "Change footprint '%s' (from '%s') to '%s'"
+msgstr "フットプリント '%s' の値を， '%s' から '%s' に変更"
+
+#: pcbnew/xchgmod.cpp:525
+msgid "No footprints!"
+msgstr "フットプリントがありません！"
+
+#: pcbnew/xchgmod.cpp:536
+msgid "Save Footprint Association File"
+msgstr "フットプリントの関連付けファイルの保存"
+
+#: pcbnew/xchgmod.cpp:547
+#, c-format
+msgid "Could not create file '%s'"
+msgstr "ファイル '%s' が作成できません"
+
+#: pcbnew/zones_by_polygon.cpp:131
 msgid ""
-"The sheet changes cannot be made because the destination sheet already has "
-"the sheet <%s> or one of it's subsheets as a parent somewhere in the "
-"schematic hierarchy."
+"The duplicated zone is on the same layer as the initial zone, which has no "
+"sense.\n"
+"Please, choose an other layer for the new zone"
 msgstr ""
-"シートの変更ができません。保存先のシートは、既にシート <%s> を持っているか、"
-"階層のどこかで親シートとしてサブシートの一つに持っています."
+"重複したゾーンが同じレイヤに既に存在するので、意味がありません.\n"
+"新しいゾーンには別のレイヤを選んでください"
 
-#: eeschema/class_drc_erc_item.cpp:40
-msgid "ERC err unspecified"
-msgstr "不明なERCエラー"
+#: pcbnew/zones_by_polygon.cpp:162
+msgid "The outline of the duplicated zone fails DRC check!"
+msgstr "重複したゾーンの外形線が DRC で不正となりました！"
 
-#: eeschema/class_drc_erc_item.cpp:42
-msgid "Duplicate sheet names within a given sheet"
-msgstr "与えられたシートの中でシート名が重複しています"
+#: pcbnew/zones_by_polygon.cpp:366 pcbnew/zones_by_polygon.cpp:424
+#: pcbnew/zones_by_polygon.cpp:811
+msgid "Area: DRC outline error"
+msgstr "エリア: DRCアウトライン エラー"
 
-#: eeschema/class_drc_erc_item.cpp:44
-msgid "Pin not connected (and no connect symbol found on this pin)"
-msgstr ""
-"ピンは接続されていません (そして、このピンに接続するシンボルが見つかりません)"
-
-#: eeschema/class_drc_erc_item.cpp:46
-msgid "Pin connected to some others pins but no pin to drive it"
-msgstr "ピンは他のピンと接続されていますが、このピンを駆動するピンがありません"
-
-#: eeschema/class_drc_erc_item.cpp:48
-msgid "Conflict problem between pins. Severity: warning"
-msgstr "ピン間の衝突問題。　重大度: 警告"
-
-#: eeschema/class_drc_erc_item.cpp:50
-msgid "Conflict problem between pins. Severity: error"
-msgstr "ピン間の衝突問題。　重大度: エラー"
-
-#: eeschema/class_drc_erc_item.cpp:52
-msgid "Mismatch between hierarchical labels and pins sheets"
-msgstr "階層ラベルとピンシート間のミスマッチ"
-
-#: eeschema/class_drc_erc_item.cpp:54
-msgid "A no connect symbol is connected to more than 1 pin"
-msgstr "未接続シンボルが1つ以上のピンと接続しています"
-
-#: eeschema/class_libentry.cpp:108 eeschema/class_libentry.cpp:268
-msgid "none"
-msgstr "なし"
-
-#: eeschema/class_libentry.cpp:531
-#, c-format
-msgid ""
-"An attempt was made to remove the %s field from component %s in library %s."
-msgstr ""
-"フィールド %s は、コンポーネント %s  (ライブラリ %s 中) から削除されようとし"
-"ています。"
-
-#: eeschema/class_library.cpp:53
-#, c-format
-msgid ""
-"Library '%s' has duplicate entry name '%s'.\n"
-"This may cause some unexpected behavior when loading components into a "
-"schematic."
-msgstr ""
-"ライブラリ '%s' は重複するエントリ名 '%s' を持っています。\n"
-"回路図にコンポーネントを読み込む際に予期せぬ動作が発生する可能性があります。"
-
-#: eeschema/class_library.cpp:300
-#, c-format
-msgid "Cannot add duplicate alias '%s' to library '%s'."
-msgstr "重複したエイリアス'%s'をライブラリ'%s'に追加できません。"
-
-#: eeschema/class_library.cpp:467
-msgid "The component library file name is not set."
-msgstr "コンポーネント ライブラリ ファイル名がセットされていません。"
-
-#: eeschema/class_library.cpp:475
-msgid "The file could not be opened."
-msgstr "そのファイルは開けません。"
-
-#: eeschema/class_library.cpp:483
-msgid "The file is empty!"
-msgstr "ファイルが空です！"
-
-#: eeschema/class_library.cpp:508
-msgid "The file is NOT an Eeschema library!"
-msgstr "このファイルは Eeschema ライブラリではありません"
-
-#: eeschema/class_library.cpp:514
-msgid "The file header is missing version and time stamp information."
-msgstr "ファイルのヘッダからバージョンとタイムスタンプの情報が失われています。"
-
-#: eeschema/class_library.cpp:558
-msgid "An error occurred attempting to read the header."
-msgstr "ヘッダの読込み中にエラーが発生しました。"
-
-#: eeschema/class_library.cpp:587
-#, c-format
-msgid "Library '%s' component load error %s."
-msgstr "ライブラリ '%s' コンポーネント読込みエラー %s。"
-
-#: eeschema/class_library.cpp:660
-#, c-format
-msgid "Could not open component document library file '%s'."
-msgstr "コンポーネント ドキュメント ライブラリ ファイル '%s' を開けません."
-
-#: eeschema/class_library.cpp:667
-#, c-format
-msgid "Part document library file '%s' is empty."
-msgstr "コンポーネントのドキュメント ライブラリ ファイル '%s' が空です。"
-
-#: eeschema/class_library.cpp:675
-#, c-format
-msgid "File '%s' is not a valid component library document file."
-msgstr ""
-"ファイル '%s' は不正なコンポーネント ライブラリ ドキュメント ファイルです。"
-
-#: eeschema/class_library.cpp:1074
-#, c-format
-msgid "Unable to load project's '%s' file"
-msgstr "プロジェクト '%s' をロードできません"
-
-#: eeschema/class_library.cpp:1165
-#, c-format
-msgid ""
-"Part library '%s' failed to load. Error:\n"
-"%s"
-msgstr ""
-"パーツライブラリ '%s' の読み込みに失敗しました。エラー:\n"
-"%s"
-
-#: eeschema/class_library.cpp:1190
-#, c-format
-msgid ""
-"Part library '%s' failed to load.\n"
-"Error: %s"
-msgstr ""
-"パーツライブラリ '%s' の読み込みに失敗しました。エラー:\n"
-"エラー: %s"
-
-#: eeschema/component_references_lister.cpp:521
-#, c-format
-msgid "Item not annotated: %s%s (unit %d)\n"
-msgstr "次のアイテムがアノテートされませんでした: %s%s (ユニット %d)\n"
-
-#: eeschema/component_references_lister.cpp:528
-#, c-format
-msgid "Item not annotated: %s%s\n"
-msgstr "次のアイテムがアノテートされませんでした: %s%s\n"
-
-#: eeschema/component_references_lister.cpp:551
-#, c-format
-msgid "Error item %s%s unit %d and no more than %d parts\n"
-msgstr "エラー : アイテム %s%s ユニット %d は %d パーツしかありません\n"
-
-#: eeschema/component_references_lister.cpp:591
-#: eeschema/component_references_lister.cpp:623
-#, c-format
-msgid "Multiple item %s%s (unit %d)\n"
-msgstr "複数のアイテム %s%s (ユニット %d)\n"
-
-#: eeschema/component_references_lister.cpp:598
-#: eeschema/component_references_lister.cpp:630
-#, c-format
-msgid "Multiple item %s%s\n"
-msgstr "複数のアイテム %s%s\n"
-
-#: eeschema/component_references_lister.cpp:646
-#, c-format
-msgid "Different values for %s%d%s (%s) and %s%d%s (%s)"
-msgstr "値に相違があります %s%d%s (%s) :: %s%d%s (%s)"
-
-#: eeschema/component_references_lister.cpp:681
-#, c-format
-msgid "Duplicate time stamp (%s) for %s%d and %s%d"
-msgstr "重複するタイムスタンプ - (%s) %s%d と %s%d のもの"
-
-#: eeschema/controle.cpp:165 eeschema/libeditframe.cpp:1257
-msgid "Clarify Selection"
-msgstr "明示的な選択:"
-
-#: eeschema/edit_bitmap.cpp:103 bitmap2component/bitmap2cmp_gui.cpp:271
-#: pagelayout_editor/pl_editor_frame.cpp:635
-msgid "Choose Image"
-msgstr "イメージの選択"
-
-#: eeschema/edit_bitmap.cpp:104 bitmap2component/bitmap2cmp_gui.cpp:272
-#: pagelayout_editor/pl_editor_frame.cpp:636
-msgid "Image Files "
-msgstr "画像ファイル"
-
-#: eeschema/edit_bitmap.cpp:115 eeschema/edit_bitmap.cpp:125
-#: pagelayout_editor/pl_editor_frame.cpp:646
-#: pagelayout_editor/pl_editor_frame.cpp:653
-#, c-format
-msgid "Couldn't load image from <%s>"
-msgstr "<%s> からイメージを読み込むことが出来ません。"
-
-#: eeschema/edit_component_in_schematic.cpp:73
-#, c-format
-msgid "Edit %s Field"
-msgstr "フィールド %s の編集"
-
-#: eeschema/edit_component_in_schematic.cpp:108
-msgid "Illegal reference string!  No change"
-msgstr "無効なリファレンス文字です! 変更されません"
-
-#: eeschema/edit_component_in_schematic.cpp:117
-msgid "The reference field cannot be empty!  No change"
-msgstr "リファレンス フィールドは空にできません! 変更されません"
-
-#: eeschema/edit_component_in_schematic.cpp:127
-msgid "The value field cannot be empty!  No change"
-msgstr "定数のフィールドは空にできません。"
-
-#: eeschema/erc.cpp:89
-msgid "Input Pin.........."
-msgstr "入力ピン.........."
-
-#: eeschema/erc.cpp:90
-msgid "Output Pin........."
-msgstr "出力ピン........."
-
-#: eeschema/erc.cpp:91
-msgid "Bidirectional Pin.."
-msgstr "双方向ピン.."
-
-#: eeschema/erc.cpp:92
-msgid "Tri-State Pin......"
-msgstr "トライステートピン......"
-
-#: eeschema/erc.cpp:93
-msgid "Passive Pin........"
-msgstr "受動ピン........"
-
-#: eeschema/erc.cpp:94
-msgid "Unspecified Pin...."
-msgstr "指定なしピン...."
-
-#: eeschema/erc.cpp:95
-msgid "Power Input Pin...."
-msgstr "電源入力ピン...."
-
-#: eeschema/erc.cpp:96
-msgid "Power Output Pin..."
-msgstr "電源出力ピン..."
-
-#: eeschema/erc.cpp:97
-msgid "Open Collector....."
-msgstr "オープンコレクタ....."
-
-#: eeschema/erc.cpp:98
-msgid "Open Emitter......."
-msgstr "オープンエミッタ....."
-
-#: eeschema/erc.cpp:99
-msgid "No Connection......"
-msgstr "未接続....."
-
-#: eeschema/erc.cpp:105
-msgid "Input Pin"
-msgstr "入力ピン"
-
-#: eeschema/erc.cpp:106
-msgid "Output Pin"
-msgstr "出力ピン"
-
-#: eeschema/erc.cpp:107
-msgid "Bidirectional Pin"
-msgstr "双方向ピン"
-
-#: eeschema/erc.cpp:108
-msgid "Tri-State Pin"
-msgstr "トライステートピン"
-
-#: eeschema/erc.cpp:109
-msgid "Passive Pin"
-msgstr "受動ピン"
-
-#: eeschema/erc.cpp:110
-msgid "Unspecified Pin"
-msgstr "指定なしピン"
-
-#: eeschema/erc.cpp:111
-msgid "Power Input Pin"
-msgstr "電源入力ピン"
-
-#: eeschema/erc.cpp:112
-msgid "Power Output Pin"
-msgstr "電源出力ピン"
-
-#: eeschema/erc.cpp:113
-msgid "Open Collector"
-msgstr "オープンコレクタ"
-
-#: eeschema/erc.cpp:114
-msgid "Open Emitter"
-msgstr "オープンエミッタ"
-
-#: eeschema/erc.cpp:115
-msgid "No Connection"
-msgstr "未接続"
-
-#: eeschema/erc.cpp:209
-msgid "Duplicate sheet name"
-msgstr "シート名の重複"
-
-#: eeschema/erc.cpp:252
-#, c-format
-msgid "Hierarchical label %s is not connected to a sheet label."
-msgstr "階層ラベル %s がシートラベルに接続されていません"
-
-#: eeschema/erc.cpp:257
-#, c-format
-msgid "Sheet label %s is not connected to a hierarchical label."
-msgstr "シートラベル %s が階層ラベルに接続されていません。"
-
-#: eeschema/erc.cpp:285
-#, c-format
-msgid "Pin %s (%s) of component %s is unconnected."
-msgstr "ピン %s (%s) (コンポーネント %s) が接続されていません。"
-
-#: eeschema/erc.cpp:302
-#, c-format
-msgid "Pin %s (%s) of component %s is not driven (Net %d)."
-msgstr "ピン %s (%s) (コンポーネント %s) は駆動されていません。(Net %d)"
-
-#: eeschema/erc.cpp:316
-msgid "More than 1 pin connected to an UnConnect symbol."
-msgstr "1つ以上のピンが空き端子フラグに接続しています"
-
-#: eeschema/erc.cpp:344
-#, c-format
-msgid "Pin %s (%s) of component %s is connected to "
-msgstr "ピン %s (%s) (コンポーネント %s) が次に接続されています。"
-
-#: eeschema/erc.cpp:349
-#, c-format
-msgid "pin %s (%s) of component %s (net %d)."
-msgstr "ピン %s (%s) コンポーネント %s (ネット %d)."
-
-#: eeschema/erc.cpp:522
-msgid "ERC report"
-msgstr "ERC レポート"
-
-#: eeschema/erc.cpp:524
-msgid "Encoding UTF8"
-msgstr "UTF8 でエンコード"
-
-#: eeschema/erc.cpp:534
-#, c-format
-msgid ""
-"\n"
-"***** Sheet %s\n"
-msgstr ""
-"\n"
-"***** シート %s\n"
-
-#: eeschema/erc.cpp:559
-#, c-format
-msgid ""
-"\n"
-" ** ERC messages: %d  Errors %d  Warnings %d\n"
-msgstr ""
-"\n"
-" ** ERC メッセージ: %d  エラー %d  警告 %d\n"
-
-#: eeschema/files-io.cpp:68
-msgid "Schematic Files"
-msgstr "回路図ファイル"
-
-#: eeschema/files-io.cpp:98
-#, c-format
-msgid "Could not save backup of file '%s'"
-msgstr "ファイル '%s' のバックアップを保存できません"
-
-#: eeschema/files-io.cpp:112
-#: eeschema/netlist_exporters/netlist_exporter_cadstar.cpp:48
-#: eeschema/netlist_exporters/netlist_exporter_orcadpcb2.cpp:51
-#: eeschema/netlist_exporters/netlist_exporter_pspice.cpp:61
-#, c-format
-msgid "Failed to create file '%s'"
-msgstr "ファイルの作成に失敗しました '%s'"
-
-#: eeschema/files-io.cpp:141
-#, c-format
-msgid "File %s saved"
-msgstr "ファイル %s を保存しました"
-
-#: eeschema/files-io.cpp:146
-msgid "File write operation failed."
-msgstr "ファイルの書き込みに失敗しました。"
-
-#: eeschema/files-io.cpp:200
-#, c-format
-msgid "Schematic file '%s' is already open."
-msgstr "この回路図ファイル '%s' は既に開かれています。"
-
-#: eeschema/files-io.cpp:213
-msgid ""
-"The current schematic has been modified.  Do you wish to save the changes?"
-msgstr "現在の回路図は変更されています。変更を保存しますか？"
-
-#: eeschema/files-io.cpp:246
-#, c-format
-msgid "Schematic '%s' does not exist.  Do you wish to create it?"
-msgstr "回路図 '%s' は存在しません。新規作成しますか?"
-
-#: eeschema/files-io.cpp:268
-#, c-format
-msgid ""
-"Ready\n"
-"Project dir: '%s'\n"
-msgstr ""
-"準備完了\n"
-"作業中のディレクトリ: '%s'\n"
-
-#: eeschema/files-io.cpp:353
-msgid "Import Schematic"
-msgstr "回路図のインポート"
-
-#: eeschema/files-io.cpp:463
-msgid ""
-"This operation cannot be undone. Besides, take into account that "
-"hierarchical sheets will not be appended.\n"
-"\n"
-"Do you want to save the current document before proceeding?"
-msgstr ""
-"この操作はやり直しができません．しかも，階層化された回路図は追加できないこと"
-"に注意してください．\n"
-"\n"
-"操作を続行する前に現在の作業内容を保存しますか？"
-
-#: eeschema/files-io.cpp:487
-#, c-format
-msgid "Directory '%s' is not writable"
-msgstr "ディレクトリ '%s' は書き込み禁止されています"
-
-#: eeschema/find.cpp:100
-#, c-format
-msgid "Design rule check marker found in sheet %s at %0.3f%s, %0.3f%s"
-msgstr ""
-"シート %s の %0.3f%s, %0.3f%s にデザイン ルール チェック マーカーが見つかりま"
-"した。"
-
-#: eeschema/find.cpp:106
-msgid "No more markers were found."
-msgstr "これ以上マーカーは見つかりませんでした。"
-
-#: eeschema/find.cpp:243
-msgid "component"
-msgstr "コンポーネント"
-
-#: eeschema/find.cpp:247
-#, c-format
-msgid "pin %s"
-msgstr "ピン %s"
-
-#: eeschema/find.cpp:251
-#, c-format
-msgid "reference %s"
-msgstr "リファレンス %s"
-
-#: eeschema/find.cpp:255
-msgid "value"
-msgstr "定数"
-
-#: eeschema/find.cpp:259
-msgid "field"
-msgstr "フィールド"
-
-#: eeschema/find.cpp:267
-#, c-format
-msgid "%s %s found"
-msgstr "%s  %s が見つかりました"
-
-#: eeschema/find.cpp:272
-#, c-format
-msgid "%s found but %s not found"
-msgstr "%s が見つかりましたが %s が見つかりません"
-
-#: eeschema/find.cpp:278
-#, c-format
-msgid "Component %s not found"
-msgstr "コンポーネント %s が見つかりません"
-
-#: eeschema/find.cpp:473
-#, c-format
-msgid "No item found matching %s."
-msgstr "%s にマッチするアイテムは見つかりませんでした。"
-
-#: eeschema/getpart.cpp:152
-msgid "History"
-msgstr "履歴"
-
-#: eeschema/getpart.cpp:158
-#, c-format
-msgid "Choose Component (%d items loaded)"
-msgstr "コンポーネントの選択 (%d アイテムが読込まれています)"
-
-#: eeschema/getpart.cpp:216
-#, c-format
-msgid "Failed to find part '%s' in library"
-msgstr "ライブラリ中にコンポーネント '%s' が見つかりませんでした"
-
-#: eeschema/hierarch.cpp:147
-msgid "Navigator"
-msgstr "ナビゲータ"
-
-#: eeschema/hierarch.cpp:157
-msgid "Root"
-msgstr "ルート"
-
-#: eeschema/hotkeys.cpp:735
-msgid "Add Pin"
-msgstr "ピンの追加"
-
-#: eeschema/lib_arc.cpp:136
-#, c-format
-msgid "Arc only had %d parameters of the required 8"
-msgstr "円弧は8個のパラメータが必要ですが、%d個しか定義されていません。"
-
-#: eeschema/lib_arc.cpp:565 eeschema/lib_bezier.cpp:417
-#: eeschema/lib_circle.cpp:279 eeschema/lib_polyline.cpp:409
-#: eeschema/lib_rectangle.cpp:256 eeschema/lib_text.cpp:424
-#: pcb_calculator/transline_ident.cpp:186
-#: pcb_calculator/transline_ident.cpp:216
-#: pcb_calculator/transline_ident.cpp:248
-#: pcb_calculator/transline_ident.cpp:353
-#: pcb_calculator/transline_ident.cpp:388
-msgid "Line Width"
-msgstr "線幅"
-
-#: eeschema/lib_arc.cpp:570 eeschema/lib_bezier.cpp:422
-#: eeschema/lib_circle.cpp:287 eeschema/lib_polyline.cpp:414
-msgid "Bounding Box"
-msgstr "バウンディング ボックス"
-
-#: eeschema/lib_arc.cpp:576
-#, c-format
-msgid "Arc center (%s, %s), radius %s"
-msgstr "円弧 中心 (%s, %s) 半径 %s"
-
-#: eeschema/lib_bezier.cpp:51
-msgid "Bezier"
-msgstr "ベジェ曲線"
-
-#: eeschema/lib_bezier.cpp:83
-#, c-format
-msgid "Bezier only had %d parameters of the required 4"
-msgstr "ベジェ曲線には4つのパラメータが必要ですが %d しかありません"
-
-#: eeschema/lib_bezier.cpp:89
-#, c-format
-msgid "Bezier count parameter %d is invalid"
-msgstr "ベジェ曲線の %d 番目のパラメータが不正です"
-
-#: eeschema/lib_bezier.cpp:105
-#, c-format
-msgid "Bezier point %d X position not defined"
-msgstr "ベジェ曲線の %d ポイントのX座標が定義されていません"
-
-#: eeschema/lib_bezier.cpp:113
-#, c-format
-msgid "Bezier point %d Y position not defined"
-msgstr "ベジェ曲線の %d ポイントのY座標が定義されていません"
-
-#: eeschema/lib_circle.cpp:76
-#, c-format
-msgid "Circle only had %d parameters of the required 6"
-msgstr "円は6個のパラメータが必要ですが、%d個しか定義されていません。"
-
-#: eeschema/lib_circle.cpp:282
-msgid "Radius"
-msgstr "半径"
-
-#: eeschema/lib_circle.cpp:293
-#, c-format
-msgid "Circle center (%s, %s), radius %s"
-msgstr "円 中心 (%s, %s) 半径 %s"
-
-#: eeschema/lib_draw_item.cpp:55
-msgid "Undefined"
-msgstr "未定義"
-
-#: eeschema/lib_draw_item.cpp:68 eeschema/lib_draw_item.cpp:75
-msgid "All"
-msgstr "全て"
-
-#: eeschema/lib_draw_item.cpp:77
-msgid "no"
-msgstr "いいえ"
-
-#: eeschema/lib_draw_item.cpp:79
-msgid "yes"
-msgstr "はい"
-
-#: eeschema/lib_draw_item.cpp:83 eeschema/libedit.cpp:496
-#: eeschema/onrightclick.cpp:440
-msgid "Convert"
-msgstr "シンボル変換"
-
-#: eeschema/lib_export.cpp:51
-msgid "Import Component"
-msgstr "コンポーネントのインポート"
-
-#: eeschema/lib_export.cpp:70
-#, c-format
-msgid ""
-"Unable to import library '%s'.  Error:\n"
-"%s"
-msgstr ""
-"ライブラリ '%s' の読込みに失敗しました。\n"
-"エラー: %s"
-
-#: eeschema/lib_export.cpp:84
-#, c-format
-msgid "Part library file '%s' is empty."
-msgstr "コンポーネント ライブラリ ファイル '%s' は空です。"
-
-#: eeschema/lib_export.cpp:111
-msgid "There is no component selected to save."
-msgstr "保存するコンポーネントが選択されていません。"
-
-#: eeschema/lib_export.cpp:119
-msgid "New Library"
-msgstr "新規ライブラリ"
-
-#: eeschema/lib_export.cpp:119
-msgid "Export Component"
-msgstr "コンポーネントのエクスポート"
-
-#: eeschema/lib_export.cpp:174
-#, c-format
-msgid "'%s' - OK"
-msgstr "'%s' - OK"
-
-#: eeschema/lib_export.cpp:176
-msgid ""
-"This library will not be available until it is loaded by Eeschema.\n"
-"\n"
-"Modify the Eeschema library configuration if you want to include it as part "
-"of this project."
-msgstr ""
-"このライブラリは Eeschema に読込まれるまで使用できません。\n"
-"\n"
-"このプロジェクトのパーツとして取り込む場合は Eeschema のライブラリ設定を変更"
-"してください。"
-
-#: eeschema/lib_export.cpp:182
-#, c-format
-msgid "'%s' - Export OK"
-msgstr "'%s' - エクスポートOK"
-
-#: eeschema/lib_export.cpp:187
-#, c-format
-msgid "Error creating '%s'"
-msgstr "ファイル '%s' 生成時エラー"
-
-#: eeschema/lib_field.cpp:72 eeschema/lib_field.cpp:756
-#: eeschema/template_fieldnames.cpp:55
-msgid "Field"
-msgstr "フィールド"
-
-#: eeschema/lib_field.cpp:595 eeschema/libedit.cpp:510
-#: eeschema/template_fieldnames.cpp:48
-msgid "Datasheet"
-msgstr "データシート"
-
-#: eeschema/lib_field.cpp:604
-#, c-format
-msgid "Field%d"
-msgstr "フィールド%d"
-
-#: eeschema/lib_field.cpp:667
-#, c-format
-msgid "Field %s %s"
-msgstr "フィールド %s %s"
-
-#: eeschema/lib_pin.cpp:168 eeschema/dialogs/dialog_edit_label_base.cpp:70
-#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:53
-msgid "Up"
-msgstr "上へ"
-
-#: eeschema/lib_pin.cpp:169 eeschema/dialogs/dialog_edit_label_base.cpp:70
-#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:56
-msgid "Down"
-msgstr "下へ"
-
-#: eeschema/lib_pin.cpp:183 eeschema/sch_text.cpp:777
-#: eeschema/dialogs/dialog_edit_label_base.cpp:82
-#: eeschema/dialogs/dialog_sch_edit_sheet_pin.cpp:30
-msgid "Input"
-msgstr "入力"
-
-#: eeschema/lib_pin.cpp:184 eeschema/sch_text.cpp:778
-#: eeschema/dialogs/dialog_edit_label_base.cpp:82
-#: eeschema/dialogs/dialog_sch_edit_sheet_pin.cpp:31
-msgid "Output"
-msgstr "出力"
-
-#: eeschema/lib_pin.cpp:185 eeschema/sch_text.cpp:779
-#: eeschema/dialogs/dialog_edit_label_base.cpp:82
-#: eeschema/dialogs/dialog_sch_edit_sheet_pin.cpp:32
-msgid "Bidirectional"
-msgstr "双方向"
-
-#: eeschema/lib_pin.cpp:186 eeschema/dialogs/dialog_sch_edit_sheet_pin.cpp:33
-msgid "Tri-state"
-msgstr "トライステート"
-
-#: eeschema/lib_pin.cpp:187 eeschema/sch_text.cpp:781
-#: eeschema/dialogs/dialog_edit_label_base.cpp:82
-#: eeschema/dialogs/dialog_sch_edit_sheet_pin.cpp:34
-msgid "Passive"
-msgstr "パッシブ"
-
-#: eeschema/lib_pin.cpp:188
-msgid "Unspecified"
-msgstr "不特定"
-
-#: eeschema/lib_pin.cpp:189
-msgid "Power input"
-msgstr "電源入力"
-
-#: eeschema/lib_pin.cpp:190
-msgid "Power output"
-msgstr "電源出力"
-
-#: eeschema/lib_pin.cpp:191
-msgid "Open collector"
-msgstr "オープンコレクタ"
-
-#: eeschema/lib_pin.cpp:192
-msgid "Open emitter"
-msgstr "オープンエミッタ"
-
-#: eeschema/lib_pin.cpp:193
-msgid "Not connected"
-msgstr "未接続"
-
-#: eeschema/lib_pin.cpp:208
-msgid "Inverted"
-msgstr "反転"
-
-#: eeschema/lib_pin.cpp:209
-msgid "Clock"
-msgstr "クロック"
-
-# 8973～8988要確認
-#: eeschema/lib_pin.cpp:210
-msgid "Inverted clock"
-msgstr "反転クロック"
-
-#: eeschema/lib_pin.cpp:211
-msgid "Input low"
-msgstr "負論理入力"
-
-#: eeschema/lib_pin.cpp:212
-msgid "Clock low"
-msgstr "負論理クロック"
-
-#: eeschema/lib_pin.cpp:213
-msgid "Output low"
-msgstr "負論理出力"
-
-#: eeschema/lib_pin.cpp:214
-msgid "Falling edge clock"
-msgstr "ネガティブエッジ クロック"
-
-#: eeschema/lib_pin.cpp:215
-msgid "NonLogic"
-msgstr "非ロジック"
-
-#: eeschema/lib_pin.cpp:255 eeschema/dialogs/dialog_color_config.cpp:75
-msgid "Pin"
-msgstr "ピン"
-
-#: eeschema/lib_pin.cpp:1984 eeschema/dialogs/dialog_lib_edit_pin_table.cpp:144
-msgid "Number"
-msgstr "ピン番号"
-
-#: eeschema/lib_pin.cpp:2269
-#, c-format
-msgid "Pin %s, %s, %s"
-msgstr "ピン %s, %s, %s"
-
-#: eeschema/lib_polyline.cpp:53
-msgid "PolyLine"
-msgstr "ポリライン"
-
-#: eeschema/lib_polyline.cpp:88
-#, c-format
-msgid "Polyline only had %d parameters of the required 4"
-msgstr "ポリラインは4個のパラメータが必要ですが、%d個しか定義されていません。"
-
-#: eeschema/lib_polyline.cpp:94
-#, c-format
-msgid "Polyline count parameter %d is invalid"
-msgstr "ポリラインのカウントパラメータ %d が不正です"
-
-#: eeschema/lib_polyline.cpp:110
-#, c-format
-msgid "Polyline point %d X position not defined"
-msgstr "ポリラインの座標点%dのX座標は定義されていません"
-
-#: eeschema/lib_polyline.cpp:118
-#, c-format
-msgid "Polyline point %d Y position not defined"
-msgstr "ポリラインの座標点%dのY座標は定義されていません"
-
-#: eeschema/lib_polyline.cpp:420
-#, c-format
-msgid "Polyline at (%s, %s) with %zu points"
-msgstr "ポリライン (%s, %s)  %zu 個の構成点"
-
-#: eeschema/lib_rectangle.cpp:51
-msgid "Rectangle"
-msgstr "矩形"
-
-#: eeschema/lib_rectangle.cpp:78
-#, c-format
-msgid "Rectangle only had %d parameters of the required 7"
-msgstr "矩形には7つのパラメータが必要ですが %d しかありません"
-
-#: eeschema/lib_rectangle.cpp:332
-#, c-format
-msgid "Rectangle from (%s, %s) to (%s, %s)"
-msgstr "矩形 始点 (%s, %s) 終点 (%s, %s)"
-
-#: eeschema/lib_text.cpp:132
-#, c-format
-msgid "Text only had %d parameters of the required 8"
-msgstr "テキストには8個のパラメータが必要ですが、%d個しか定義されていません。"
-
-#: eeschema/lib_text.cpp:485 eeschema/sch_text.cpp:603
-#, c-format
-msgid "Graphic Text %s"
-msgstr "図形テキスト %s"
-
-#: eeschema/libarch.cpp:101 eeschema/project_rescue.cpp:61
-#, c-format
-msgid "An error occurred attempting to save component library '%s'."
-msgstr ""
-"コンポーネント ライブラリ '%s' を保存しようとしたところエラーが発生しました。"
-
-#: eeschema/libarch.cpp:111 eeschema/libedit.cpp:406
-#: eeschema/project_rescue.cpp:71
-#, c-format
-msgid "Failed to create component library file '%s'"
-msgstr "コンポーネントライブラリファイル '%s' が作成できませんでした。"
-
-#: eeschema/libedit.cpp:53
-msgid "Part Library Editor: "
-msgstr "コンポーネントライブラリエディタ:"
-
-#: eeschema/libedit.cpp:89 eeschema/libedit.cpp:120
-msgid ""
-"The current component is not saved.\n"
-"\n"
-"Discard current changes?"
-msgstr ""
-"現在のパーツは保存されていません。\n"
-"\n"
-"現在の変更を破棄しますか？"
-
-#: eeschema/libedit.cpp:168
-msgid "The selected component is not in the active library."
-msgstr "選択されたコンポーネントは、アクティブなライブラリ中にありません."
-
-#: eeschema/libedit.cpp:170
-msgid "Do you want to change the active library?"
-msgstr "アクティブなライブラリを変更して宜しいですか？"
-
-#: eeschema/libedit.cpp:180
-#, c-format
-msgid "Part name '%s' not found in library '%s'"
-msgstr "コンポーネント名 \"%s\" はライブラリ \"%s\" 中に見つかりませんでした。"
-
-#: eeschema/libedit.cpp:315 eeschema/libeditframe.cpp:737
-msgid "No library specified."
-msgstr "指定されたライブラリがありません。"
-
-#: eeschema/libedit.cpp:321
-msgid "Include last component changes?"
-msgstr "最後のコンポーネントの変更を含めますか？"
-
-#: eeschema/libedit.cpp:336
-msgid "Part Library Name:"
-msgstr "コンポーネントライブラリ名:"
-
-#: eeschema/libedit.cpp:356
-#, c-format
-msgid "Modify library file '%s' ?"
-msgstr "ライブラリファイル '%s' を変更しますか?"
-
-#: eeschema/libedit.cpp:396
-#, c-format
-msgid "Error occurred while saving library file '%s'"
-msgstr "ライブラリファイル '%s' の保存中にエラーが発生しました"
-
-#: eeschema/libedit.cpp:398 eeschema/libedit.cpp:440
-msgid "*** ERROR: ***"
-msgstr "***エラー: ***"
-
-#: eeschema/libedit.cpp:438
-#, c-format
-msgid "Error occurred while saving library documentation file <%s>"
-msgstr "ライブラリドキュメントファイル <%s> の保存中にエラーが発生しました"
-
-#: eeschema/libedit.cpp:448
-#, c-format
-msgid "Failed to create component document library file <%s>"
-msgstr ""
-"コンポーネントのドキュメントライブラリファイル <%s> が作成できませんでした"
-
-#: eeschema/libedit.cpp:454
-#, c-format
-msgid "Library file '%s' OK"
-msgstr "ライブラリファイル '%s' : OK"
-
-#: eeschema/libedit.cpp:457
-#, c-format
-msgid "Documentation file '%s' OK"
-msgstr "ドキュメントファイル '%s' OK"
-
-#: eeschema/libedit.cpp:488 eeschema/viewlibs.cpp:307
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:202
-msgid "Alias"
-msgstr "エイリアス"
-
-#: eeschema/libedit.cpp:500 eeschema/dialogs/dialog_color_config.cpp:73
-msgid "Body"
-msgstr "ボディ形状"
-
-#: eeschema/libedit.cpp:503
-msgid "Power Symbol"
-msgstr "電源シンボル"
-
-#: eeschema/libedit.cpp:505 eeschema/viewlibs.cpp:306
-msgid "Part"
-msgstr "パーツ"
-
-#: eeschema/libedit.cpp:509 eeschema/viewlibs.cpp:309
-msgid "Key words"
-msgstr "キーワード"
-
-#: eeschema/libedit.cpp:535
-msgid "Please select a component library."
-msgstr "コンポーネント ライブラリを選択してください"
-
-#: eeschema/libedit.cpp:544
-#, c-format
-msgid "Part library '%s' is empty."
-msgstr "コンポーネント ライブラリ '%s' は空です。"
-
-#: eeschema/libedit.cpp:545
-msgid "Delete Entry Error"
-msgstr "Delete Entry エラー"
-
-#: eeschema/libedit.cpp:549
-#, c-format
-msgid ""
-"Select one of %zu components to delete\n"
-"from library '%s'."
-msgstr ""
-"削除するコンポーネント(1 of %zu )を選択\n"
-"(ライブラリ '%s' )."
-
-#: eeschema/libedit.cpp:553
-msgid "Delete Part"
-msgstr "コンポーネントの削除"
-
-#: eeschema/libedit.cpp:562
-#, c-format
-msgid "Entry '%s' not found in library '%s'."
-msgstr "エントリー '%s' が ライブラリ '%s' 中に存在しません。"
-
-#: eeschema/libedit.cpp:569
-#, c-format
-msgid "Delete component '%s' from library '%s' ?"
-msgstr "コンポーネント '%s' をライブラリ '%s' から削除して宜しいですか？"
-
-#: eeschema/libedit.cpp:588
-msgid ""
-"The component being deleted has been modified. All changes will be lost. "
-"Discard changes?"
-msgstr ""
-"削除しようとしているコンポーネントは編集されています。全ての変更が失われま"
-"す。変更を取りやめますか？"
-
-#: eeschema/libedit.cpp:617
-msgid ""
-"All changes to the current component will be lost!\n"
-"\n"
-"Clear the current component from the screen?"
-msgstr ""
-"現在のコンポーネントの全ての変更が失われます!\n"
-"\n"
-"スクリーンから現在のコンポーネントをクリアしますか？"
-
-#: eeschema/libedit.cpp:636
-msgid "This new component has no name and cannot be created. Aborted"
-msgstr "この新しいコンポーネントは名前がなく、作成できませんでした。中止"
-
-#: eeschema/libedit.cpp:649
-#, c-format
-msgid "Part '%s' already exists in library '%s'"
-msgstr "コンポーネント '%s' は既にライブラリ '%s' 内に既に存在します。"
-
-#: eeschema/libedit.cpp:721
-#, c-format
-msgid "Part '%s' already exists. Change it?"
-msgstr "コンポーネント '%s' は既に存在します。変更して宜しいですか？"
-
-#: eeschema/libedit.cpp:735
-#, c-format
-msgid "Part '%s' saved in library '%s'"
-msgstr "コンポーネント '%s' がライブラリ '%s' 内に保存されました"
-
-#: eeschema/libedit_onrightclick.cpp:118
-msgid "Move Arc"
-msgstr "円弧の移動"
-
-#: eeschema/libedit_onrightclick.cpp:122
-msgid "Drag Arc Size"
-msgstr "円弧サイズのドラッグ"
-
-#: eeschema/libedit_onrightclick.cpp:126
-msgid "Edit Arc Options"
-msgstr "円弧オプションの編集"
-
-#: eeschema/libedit_onrightclick.cpp:131
-msgid "Delete Arc"
-msgstr "円弧の削除"
-
-#: eeschema/libedit_onrightclick.cpp:139
-msgid "Move Circle"
-msgstr "円の移動"
-
-#: eeschema/libedit_onrightclick.cpp:143
-msgid "Drag Circle Outline"
-msgstr "円のアウトラインをドラッグ"
-
-#: eeschema/libedit_onrightclick.cpp:148
-msgid "Edit Circle Options"
-msgstr "円のオプションを編集"
-
-#: eeschema/libedit_onrightclick.cpp:154
-msgid "Delete Circle"
-msgstr "円の削除"
-
-#: eeschema/libedit_onrightclick.cpp:163
-msgid "Move Rectangle"
-msgstr "矩形の移動"
-
-#: eeschema/libedit_onrightclick.cpp:169
-msgid "Edit Rectangle Options"
-msgstr "矩形オプションの編集"
-
-#: eeschema/libedit_onrightclick.cpp:175
-msgid "Drag Rectangle Edge"
-msgstr "矩形の端をドラッグ"
-
-#: eeschema/libedit_onrightclick.cpp:178
-msgid "Delete Rectangle"
-msgstr "矩形の削除"
-
-#: eeschema/libedit_onrightclick.cpp:210
-msgid "Move Line"
-msgstr "線の移動"
-
-#: eeschema/libedit_onrightclick.cpp:214
-msgid "Drag Edge Point"
-msgstr "端点のドラッグ"
-
-#: eeschema/libedit_onrightclick.cpp:220
-msgid "Line End"
-msgstr "線の終端"
-
-#: eeschema/libedit_onrightclick.cpp:224
-msgid "Edit Line Options"
-msgstr "線オプションの編集"
-
-#: eeschema/libedit_onrightclick.cpp:230
-msgid "Delete Line "
-msgstr "線の削除"
-
-#: eeschema/libedit_onrightclick.cpp:250 eeschema/onrightclick.cpp:306
-msgid "Move Field"
-msgstr "フィールドの移動"
-
-#: eeschema/libedit_onrightclick.cpp:256
-msgid "Field Rotate"
-msgstr "フィールドの回転"
-
-#: eeschema/libedit_onrightclick.cpp:258
-msgid "Field Edit"
-msgstr "フィールドの編集"
-
-#: eeschema/libedit_onrightclick.cpp:283
-msgid "Move Pin "
-msgstr "ピンの移動"
-
-#: eeschema/libedit_onrightclick.cpp:288
-msgid "Edit Pin "
-msgstr "ピンの編集"
-
-#: eeschema/libedit_onrightclick.cpp:291
-msgid "Rotate Pin "
-msgstr "ピンの回転"
-
-#: eeschema/libedit_onrightclick.cpp:296
-msgid "Delete Pin "
-msgstr "ピンの削除"
-
-#: eeschema/libedit_onrightclick.cpp:303
-msgid "Global"
-msgstr "グローバル"
-
-#: eeschema/libedit_onrightclick.cpp:306
-msgid "Pin Size to selected pins"
-msgstr "選択したピンのピンサイズ"
-
-#: eeschema/libedit_onrightclick.cpp:307
-msgid "Pin Size to Others"
-msgstr "他のピンサイズ"
-
-#: eeschema/libedit_onrightclick.cpp:310
-msgid "Pin Name Size to selected pin"
-msgstr "選択したピンのピン名サイズ"
-
-#: eeschema/libedit_onrightclick.cpp:311
-msgid "Pin Name Size to Others"
-msgstr "他のピン名サイズ"
-
-#: eeschema/libedit_onrightclick.cpp:314
-msgid "Pin Num Size to selected pin"
-msgstr "選択したピンのピン番号サイズ"
-
-#: eeschema/libedit_onrightclick.cpp:315
-msgid "Pin Num Size to Others"
-msgstr "他のピンのピン番号サイズ"
-
-#: eeschema/libedit_onrightclick.cpp:337
-msgid "Select Items"
-msgstr "アイテム選択"
-
-#: eeschema/libedit_onrightclick.cpp:340 eeschema/onrightclick.cpp:849
-msgid "Mirror Block ||"
-msgstr "ブロックの縦軸ミラー"
-
-#: eeschema/libedit_onrightclick.cpp:342 eeschema/onrightclick.cpp:852
-msgid "Mirror Block --"
-msgstr "ブロックの横軸ミラー"
-
-#: eeschema/libedit_onrightclick.cpp:344
-msgid "Rotate Block ccw"
-msgstr "ブロックを反時計周り"
-
-#: eeschema/libedit_plot_component.cpp:57
-msgid "No component"
-msgstr "コンポーネントがありません"
-
-#: eeschema/libedit_plot_component.cpp:74
-#: eeschema/libedit_plot_component.cpp:97
-msgid "Filename:"
-msgstr "ファイル名:"
-
-#: eeschema/libedit_plot_component.cpp:139
-#, c-format
-msgid "Can't save file <%s>"
-msgstr "ファイル <%s> が保存できません"
-
-#: eeschema/libeditframe.cpp:181
-msgid "Library Editor"
-msgstr "コンポーネント ライブラリ エディタ"
-
-#: eeschema/libeditframe.cpp:323
-msgid "Save the changes in the library before closing?"
-msgstr "終了前にライブラリの変更を保存しますか？"
-
-#: eeschema/libeditframe.cpp:350
-#, c-format
-msgid ""
-"Library '%s' was modified!\n"
-"Discard changes?"
-msgstr ""
-"ライブラリ '%s'は編集されています! \n"
-"変更を破棄しますか？"
-
-#: eeschema/libeditframe.cpp:456 eeschema/onrightclick.cpp:451
-#, c-format
-msgid "Unit %s"
-msgstr "ユニット %s"
-
-#: eeschema/libeditframe.cpp:724
-msgid "No part to save."
-msgstr "保存するコンポーネントがありません。"
-
-#: eeschema/libeditframe.cpp:1116
-msgid "Add pin"
-msgstr "ピンの追加"
-
-#: eeschema/libeditframe.cpp:1120
-msgid "Set pin options"
-msgstr "ピンのオプションをセット"
-
-#: eeschema/libeditframe.cpp:1135
-msgid "Add rectangle"
-msgstr "矩形を追加"
-
-#: eeschema/libeditframe.cpp:1151
-msgid "Set anchor position"
-msgstr "アンカー位置の設定"
-
-#: eeschema/libeditframe.cpp:1155
-msgid "Import"
-msgstr "インポート"
-
-#: eeschema/libeditframe.cpp:1161 bitmap2component/bitmap2cmp_gui_base.cpp:124
-msgid "Export"
-msgstr "エクスポート"
-
-#: eeschema/libfield.cpp:57
-msgid "Component Name"
-msgstr "コンポーネント名"
-
-#: eeschema/libfield.cpp:58
-msgid "Enter a name to create a new component based on this one."
-msgstr ""
-"このパーツをベースとして新しいコンポーネントを作成するための名前を入力してく"
-"ださい。"
-
-#: eeschema/libfield.cpp:62
-#, c-format
-msgid "Edit Field %s"
-msgstr "フィールドの編集 %s"
-
-#: eeschema/libfield.cpp:63
-#, c-format
-msgid "Enter a new value for the %s field."
-msgstr "%s フィールドの新しい値を入力してください。"
-
-#: eeschema/libfield.cpp:79
-#, c-format
-msgid "A %s field cannot be empty."
-msgstr "%s フィールドは空にできません。"
-
-#: eeschema/libfield.cpp:88
-msgid "Illegal reference. A reference must start by a letter"
-msgstr ""
-"無効なリファレンスです。リファレンスはアルファベット文字で始まる必要がありま"
-"す。"
-
-#: eeschema/libfield.cpp:108
-#, c-format
-msgid ""
-"The name '%s' conflicts with an existing entry in the component library "
-"'%s'.\n"
-"\n"
-"Do you wish to replace the current component in library with this one?"
-msgstr ""
-" '%s' という名前はコンポーネント ライブラリ '%s' 内の既存エントリと衝突しま"
-"す。\n"
-"\n"
-"現在のコンポーネントをライブラリ内のコンポーネントと交換しますか？"
-
-#: eeschema/libfield.cpp:114 eeschema/libfield.cpp:130
-#: eeschema/libfield.cpp:149
-msgid "Confirm"
-msgstr "確認"
-
-#: eeschema/libfield.cpp:125
-#, c-format
-msgid ""
-"The current component already has an alias named '%s'.\n"
-"\n"
-"Do you wish to remove this alias from the component?"
-msgstr ""
-"現在のコンポーネントは既にエイリアス名 '%s' を持っています。\n"
-"\n"
-"このエイリアスをコンポーネントから削除しますか？"
-
-#: eeschema/libfield.cpp:144
-#, c-format
-msgid ""
-"The new component contains alias names that conflict with entries in the "
-"component library '%s'.\n"
-"\n"
-"Do you wish to remove all of the conflicting aliases from this component?"
-msgstr ""
-"新しいコンポーネントに含まれているエイリアス名はコンポーネント ライブラリ "
-"'%s' 内の既存エントリと衝突します。\n"
-"\n"
-"このコンポーネント内の衝突するエイリアスを削除しますか？"
-
-#: eeschema/load_one_schematic_file.cpp:94
-#, c-format
-msgid "Failed to open '%s'"
-msgstr "ファイル '%s' が開けませんでした"
-
-#: eeschema/load_one_schematic_file.cpp:102
-#, c-format
-msgid "Loading '%s'"
-msgstr "読込み中 '%s'"
-
-#: eeschema/load_one_schematic_file.cpp:109
-#, c-format
-msgid "'%s' is NOT an Eeschema file!"
-msgstr "'%s' は Eeschema のファイルではありません！"
-
-#: eeschema/load_one_schematic_file.cpp:128
-#, c-format
-msgid ""
-"'%s' was created by a more recent version of Eeschema and may not load "
-"correctly. Please consider updating!"
-msgstr ""
-"'%s' は新しいバージョンの Eeschema で作成されており、正しく読み込めない可能性"
-"があります。ソフトウェアの更新を検討してください！"
-
-#: eeschema/load_one_schematic_file.cpp:139
-msgid ""
-" was created by an older version of Eeschema. It will be stored in the new "
-"file format when you save this file again."
-msgstr ""
-"　は古いバージョンの Eeschema で作成されています。このファイルは保存する際に"
-"新しいフォーマットで保存されます。"
-
-#: eeschema/load_one_schematic_file.cpp:225
-#, c-format
-msgid "Eeschema file text load error at line %d"
-msgstr "%d 行で Eeschema のファイル読み込みエラー"
-
-#: eeschema/load_one_schematic_file.cpp:241
-#, c-format
-msgid "Eeschema file undefined object at line %d, aborted"
-msgstr ""
-"Eeschema ファイルの %d 行目に未定義のオブジェクトがありました、中止します。"
-
-#: eeschema/load_one_schematic_file.cpp:264
-#, c-format
-msgid "Eeschema file object not loaded at line %d, aborted"
-msgstr ""
-"Eeschema ファイルの %d 行目に読み込まれていないオブジェクトがありました、中止"
-"します。"
-
-#: eeschema/load_one_schematic_file.cpp:281
-#, c-format
-msgid "Done Loading <%s>"
-msgstr "読み込み完了 <%s>"
-
-#: eeschema/load_one_schematic_file.cpp:310
-#, c-format
-msgid ""
-"Eeschema file dimension definition error line %d,\n"
-"Abort reading file.\n"
-msgstr ""
-"Eeschema ファイルの単位系定義でエラー (行番号: %d)\n"
-"ファイルの読み込みを中断しました。\n"
-
-#: eeschema/menubar.cpp:69
-msgid "&New Schematic Project"
-msgstr "新規回路図プロジェクト(&N)"
-
-#: eeschema/menubar.cpp:70
-msgid "Clear current schematic hierarchy and start a new schematic root sheet"
-msgstr "現在の回路図階層をクリアし、新しい回路図ルートシートを開始する"
-
-#: eeschema/menubar.cpp:73
-msgid "&Open Schematic Project"
-msgstr "既存の回路図プロジェクトを開く(&O)"
-
-#: eeschema/menubar.cpp:76
-msgid "Open an existing schematic hierarchy"
-msgstr "既存の回路図階層を開く"
-
-#: eeschema/menubar.cpp:98
-msgid "Open a recent opened schematic project"
-msgstr "最近開いた回路図を開く"
-
-#: eeschema/menubar.cpp:103
-msgid "App&end Schematic Sheet"
-msgstr "回路図シートを追加(&e)"
-
-#: eeschema/menubar.cpp:104
-msgid "Append schematic sheet to current project"
-msgstr "現在読み込まれている回路図へ、他の回路図プロジェクトを追加する"
-
-#: eeschema/menubar.cpp:109
-msgid "&Save Schematic Project"
-msgstr "回路図プロジェクトの保存(&S)"
-
-#: eeschema/menubar.cpp:113
-msgid "Save all sheets in schematic project"
-msgstr "回路図プロジェクト内の全てのシートを保存"
-
-#: eeschema/menubar.cpp:118
-msgid "Save &Current Sheet Only"
-msgstr "現在のシートのみ保存(&C)"
-
-#: eeschema/menubar.cpp:119
-msgid "Save only current schematic sheet"
-msgstr "現在の回路図シートのみ保存"
-
-#: eeschema/menubar.cpp:126
-msgid "Save C&urrent Sheet As"
-msgstr "現在のシートを名前をつけて保存(&u)"
-
-#: eeschema/menubar.cpp:127
-msgid "Save current schematic sheet as..."
-msgstr "現在の回路図シートを名前をつけて保存"
-
-#: eeschema/menubar.cpp:135
-msgid "Pa&ge Settings"
-msgstr "ページ設定(&G)"
-
-#: eeschema/menubar.cpp:136
-msgid "Setting for sheet size and frame references"
-msgstr "ページサイズと図枠情報の設定"
-
-#: eeschema/menubar.cpp:141
-msgid "Pri&nt"
-msgstr "印刷(&N)"
-
-#: eeschema/menubar.cpp:142
-msgid "Print schematic sheet"
-msgstr "回路図の印刷"
-
-#: eeschema/menubar.cpp:148 eeschema/menubar.cpp:160
-msgid "&Plot"
-msgstr "出図(&P)"
-
-#: eeschema/menubar.cpp:149
-msgid "Plot schematic sheet in PostScript, PDF, SVG, DXF or HPGL format"
-msgstr ""
-"回路図シートをPostScript, PDF, SVG, DXF, HPGLフォーマット等でプロットする"
-
-#: eeschema/menubar.cpp:154
-msgid "Plot to C&lipboard"
-msgstr "クリップボードにプロット(&l)"
-
-#: eeschema/menubar.cpp:155
-msgid "Export drawings to clipboard"
-msgstr "クリップボードに図をエクスポート"
-
-#: eeschema/menubar.cpp:161
-msgid "Plot schematic sheet in HPGL, PostScript or SVG format"
-msgstr "HPGL, PostScript, SVGフォーマットのいづれかで回路図シートをプロット"
-
-#: eeschema/menubar.cpp:171
-msgid "Close Eeschema"
-msgstr "Eeschema の終了"
-
-#: eeschema/menubar.cpp:199
-msgid "Find and Re&place"
-msgstr "検索と置換(&P)"
-
-#: eeschema/menubar.cpp:207
-msgid "Import Footprint Selection"
-msgstr "フットプリントの関連付けをインポート"
-
-#: eeschema/menubar.cpp:249
-msgid "Show &Hierarchical Navigator"
-msgstr "階層ナビゲータの表示(&H)"
-
-#: eeschema/menubar.cpp:250
-msgid "Navigate hierarchical sheets"
-msgstr "階層シートのナビゲート"
-
-#: eeschema/menubar.cpp:253
-msgid "&Leave Sheet"
-msgstr "シートから抜ける(&L)"
-
-#: eeschema/menubar.cpp:258 eeschema/onrightclick.cpp:196
-msgid "Leave Sheet"
-msgstr "シートから抜ける"
-
-#: eeschema/menubar.cpp:264
-msgid "&Component"
-msgstr "コンポーネント(&C)"
-
-#: eeschema/menubar.cpp:270
-msgid "&Power Port"
-msgstr "電源ポート(&P)"
-
-#: eeschema/menubar.cpp:276
-msgid "&Wire"
-msgstr "配線(&W)"
-
-#: eeschema/menubar.cpp:282
-msgid "&Bus"
-msgstr "バス(&B)"
-
-#: eeschema/menubar.cpp:288
-msgid "Wire to Bus &Entry"
-msgstr "ワイヤ-バス・エントリの追加(&E)"
-
-#: eeschema/menubar.cpp:294
-msgid "Bus &to Bus Entry"
-msgstr "バス-バス・エントリの追加(&T)"
-
-#: eeschema/menubar.cpp:300
-msgid "&No Connect Flag"
-msgstr "空き端子フラグ(&N)"
-
-#: eeschema/menubar.cpp:304
-msgid "&Junction"
-msgstr "ジャンクション(&J)"
-
-#: eeschema/menubar.cpp:310
-msgid "&Label"
-msgstr "ラベル(&L)"
-
-#: eeschema/menubar.cpp:316
-msgid "Gl&obal Label"
-msgstr "グローバル ラベル(&O)"
-
-#: eeschema/menubar.cpp:324
-msgid "&Hierarchical Label"
-msgstr "階層ラベル(&H)"
-
-#: eeschema/menubar.cpp:331
-msgid "Hierarchical &Sheet"
-msgstr "階層シート(&S)"
-
-#: eeschema/menubar.cpp:339
-msgid "I&mport Hierarchical Label"
-msgstr "階層ラベルのインポート(&M)"
-
-#: eeschema/menubar.cpp:345
-msgid "Hierarchical Pi&n to Sheet"
-msgstr "階層ピンをシートに追加(&N)"
-
-#: eeschema/menubar.cpp:351
-msgid "Graphic Pol&yline"
-msgstr "図形ライン入力(&y)"
-
-#: eeschema/menubar.cpp:357
-msgid "&Graphic Text"
-msgstr "図形テキスト(&G)"
-
-#: eeschema/menubar.cpp:364
-msgid "&Image"
-msgstr "画像(&I)"
-
-#: eeschema/menubar.cpp:374 eeschema/menubar_libedit.cpp:230
-msgid "Component &Libraries"
-msgstr "コンポーネントライブラリ(&L)"
-
-#: eeschema/menubar.cpp:375 eeschema/menubar_libedit.cpp:231
-msgid "Configure component libraries and paths"
-msgstr "コンポーネント ライブラリとパスの設定"
-
-#: eeschema/menubar.cpp:381 eeschema/menubar_libedit.cpp:244
-msgid "Set &Colors Scheme"
-msgstr "色の設定(&C)"
-
-#: eeschema/menubar.cpp:382 eeschema/menubar_libedit.cpp:245
-msgid "Set color preferences"
-msgstr "色の設定"
-
-#: eeschema/menubar.cpp:392
-msgid "Schematic Editor &Options"
-msgstr "回路図エディタ オプション(&O)"
-
-#: eeschema/menubar.cpp:393
-msgid "Set Eeschema preferences"
-msgstr "Eeschema の設定"
-
-#: eeschema/menubar.cpp:424
-msgid "Library &Editor"
-msgstr "コンポーネント ライブラリ エディタ(&E)"
-
-#: eeschema/menubar.cpp:429
-msgid "Library &Browser"
-msgstr "ライブラリ ブラウザ(&B)"
-
-#: eeschema/menubar.cpp:434
-msgid "&Rescue Old Components"
-msgstr "キャッシュされたコンポーネントのレスキュー(&R)"
-
-#: eeschema/menubar.cpp:435
-msgid "Find old components in the project and rename/rescue them"
-msgstr "プロジェクトにある古いコンポーネントを探してリネーム/レスキューする"
-
-#: eeschema/menubar.cpp:442
-msgid "&Annotate Schematic"
-msgstr "回路図のアノテーション(&A)"
-
-#: eeschema/menubar.cpp:448
-msgid "Electrical Rules &Checker"
-msgstr "エレクトリックルール チェッカ(ERC) (&C)"
-
-#: eeschema/menubar.cpp:449 eeschema/tool_sch.cpp:149
-msgid "Perform electrical rules check"
-msgstr "エレクトリック ルール チェッカの実行"
-
-#: eeschema/menubar.cpp:454
-msgid "Generate &Netlist File"
-msgstr "ネットリストの生成(&N)"
-
-#: eeschema/menubar.cpp:455
-msgid "Generate the component netlist file"
-msgstr "コンポーネントネットリストの生成"
-
-#: eeschema/menubar.cpp:460
-msgid "Generate Bill of &Materials"
-msgstr "部品表の生成(&M)"
-
-#: eeschema/menubar.cpp:471
-msgid "A&ssign Component Footprint"
-msgstr "コンポーネントにフットプリントを割付け(&S)"
-
-#: eeschema/menubar.cpp:472
-msgid "Run CvPcb"
-msgstr "CVpcb起動"
-
-#: eeschema/menubar.cpp:479
-msgid "&Layout Printed Circuit Board"
-msgstr "プリント基板のレイアウト(&L)"
-
-#: eeschema/menubar.cpp:491 eeschema/tool_viewlib.cpp:250
-msgid "Eesc&hema Manual"
-msgstr "Eeschema マニュアル(&H)"
-
-#: eeschema/menubar.cpp:492 eeschema/tool_viewlib.cpp:251
-msgid "Open Eeschema manual"
-msgstr "Eeschema のマニュアルを開く"
-
-#: eeschema/menubar.cpp:504 eeschema/menubar_libedit.cpp:278
-#: eeschema/tool_viewlib.cpp:262
-msgid "&About Eeschema"
-msgstr "Eeschema について(&A)"
-
-#: eeschema/menubar.cpp:505 eeschema/menubar_libedit.cpp:279
-#: eeschema/tool_viewlib.cpp:263
-msgid "About Eeschema schematic designer"
-msgstr "Eeschema 回路図デザイナについて"
-
-#: eeschema/menubar_libedit.cpp:68
-msgid "&Current Library"
-msgstr "現在のライブラリ(&C)"
-
-#: eeschema/menubar_libedit.cpp:69 eeschema/tool_lib.cpp:115
-msgid "Select working library"
-msgstr "作業ライブラリの選択"
-
-#: eeschema/menubar_libedit.cpp:76
-msgid "&Save Current Library\tCtrl+S"
-msgstr "現在のライブラリを保存(&S)\tCtrl+S"
-
-#: eeschema/menubar_libedit.cpp:77
-msgid "Save the current active library"
-msgstr "現在のアクティブライブラリを保存"
-
-#: eeschema/menubar_libedit.cpp:83
-msgid "Save Current Library &As"
-msgstr "現在のライブラリを名前をつけて保存(&A)"
-
-#: eeschema/menubar_libedit.cpp:84
-msgid "Save current active library as..."
-msgstr "現在アクティブなライブラリを名前をつけて保存"
-
-#: eeschema/menubar_libedit.cpp:93
-msgid "Create &PNG File from Screen"
-msgstr "画面からPNGファイルを生成(&P)"
-
-#: eeschema/menubar_libedit.cpp:94
-msgid "Create a PNG file from the component displayed on screen"
-msgstr "スクリーン上に表示されたコンポーネントからPNGファイルを作成"
-
-#: eeschema/menubar_libedit.cpp:100
-msgid "Create S&VG File"
-msgstr "SVGファイル作成(&V)"
-
-#: eeschema/menubar_libedit.cpp:101
-msgid "Create a SVG file from the current loaded component"
-msgstr "現在読込まれているコンポーネントからSVGファイルを作成"
-
-#: eeschema/menubar_libedit.cpp:110
-msgid "&Quit"
-msgstr "終了(&Q)"
-
-#: eeschema/menubar_libedit.cpp:111
-msgid "Quit Library Editor"
-msgstr "コンポーネント ライブラリ エディタの終了"
-
-#: eeschema/menubar_libedit.cpp:123
-msgid "Undo last edit"
-msgstr "一つ前の編集を元に戻す"
-
-#: eeschema/menubar_libedit.cpp:185
-msgid "&Pin"
-msgstr "ピン(&P)"
-
-#: eeschema/menubar_libedit.cpp:192
-msgid "Graphic &Text"
-msgstr "図形テキスト(&T)"
-
-#: eeschema/menubar_libedit.cpp:199
-msgid "&Rectangle"
-msgstr "矩形(&R)"
-
-#: eeschema/menubar_libedit.cpp:237
-msgid "Component Editor &Options"
-msgstr "コンポーネントライブラリエディタ オプション(&O)"
-
-#: eeschema/menubar_libedit.cpp:238
-msgid "Set Component Editor default values and options"
-msgstr "コンポーネント エディタにデフォルトの値とオプションを設定する"
-
-#: eeschema/menubar_libedit.cpp:264
-msgid "Open the Eeschema manual"
-msgstr "Eeschema マニュアルを開く"
-
-#: eeschema/netform.cpp:111
-msgid "Run command:"
-msgstr "コマンドラインで実行:"
-
-#: eeschema/netform.cpp:117
-#, c-format
-msgid "Command error. Return code %d"
-msgstr "コマンドエラー. リターンコード %d"
-
-#: eeschema/netform.cpp:120
-msgid "Success"
-msgstr "成功"
-
-#: eeschema/netform.cpp:127
-msgid "Info messages:"
-msgstr "Info メッセージ:"
-
-#: eeschema/netform.cpp:137
-msgid "Error messages:"
-msgstr "エラーメッセージ:"
-
-#: eeschema/netlist.cpp:68
-msgid ""
-"Exporting the netlist requires a completely\n"
-"annotated schematic."
-msgstr ""
-"ネットリストのエクスポートには回路図の完全な\n"
-"アノテーションが必要です."
-
-#: eeschema/netlist.cpp:78
-msgid "Error: duplicate sheet names. Continue?"
-msgstr "エラー: シート名の重複。続けますか？"
-
-#: eeschema/netlist.cpp:172
-msgid "No Objects"
-msgstr "オブジェクトがありまs年"
-
-#: eeschema/netlist.cpp:176
-#, c-format
-msgid "Net count = %zu"
-msgstr "ネット数 = %zu"
-
-#: eeschema/onrightclick.cpp:102 eeschema/onrightclick.cpp:573
-msgid "Edit Label"
-msgstr "ラベルの編集"
-
-#: eeschema/onrightclick.cpp:108 eeschema/onrightclick.cpp:501
-msgid "Edit Global Label"
-msgstr "グローバル ラベルの編集"
-
-#: eeschema/onrightclick.cpp:115 eeschema/onrightclick.cpp:537
-msgid "Edit Hierarchical Label"
-msgstr "階層ラベルの編集"
-
-#: eeschema/onrightclick.cpp:122 eeschema/onrightclick.cpp:895
-msgid "Edit Image"
-msgstr "イメージの編集"
-
-#: eeschema/onrightclick.cpp:209
-msgid "Delete No Connect"
-msgstr "接続の削除"
-
-#: eeschema/onrightclick.cpp:303
-msgid "Move Reference"
-msgstr "リファレンスの移動"
-
-#: eeschema/onrightclick.cpp:304
-msgid "Move Value"
-msgstr "ラベルの移動"
-
-#: eeschema/onrightclick.cpp:305
-msgid "Move Footprint Field"
-msgstr "フットプリントフィールドの移動"
-
-#: eeschema/onrightclick.cpp:316
-msgid "Rotate Reference"
-msgstr "リファレンスの回転"
-
-#: eeschema/onrightclick.cpp:317
-msgid "Rotate Value"
-msgstr "値の回転"
-
-#: eeschema/onrightclick.cpp:318
-msgid "Rotate Footprint Field"
-msgstr "フットプリントフィールドの回転"
-
-#: eeschema/onrightclick.cpp:319
-msgid "Rotate Field"
-msgstr "フィールドの回転"
-
-#: eeschema/onrightclick.cpp:331
-msgid "Edit Reference"
-msgstr "リファレンスの編集"
-
-#: eeschema/onrightclick.cpp:335
-msgid "Edit Value"
-msgstr "ラベルの編集"
-
-#: eeschema/onrightclick.cpp:339
-msgid "Edit Footprint Field"
-msgstr "フットプリントフィールドの編集"
-
-#: eeschema/onrightclick.cpp:343
-msgid "Edit Field"
-msgstr "フィールドの編集"
-
-#: eeschema/onrightclick.cpp:364
-#, c-format
-msgid "Move Component %s"
-msgstr "コンポーネント %s の移動"
-
-#: eeschema/onrightclick.cpp:368
-msgid "Drag Component"
-msgstr "コンポーネントのドラッグ"
-
-#: eeschema/onrightclick.cpp:373
-msgid "Rotate Clockwise"
-msgstr "右回転"
-
-#: eeschema/onrightclick.cpp:375
-msgid "Rotate Counterclockwise"
-msgstr "左回転"
-
-#: eeschema/onrightclick.cpp:377 eeschema/onrightclick.cpp:769
-#: eeschema/onrightclick.cpp:889
-msgid "Mirror --"
-msgstr "横軸でミラー"
-
-#: eeschema/onrightclick.cpp:379 eeschema/onrightclick.cpp:771
-#: eeschema/onrightclick.cpp:892
-msgid "Mirror ||"
-msgstr "縦軸でミラー"
-
-#: eeschema/onrightclick.cpp:384
-msgid "Orient Component"
-msgstr "コンポーネントの角度"
-
-#: eeschema/onrightclick.cpp:390
-msgid "Copy Component"
-msgstr "コンポーネントのコピー"
-
-#: eeschema/onrightclick.cpp:393
-msgid "Delete Component"
-msgstr "コンポーネントの削除"
-
-#: eeschema/onrightclick.cpp:470
-msgid "Edit with Library Editor"
-msgstr "コンポーネント ライブラリ エディタで編集"
-
-#: eeschema/onrightclick.cpp:477
-msgid "Edit Component"
-msgstr "コンポーネントの編集"
-
-#: eeschema/onrightclick.cpp:488
-msgid "Move Global Label"
-msgstr "グローバル ラベルの移動"
-
-#: eeschema/onrightclick.cpp:491
-msgid "Drag Global Label"
-msgstr "グローバル ラベルのドラッグ"
-
-#: eeschema/onrightclick.cpp:494
-msgid "Copy Global Label"
-msgstr "グローバル ラベルのコピー"
-
-#: eeschema/onrightclick.cpp:499
-msgid "Rotate Global Label"
-msgstr "グローバル ラベルの回転"
-
-#: eeschema/onrightclick.cpp:503
-msgid "Delete Global Label"
-msgstr "グローバル ラベルの削除"
-
-#: eeschema/onrightclick.cpp:508 eeschema/onrightclick.cpp:580
-#: eeschema/onrightclick.cpp:620
-msgid "Change to Hierarchical Label"
-msgstr "階層ラベルに変更"
-
-#: eeschema/onrightclick.cpp:510 eeschema/onrightclick.cpp:544
-#: eeschema/onrightclick.cpp:618
-msgid "Change to Label"
-msgstr "ラベルに変更"
-
-#: eeschema/onrightclick.cpp:512 eeschema/onrightclick.cpp:546
-#: eeschema/onrightclick.cpp:582
-msgid "Change to Text"
-msgstr "テキストに変更"
-
-#: eeschema/onrightclick.cpp:514 eeschema/onrightclick.cpp:550
-#: eeschema/onrightclick.cpp:586 eeschema/onrightclick.cpp:624
-msgid "Change Type"
-msgstr "タイプの変更"
-
-#: eeschema/onrightclick.cpp:525
-msgid "Move Hierarchical Label"
-msgstr "階層ラベルの移動"
-
-#: eeschema/onrightclick.cpp:528
-msgid "Drag Hierarchical Label"
-msgstr "階層ラベルのドラッグ"
-
-#: eeschema/onrightclick.cpp:530
-msgid "Copy Hierarchical Label"
-msgstr "階層ラベルのコピー"
-
-#: eeschema/onrightclick.cpp:535
-msgid "Rotate Hierarchical Label"
-msgstr "階層ラベルの回転"
-
-#: eeschema/onrightclick.cpp:539
-msgid "Delete Hierarchical Label"
-msgstr "階層ラベル削除"
-
-#: eeschema/onrightclick.cpp:548 eeschema/onrightclick.cpp:584
-#: eeschema/onrightclick.cpp:622
-msgid "Change to Global Label"
-msgstr "グローバルラベルに変更"
-
-#: eeschema/onrightclick.cpp:561
-msgid "Move Label"
-msgstr "ラベルの移動"
-
-#: eeschema/onrightclick.cpp:564
-msgid "Drag Label"
-msgstr "ラベルのドラッグ"
-
-#: eeschema/onrightclick.cpp:566
-msgid "Copy Label"
-msgstr "ラベルのコピー"
-
-#: eeschema/onrightclick.cpp:571
-msgid "Rotate Label"
-msgstr "ラベルの回転"
-
-#: eeschema/onrightclick.cpp:575
-msgid "Delete Label"
-msgstr "ラベルの削除"
-
-#: eeschema/onrightclick.cpp:600
-msgid "Copy Text"
-msgstr "テキストのコピー"
-
-#: eeschema/onrightclick.cpp:634
-msgid "Delete Junction"
-msgstr "ジャンクションの削除"
-
-#: eeschema/onrightclick.cpp:640
-msgid "Drag Junction"
-msgstr "ジャンクション (接続点) のドラッグ"
-
-#: eeschema/onrightclick.cpp:643 eeschema/onrightclick.cpp:691
-msgid "Break Wire"
-msgstr "配線の切断"
-
-#: eeschema/onrightclick.cpp:649 eeschema/onrightclick.cpp:683
-msgid "Delete Node"
-msgstr "ノードの削除"
-
-# コネクション→一連のネットの意であればそのまま用語として残す
-#: eeschema/onrightclick.cpp:651 eeschema/onrightclick.cpp:685
-msgid "Delete Connection"
-msgstr "コネクションの削除"
-
-#: eeschema/onrightclick.cpp:665
-msgid "Begin Wire"
-msgstr "配線の開始"
-
-#: eeschema/onrightclick.cpp:673
-msgid "Wire End"
-msgstr "ワイヤの終端"
-
-#: eeschema/onrightclick.cpp:678
-msgid "Drag Wire"
-msgstr "ワイヤのドラッグ"
-
-#: eeschema/onrightclick.cpp:681
-msgid "Delete Wire"
-msgstr "ワイヤの削除"
-
-#: eeschema/onrightclick.cpp:696 eeschema/onrightclick.cpp:734
-msgid "Add Junction"
-msgstr "ジャンクションの追加"
-
-#: eeschema/onrightclick.cpp:698 eeschema/onrightclick.cpp:736
-msgid "Add Label"
-msgstr "ラベルの追加"
-
-#: eeschema/onrightclick.cpp:703 eeschema/onrightclick.cpp:741
-msgid "Add Global Label"
-msgstr "グローバル ラベルの追加"
-
-#: eeschema/onrightclick.cpp:715
-msgid "Begin Bus"
-msgstr "バスの開始"
-
-#: eeschema/onrightclick.cpp:723
-msgid "Bus End"
-msgstr "バスの終端"
-
-#: eeschema/onrightclick.cpp:728
-msgid "Delete Bus"
-msgstr "バス削除"
-
-#: eeschema/onrightclick.cpp:731
-msgid "Break Bus"
-msgstr "バスの切断"
-
-#: eeschema/onrightclick.cpp:752
-msgid "Enter Sheet"
-msgstr "シートに入る"
-
-#: eeschema/onrightclick.cpp:755
-msgid "Move Sheet"
-msgstr "シートの移動"
-
-#: eeschema/onrightclick.cpp:759
-msgid "Drag Sheet"
-msgstr "シートのドラッグ"
-
-#: eeschema/onrightclick.cpp:763
-msgid "Rotate Sheet CW"
-msgstr "シートを時計方向に回転"
-
-#: eeschema/onrightclick.cpp:766
-msgid "Rotate Sheet CCW"
-msgstr "シートを反時計方向に回転"
-
-#: eeschema/onrightclick.cpp:775
-msgid "Orient Sheet"
-msgstr "シートの向きを合わせる."
-
-#: eeschema/onrightclick.cpp:780
-msgid "Place Sheet"
-msgstr "シートの配置"
-
-#: eeschema/onrightclick.cpp:784
-msgid "Edit Sheet"
-msgstr "シートの編集"
-
-#: eeschema/onrightclick.cpp:787
-msgid "Resize Sheet"
-msgstr "シートのリサイズ"
-
-#: eeschema/onrightclick.cpp:790
-msgid "Import Sheet Pins"
-msgstr "シートピンのインポート"
-
-#: eeschema/onrightclick.cpp:794
-msgid "Cleanup Sheet Pins"
-msgstr "シートピンのクリーンアップ"
-
-#: eeschema/onrightclick.cpp:798
-msgid "Delete Sheet"
-msgstr "シートの削除"
-
-#: eeschema/onrightclick.cpp:810
-msgid "Move Sheet Pin"
-msgstr "シートピンの移動"
-
-#: eeschema/onrightclick.cpp:815
-msgid "Edit Sheet Pin"
-msgstr "シートピンの編集"
-
-#: eeschema/onrightclick.cpp:818
-msgid "Delete Sheet Pin"
-msgstr "シートピンの削除"
-
-#: eeschema/onrightclick.cpp:833
-msgid "Window Zoom"
-msgstr "選択範囲ズーム"
-
-#: eeschema/onrightclick.cpp:841
-msgid "Save Block"
-msgstr "ブロックの保存"
-
-#: eeschema/onrightclick.cpp:845
-msgid "Drag Block"
-msgstr "ブロックのドラッグ"
-
-#: eeschema/onrightclick.cpp:855
-msgid "Rotate Block CCW"
-msgstr "ブロックの左回転"
-
-#: eeschema/onrightclick.cpp:861
-msgid "Copy to Clipboard"
-msgstr "クリップボードにコピー"
-
-#: eeschema/onrightclick.cpp:882
-msgid "Move Image"
-msgstr "イメージの移動"
-
-#: eeschema/onrightclick.cpp:887
-msgid "Rotate Image"
-msgstr "イメージの回転"
-
-#: eeschema/onrightclick.cpp:901
-msgid "Delete Image"
-msgstr "イメージの削除"
-
-#: eeschema/onrightclick.cpp:913
-msgid "Move Bus Entry"
-msgstr "バスエントリの移動"
-
-#: eeschema/onrightclick.cpp:920
-msgid "Set Bus Entry Shape /"
-msgstr "バスエントリ形状のセット /"
-
-#: eeschema/onrightclick.cpp:923
-msgid "Set Bus Entry Shape \\"
-msgstr "バスエントリ形状のセット \\"
-
-#: eeschema/onrightclick.cpp:925
-msgid "Delete Bus Entry"
-msgstr "バスエントリの削除"
-
-#: eeschema/pinedit.cpp:249
-msgid "This position is already occupied by another pin. Continue?"
-msgstr "この位置にはすでに他のピンがあります。続けますか？"
-
-#: eeschema/pinedit.cpp:665
-msgid "No pins!"
-msgstr "ピンがありません！"
-
-#: eeschema/pinedit.cpp:675
-msgid "Marker Information"
-msgstr "マーカー情報"
-
-#: eeschema/pinedit.cpp:701
-#, c-format
-msgid ""
-"<b>Duplicate pin %s</b> \"%s\" at location <b>(%.3f, %.3f)</b> conflicts "
-"with pin %s \"%s\" at location <b>(%.3f, %.3f)</b>"
-msgstr ""
-"<b>重複ピン %s</b> \"%s\" 位置 <b>(%.3f, %.3f)</b> 衝突ピン %s \"%s\" 位置 "
-"<b>(%.3f, %.3f)</b>"
-
-#: eeschema/pinedit.cpp:715 eeschema/pinedit.cpp:757
-#, c-format
-msgid " in part %c"
-msgstr "パーツ %c"
-
-#: eeschema/pinedit.cpp:721 eeschema/pinedit.cpp:763
-msgid "  of converted"
-msgstr " 変換シンボル"
-
-#: eeschema/pinedit.cpp:723 eeschema/pinedit.cpp:765
-msgid "  of normal"
-msgstr "標準"
-
-#: eeschema/pinedit.cpp:748
-#, c-format
-msgid "<b>Off grid pin %s</b> \"%s\" at location <b>(%.3f, %.3f)</b>"
-msgstr "<b>グリッドから外れたピン %s</b> \"%s\" 位置 <b>(%.3f, %.3f)</b>"
-
-#: eeschema/pinedit.cpp:774
-msgid "No off grid or duplicate pins were found."
-msgstr "グリッドから外れたり、重複したピンは見つかりませんでした。"
-
-#: eeschema/plot_schematic_DXF.cpp:94 eeschema/plot_schematic_HPGL.cpp:190
-#: eeschema/plot_schematic_PDF.cpp:140 eeschema/plot_schematic_PS.cpp:123
-#: eeschema/plot_schematic_SVG.cpp:100 eeschema/plot_schematic_SVG.cpp:137
-#, c-format
-msgid "Plot: '%s' OK.\n"
-msgstr "プロット: '%s' OK.\n"
-
-#: eeschema/plot_schematic_DXF.cpp:99 eeschema/plot_schematic_HPGL.cpp:195
-#: eeschema/plot_schematic_PDF.cpp:103 eeschema/plot_schematic_PS.cpp:129
-#: eeschema/plot_schematic_SVG.cpp:144
-#, c-format
-msgid "Unable to create file '%s'.\n"
-msgstr "ファイル '%s' を作成できません\n"
-
-#: eeschema/plot_schematic_SVG.cpp:94
-#, c-format
-msgid "Cannot create file '%s'.\n"
-msgstr "ファイル '%s' を作成できません\n"
-
-#: eeschema/project_rescue.cpp:295
-#, c-format
-msgid "Rename to %s"
-msgstr "ファイル名を %s へ変更"
-
-#: eeschema/project_rescue.cpp:389
-#, c-format
-msgid "Rescue %s as %s"
-msgstr "%s を %s としてレスキュー"
-
-#: eeschema/project_rescue.cpp:527
-msgid "This project has nothing to rescue."
-msgstr "このプロジェクトにレスキューは必要ありません."
-
-#: eeschema/project_rescue.cpp:541
-msgid "No symbols were rescued."
-msgstr "レスキューするシンボルがありません."
-
-#: eeschema/sch_bus_entry.cpp:333
-msgid "Bus to Wire Entry"
-msgstr "ワイヤ-バス・エントリ"
-
-#: eeschema/sch_bus_entry.cpp:339
-msgid "Bus to Bus Entry"
-msgstr "バス-バス・エントリ"
-
-#: eeschema/sch_collectors.cpp:432
-#, c-format
-msgid "Child item %s of parent item %s found in sheet %s"
-msgstr "子アイテム %s の親アイテム %s がシート %s 中にありません"
-
-#: eeschema/sch_collectors.cpp:439
-#, c-format
-msgid "Item %s found in sheet %s"
-msgstr "アイテム %s がシート%s 内に見つかりませんでした"
-
-#: eeschema/sch_component.cpp:1518
-msgid "Power symbol"
-msgstr "電源シンボル"
-
-#: eeschema/sch_component.cpp:1523 eeschema/dialogs/dialog_color_config.cpp:103
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:23
-msgid "Component"
-msgstr "コンポーネント"
-
-#: eeschema/sch_component.cpp:1526
-msgid "Alias of"
-msgstr "エイリアス"
-
-#: eeschema/sch_component.cpp:1534
-msgid "<Unknown>"
-msgstr "<不明>"
-
-#: eeschema/sch_component.cpp:1540
-msgid "Key Words"
-msgstr "キーワード"
-
-#: eeschema/sch_component.cpp:1784
-#, c-format
-msgid "Component %s, %s"
-msgstr "コンポーネント %s, %s"
-
-#: eeschema/sch_field.cpp:453
-#, c-format
-msgid "Field %s"
-msgstr "フィールド %s"
-
-#: eeschema/sch_line.cpp:476
-#, c-format
-msgid "%s Graphic Line from (%s,%s) to (%s,%s) "
-msgstr "%s 図形ライン 始点 (%s,%s) 終点 (%s,%s) "
-
-#: eeschema/sch_line.cpp:480
-#, c-format
-msgid "%s Wire from (%s,%s) to (%s,%s)"
-msgstr "%s ワイヤ 始点 (%s,%s) 終点 (%s,%s)"
-
-#: eeschema/sch_line.cpp:484
-#, c-format
-msgid "%s Bus from (%s,%s) to (%s,%s)"
-msgstr "%s バス 始点 (%s,%s) 終点 (%s,%s)"
-
-#: eeschema/sch_line.cpp:488
-#, c-format
-msgid "%s Line on Unknown Layer from (%s,%s) to (%s,%s)"
-msgstr "%s ライン 不明なレイヤ 始点 (%s,%s) 終点 (%s,%s)"
-
-#: eeschema/sch_marker.cpp:142
-msgid "Electronics Rule Check Error"
-msgstr "エレクトリックルール チェッカ (ERC) エラー"
-
-#: eeschema/sch_sheet.cpp:828
-msgid "Sheet Name"
-msgstr "シート名"
-
-#: eeschema/sch_sheet.cpp:829
-msgid "File Name"
-msgstr "ファイル名"
-
-#: eeschema/sch_sheet.cpp:834
-msgid "Time Stamp"
-msgstr "タイムスタンプ"
-
-#: eeschema/sch_sheet.cpp:1047
-#, c-format
-msgid "Hierarchical Sheet %s"
-msgstr "階層シート　%s"
-
-#: eeschema/sch_sheet_path.cpp:175
-#, c-format
-msgid "Schematic sheets can only be nested %d levels deep."
-msgstr "回路図シートは %d 層までしかネストできません。"
-
-#: eeschema/sch_sheet_path.cpp:206
-#, c-format
-msgid "%8.8lX/"
-msgstr "%8.8lX/"
-
-#: eeschema/sch_sheet_pin.cpp:500
-#, c-format
-msgid "Hierarchical Sheet Pin %s"
-msgstr "階層シートピン %s"
-
-#: eeschema/sch_text.cpp:708
-msgid "Graphic Text"
-msgstr "図形テキスト"
-
-#: eeschema/sch_text.cpp:712 eeschema/dialogs/dialog_color_config.cpp:64
-msgid "Label"
-msgstr "ラベル"
-
-#: eeschema/sch_text.cpp:716
-msgid "Global Label"
-msgstr "グローバル ラベル"
-
-#: eeschema/sch_text.cpp:720
-msgid "Hierarchical Label"
-msgstr "階層ラベル"
-
-#: eeschema/sch_text.cpp:724
-msgid "Hierarchical Sheet Pin"
-msgstr "階層シートピン"
-
-#: eeschema/sch_text.cpp:740
-msgid "Vertical up"
-msgstr "下方向"
-
-#: eeschema/sch_text.cpp:744
-msgid "Horizontal invert"
-msgstr "水平反転"
-
-#: eeschema/sch_text.cpp:748
-msgid "Vertical down"
-msgstr "上方向"
-
-#: eeschema/sch_text.cpp:758
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:182
-#: eeschema/dialogs/dialog_edit_label_base.cpp:76
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:92
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:97 common/eda_text.cpp:379
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:90
-msgid "Bold"
-msgstr "太字"
-
-#: eeschema/sch_text.cpp:758
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:182
-#: eeschema/dialogs/dialog_edit_label_base.cpp:76
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:92
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:97
-msgid "Bold Italic"
-msgstr "斜太字"
-
-#: eeschema/sch_text.cpp:780 eeschema/dialogs/dialog_edit_label_base.cpp:82
-msgid "Tri-State"
-msgstr "トライステート"
-
-#: eeschema/sch_text.cpp:1009
-#, c-format
-msgid "Label %s"
-msgstr "ラベル %s"
-
-#: eeschema/sch_text.cpp:1434
-#, c-format
-msgid "Global Label %s"
-msgstr "グローバル ラベル %s"
-
-#: eeschema/sch_text.cpp:1775
-#, c-format
-msgid "Hierarchical Label %s"
-msgstr "階層ラベル %s"
-
-#: eeschema/schedit.cpp:258
-msgid "There are no undefined labels in this sheet to clean up."
-msgstr "このシート中に未定義のラベルはありません。"
-
-#: eeschema/schedit.cpp:262
-msgid "Do you wish to cleanup this sheet?"
-msgstr "このシートをクリーンアップしますか？"
-
-#: eeschema/schedit.cpp:519
-msgid "No tool selected"
-msgstr "ツールが選択されていません"
-
-#: eeschema/schedit.cpp:523
-msgid "Descend or ascend hierarchy"
-msgstr "階層の上下移動"
-
-#: eeschema/schedit.cpp:527
-msgid "Add no connect"
-msgstr "空き端子フラグの入力"
-
-#: eeschema/schedit.cpp:531
-msgid "Add wire"
-msgstr "ワイヤの追加"
-
-#: eeschema/schedit.cpp:535
-msgid "Add bus"
-msgstr "バスの追加"
-
-#: eeschema/schedit.cpp:539
-msgid "Add lines"
-msgstr "線の追加"
-
-#: eeschema/schedit.cpp:543
-msgid "Add junction"
-msgstr "ジャンクションの追加"
-
-#: eeschema/schedit.cpp:547
-msgid "Add label"
-msgstr "ラベルの追加"
-
-#: eeschema/schedit.cpp:551
-msgid "Add global label"
-msgstr "グローバル ラベルの追加"
-
-#: eeschema/schedit.cpp:555
-msgid "Add hierarchical label"
-msgstr "階層ラベルの追加"
-
-#: eeschema/schedit.cpp:563
-msgid "Add image"
-msgstr "イメージの追加"
-
-#: eeschema/schedit.cpp:567
-msgid "Add wire to bus entry"
-msgstr "配線にバスエントリを追加"
-
-#: eeschema/schedit.cpp:571
-msgid "Add bus to bus entry"
-msgstr "バスに バスエントリを追加"
-
-#: eeschema/schedit.cpp:575
-msgid "Add sheet"
-msgstr "シートの追加"
-
-#: eeschema/schedit.cpp:579
-msgid "Add sheet pins"
-msgstr "シートピンの追加"
-
-#: eeschema/schedit.cpp:583
-msgid "Import sheet pins"
-msgstr "シートピンのインポート"
-
-#: eeschema/schedit.cpp:587
-msgid "Add component"
-msgstr "コンポーネントの追加"
-
-#: eeschema/schedit.cpp:591
-msgid "Add power"
-msgstr "電源の追加"
-
-#: eeschema/schframe.cpp:171
-msgid "The following libraries were not found:"
-msgstr "ライブラリは見つかりませんでした:"
-
-#: eeschema/schframe.cpp:766
-msgid "Draw wires and buses in any direction"
-msgstr "配線、バスを自由角度で描画"
-
-#: eeschema/schframe.cpp:767
-msgid "Draw horizontal and vertical wires and buses only"
-msgstr "配線、バスを90度のみで描画"
-
-#: eeschema/schframe.cpp:776
-msgid "Do not show hidden pins"
-msgstr "非表示のピンを表示しない"
-
-#: eeschema/schframe.cpp:777 eeschema/tool_sch.cpp:296
-msgid "Show hidden pins"
-msgstr "非表示ピンを表示"
-
-#: eeschema/schframe.cpp:902
-msgid "Schematic"
-msgstr "回路図"
-
-#: eeschema/schframe.cpp:921
-msgid "New Schematic"
-msgstr "新規回路図"
-
-#: eeschema/schframe.cpp:934
-#, c-format
-msgid "Schematic file '%s' already exists, use Open instead"
-msgstr "回路図ファイル '%s' は既に存在します。"
-
-#: eeschema/schframe.cpp:954
-msgid "Open Schematic"
-msgstr "回路図を開く"
-
-#: eeschema/schframe.cpp:1111
-msgid "Error: not a component or no component"
-msgstr "Error: コンポーネントではありません、又はコンポーネントがありません"
-
-#: eeschema/schframe.cpp:1341
-msgid " [no file]"
-msgstr " [no file]"
-
-#: eeschema/selpart.cpp:65
-msgid "No component libraries are loaded."
-msgstr "コンポーネント ライブラリが読込まれていません"
-
-#: eeschema/selpart.cpp:139
-msgid "Select Component"
-msgstr "コンポーネントの選択"
-
-#: eeschema/sheet.cpp:84
-msgid "File name is not valid!"
-msgstr "ファイル名が不正です! "
-
-#: eeschema/sheet.cpp:93
-#, c-format
-msgid "A sheet named \"%s\" already exists."
-msgstr "シート名 \"%s\" は既に存在します。"
-
-#: eeschema/sheet.cpp:126
-#, c-format
-msgid "A file named '%s' already exists in the current schematic hierarchy."
-msgstr "名前'%s'のファイルは既に回路図階層内に存在しています。"
-
-#: eeschema/sheet.cpp:131
-#, c-format
-msgid "A file named '%s' already exists."
-msgstr "ファイル名 '%s' は既に存在しています。"
-
-#: eeschema/sheet.cpp:134
-msgid ""
-"\n"
-"\n"
-"Do you want to create a sheet with the contents of this file?"
-msgstr ""
-"\n"
-"\n"
-"このファイルの内容でシートを作成しますか？"
-
-#: eeschema/sheet.cpp:161
-msgid "Changing the sheet file name cannot be undone.  "
-msgstr "シートファイル名を変更すると元に戻せません。"
-
-#: eeschema/sheet.cpp:169
-#, c-format
-msgid "A file named <%s> already exists in the current schematic hierarchy."
-msgstr "ファイル名 <%s> は既に回路図階層内に存在しています。"
-
-#: eeschema/sheet.cpp:174
-#, c-format
-msgid "A file named <%s> already exists."
-msgstr "ファイル名 <%s> は既に存在します。"
-
-#: eeschema/sheet.cpp:179
-msgid ""
-"\n"
-"\n"
-"Do you want to replace the sheet with the contents of this file?"
-msgstr ""
-"\n"
-"\n"
-"このファイルの内容でシートを置換しますか？"
-
-#: eeschema/sheet.cpp:191
-msgid ""
-"This sheet uses shared data in a complex hierarchy.\n"
-"\n"
-msgstr ""
-"このシートは複雑な階層の中で共有データを使用しています。\n"
-"\n"
-
-#: eeschema/sheet.cpp:192
-msgid "Do you wish to convert it to a simple hierarchical sheet?"
-msgstr "シンプルな階層シートに変換しますか？"
-
-#: eeschema/sheetlab.cpp:164
-msgid "No new hierarchical labels found."
-msgstr "新しい階層ラベルが見つかりません"
-
-#: eeschema/symbedit.cpp:65
-msgid "Import Symbol Drawings"
-msgstr "シンボル図形をインポート"
-
-#: eeschema/symbedit.cpp:87
-#, c-format
-msgid "Error '%s' occurred loading part file '%s'."
-msgstr "エラー '%s' がコンポーネントファイル '%s' の読み込み時に発生しました。"
-
-#: eeschema/symbedit.cpp:98
-#, c-format
-msgid "No parts found in part file '%s'."
-msgstr "シンボル ライブラリ '%s' 内にコンポーネントがありません。"
-
-#: eeschema/symbedit.cpp:108
-#, c-format
-msgid "More than one part in part file '%s'."
-msgstr "パーツファイル '%s' 内に1つ以上のパーツがあります。"
-
-#: eeschema/symbedit.cpp:111 common/confirm.cpp:75 common/pgm_base.cpp:831
-msgid "Warning"
-msgstr "警告"
-
-#: eeschema/symbedit.cpp:158
-msgid "Export Symbol Drawings"
-msgstr "シンボル図形のエクスポート"
-
-#: eeschema/symbedit.cpp:174
-#, c-format
-msgid "Saving symbol in '%s'"
-msgstr "シンボルを \"%s\" へ保存中"
-
-#: eeschema/symbedit.cpp:240
-#, c-format
-msgid "An error occurred attempting to save symbol file '%s'"
-msgstr "シンボルファイル '%s' を保存しようとしたところエラーが発生しました。"
-
-#: eeschema/tool_lib.cpp:62
-msgid "Deselect current tool"
-msgstr "現在のツールの選択を外す"
-
-#: eeschema/tool_lib.cpp:83
-msgid "Move part anchor"
-msgstr "パーツのアンカーを移動"
-
-#: eeschema/tool_lib.cpp:86
-msgid "Import existing drawings"
-msgstr "既存の図形のインポート"
-
-#: eeschema/tool_lib.cpp:89
-msgid "Export current drawing"
-msgstr "現在の図形のエクスポート"
-
-#: eeschema/tool_lib.cpp:112
-msgid "Save current library to disk"
-msgstr "ディスクに現在のライブラリを保存"
-
-#: eeschema/tool_lib.cpp:118
-msgid "Delete component in current library"
-msgstr "現在のライブラリのコンポーネントを削除"
-
-#: eeschema/tool_lib.cpp:126
-msgid "Create a new component"
-msgstr "新規コンポーネントを作成"
-
-#: eeschema/tool_lib.cpp:130
-msgid "Load component to edit from the current library"
-msgstr "現在のライブラリから、エディタへコンポーネントを読み込む"
-
-#: eeschema/tool_lib.cpp:134
-msgid "Create a new component from the current one"
-msgstr "現在のものから新規コンポーネントを作成"
-
-#: eeschema/tool_lib.cpp:138
-msgid "Update current component in current library"
-msgstr "現在のライブラリ内の現在のコンポーネントを更新"
-
-#: eeschema/tool_lib.cpp:141
-msgid "Import component"
-msgstr "コンポーネントのインポート"
-
-#: eeschema/tool_lib.cpp:144
-msgid "Export component"
-msgstr "コンポーネントのエクスポート"
-
-#: eeschema/tool_lib.cpp:147
-msgid "Save current component to new library"
-msgstr "新しいライブラリへ現在のコンポーネントを保存"
-
-#: eeschema/tool_lib.cpp:150 eeschema/help_common_strings.h:40
-msgid "Undo last command"
-msgstr "一つ前のコマンドを元に戻す"
-
-#: eeschema/tool_lib.cpp:152
-msgid "Redo the last command"
-msgstr "一つ前のコマンドをやり直し"
-
-#: eeschema/tool_lib.cpp:158
-msgid "Edit component properties"
-msgstr "コンポーネント プロパティの編集"
-
-#: eeschema/tool_lib.cpp:162
-msgid "Add and remove fields and edit field properties"
-msgstr "フィールドの追加/削除とプロパティの編集"
-
-#: eeschema/tool_lib.cpp:166
-msgid "Test for duplicate and off grid pins"
-msgstr "重複ピンとグリッドから外れたピンのテスト"
-
-#: eeschema/tool_lib.cpp:183 eeschema/tool_viewlib.cpp:98
-msgid "Show as \"De Morgan\" normal part"
-msgstr "\"ド・モルガン\" 標準部品として表示"
-
-#: eeschema/tool_lib.cpp:185 eeschema/tool_viewlib.cpp:103
-msgid "Show as \"De Morgan\" convert part"
-msgstr "\"ド・モルガン\" 変換部品として表示"
-
-#: eeschema/tool_lib.cpp:189
-msgid "Show the associated datasheet or document"
-msgstr "関連するデータシートまたはドキュメントを表示する"
-
-#: eeschema/tool_lib.cpp:209
-msgid "Edit pins per part or body style (Use carefully!)"
-msgstr "パーツ/ボディ形状ごとのピンの編集 (気をつけて使うこと!)"
-
-#: eeschema/tool_lib.cpp:213
-msgid "Show pin table"
-msgstr "ピン テーブルの表示"
-
-#: eeschema/tool_lib.cpp:229 eeschema/tool_sch.cpp:279
-#: gerbview/toolbars_gerber.cpp:151
-msgid "Turn grid off"
-msgstr "グリッド非表示"
-
-#: eeschema/tool_sch.cpp:58
-msgid "New schematic project"
-msgstr "新規回路図作成"
-
-#: eeschema/tool_sch.cpp:61
-msgid "Open schematic project"
-msgstr "既存回路図を開く"
-
-#: eeschema/tool_sch.cpp:65
-msgid "Save schematic project"
-msgstr "回路図プロジェクトの保存"
-
-#: eeschema/tool_sch.cpp:71 pagelayout_editor/toolbars_pl_editor.cpp:61
-msgid "Page settings"
-msgstr "ページの設定"
-
-#: eeschema/tool_sch.cpp:76
-msgid "Print schematic"
-msgstr "回路図の印刷"
-
-#: eeschema/tool_sch.cpp:82
-msgid "Cut selected item"
-msgstr "選択したアイテムを切り取り"
-
-#: eeschema/tool_sch.cpp:85
-msgid "Copy selected item"
-msgstr "選択したアイテムをコピー"
-
-#: eeschema/tool_sch.cpp:88
-msgid "Paste"
-msgstr "貼り付け"
-
-#: eeschema/tool_sch.cpp:106
-msgid "Find and replace text"
-msgstr "テキストの検索と置換"
-
-#: eeschema/tool_sch.cpp:128
-msgid "Navigate schematic hierarchy"
-msgstr "回路図の階層ナビゲータを表示"
-
-#: eeschema/tool_sch.cpp:132
-msgid "Leave sheet"
-msgstr "シートから抜ける"
-
-#: eeschema/tool_sch.cpp:152
-msgid "Generate netlist"
-msgstr "ネットリストの生成"
-
-#: eeschema/tool_sch.cpp:170
-msgid "Run CvPcb to associate components and footprints"
-msgstr "CvPcb (コンポーネントとフットプリントの関連付け) を実行"
-
-#: eeschema/tool_sch.cpp:174
-msgid "Run Pcbnew to layout printed circuit board"
-msgstr "Pcbnew (プリント基板のレイアウト) の実行"
-
-#: eeschema/tool_sch.cpp:201
-msgid "Ascend/descend hierarchy"
-msgstr "階層の上下移動"
-
-#: eeschema/tool_sch.cpp:257 eeschema/help_common_strings.h:90
-msgid "Add bitmap image"
-msgstr "ビットマップイメージの追加"
-
-#: eeschema/tool_sch.cpp:283
-msgid "Set unit to inch"
-msgstr "単位をインチ系に設定"
-
-#: eeschema/tool_sch.cpp:287
-msgid "Set unit to mm"
-msgstr "単位をmm系に設定"
-
-#: eeschema/tool_sch.cpp:301
-msgid "HV orientation for wires and bus"
-msgstr "配線、バスの90度入力"
-
-#: eeschema/tool_viewlib.cpp:63
-msgid "Select component to browse"
-msgstr "参照するパーツの選択"
-
-#: eeschema/tool_viewlib.cpp:68
-msgid "Display previous component"
-msgstr "前のコンポーネントの表示"
-
-#: eeschema/tool_viewlib.cpp:72
-msgid "Display next component"
-msgstr "次のコンポーネントを表示"
-
-#: eeschema/tool_viewlib.cpp:116
-msgid "View component documents"
-msgstr "コンポーネントのドキュメントを見る "
-
-#: eeschema/tool_viewlib.cpp:124
-msgid "Insert component in schematic"
-msgstr "回路図にコンポーネントを挿入"
-
-#: eeschema/tool_viewlib.cpp:170
-#, c-format
-msgid "Unit %c"
-msgstr "ユニット %c"
-
-#: eeschema/tool_viewlib.cpp:219
-msgid "Close schematic component viewer"
-msgstr "回路図 コンポーネント ビューアを閉じる"
-
-#: eeschema/dialogs/dialog_annotate.cpp:195
-msgid "Clear and annotate all of the components on the entire schematic?"
-msgstr ""
-"全回路図の全てコンポーネントについて、アノテーションをクリアしてやり直します"
-"か？"
-
-#: eeschema/dialogs/dialog_annotate.cpp:197
-msgid "Clear and annotate all of the components on the current sheet?"
-msgstr ""
-"現在のシートの全てコンポーネントについて、アノテーションをクリアしてやり直し"
-"ますか？"
-
-#: eeschema/dialogs/dialog_annotate.cpp:203
-msgid "Annotate only the unannotated components on the entire schematic?"
-msgstr ""
-"全回路図のアノテートされていないコンポーネントに対してのみ、アノテーションを"
-"実行しますか？"
-
-#: eeschema/dialogs/dialog_annotate.cpp:205
-msgid "Annotate only the unannotated components on the current sheet?"
-msgstr ""
-"現在のシートのアノテートされていないコンポーネントに対してのみ、アノテーショ"
-"ンを実行しますか？"
-
-#: eeschema/dialogs/dialog_annotate.cpp:208
-msgid ""
-"\n"
-"\n"
-"This operation will change the current annotation and cannot be undone."
-msgstr ""
-"\n"
-"\n"
-"この操作は現在のアノテーションを変更し、取り消すことができません。"
-
-#: eeschema/dialogs/dialog_annotate.cpp:248
-msgid "Clear the existing annotation for the entire schematic?"
-msgstr "全回路図の既存のアノテーションを削除しますか？"
-
-#: eeschema/dialogs/dialog_annotate.cpp:250
-msgid "Clear the existing annotation for the current sheet?"
-msgstr "現在のシートの既存のアノテーションを削除しますか？"
-
-#: eeschema/dialogs/dialog_annotate.cpp:252
-msgid ""
-"\n"
-"\n"
-"This operation will clear the existing annotation and cannot be undone."
-msgstr ""
-"\n"
-"\n"
-"この操作は既存のアノテーションをクリアし、取り消すことができません。"
-
-#: eeschema/dialogs/dialog_annotate_base.cpp:28
-msgid "Scope"
-msgstr "実行範囲"
-
-#: eeschema/dialogs/dialog_annotate_base.cpp:37
-msgid "Use the &entire schematic"
-msgstr "全ての回路図、階層を使用(&E)"
-
-#: eeschema/dialogs/dialog_annotate_base.cpp:40
-msgid "Use the current &page only"
-msgstr "現在のページでのみ使用(&P)"
-
-#: eeschema/dialogs/dialog_annotate_base.cpp:46
-msgid "&Keep existing annotation"
-msgstr "既存のアノテーションをキープ(&K)"
-
-#: eeschema/dialogs/dialog_annotate_base.cpp:49
-msgid "&Reset existing annotation"
-msgstr "既存のアノテーションをリセット(&R)"
-
-#: eeschema/dialogs/dialog_annotate_base.cpp:52
-msgid "R&eset, but do not swap any annotated multi-unit parts"
-msgstr ""
-"既存のアノテーションをリセット、ただし複数ユニットを持つ部品はキープ(&E)"
-
-#: eeschema/dialogs/dialog_annotate_base.cpp:61
-msgid "Annotation Order"
-msgstr "アノテーションの順番"
-
-#: eeschema/dialogs/dialog_annotate_base.cpp:73
-msgid "Sort components by &X position"
-msgstr "コンポーネントを X位置でソート(&X)"
-
-#: eeschema/dialogs/dialog_annotate_base.cpp:88
-msgid "Sort components by &Y position"
-msgstr "コンポーネントを Y位置でソート(&Y)"
-
-#: eeschema/dialogs/dialog_annotate_base.cpp:109
-msgid "Annotation Choice"
-msgstr "アノテーションの選択"
-
-#: eeschema/dialogs/dialog_annotate_base.cpp:121
-msgid "Use first free number in schematic"
-msgstr "回路図中の最初の空き番号から使用する"
-
-#: eeschema/dialogs/dialog_annotate_base.cpp:133
-msgid "Start to  sheet number*100 and use first free number"
-msgstr "シートのRef番号を *100から開始し、最初の空き番号から使用する"
-
-#: eeschema/dialogs/dialog_annotate_base.cpp:145
-msgid "Start to  sheet number*1000 and use first free number"
-msgstr "シートのRef番号を *1000 から開始し、最初の空き番号から使用する"
-
-#: eeschema/dialogs/dialog_annotate_base.cpp:166
-msgid "Dialog"
-msgstr "ダイアログ"
-
-#: eeschema/dialogs/dialog_annotate_base.cpp:178
-msgid "Keep this dialog open"
-msgstr "ダイアログを自動的に閉じない"
-
-#: eeschema/dialogs/dialog_annotate_base.cpp:190
-msgid "Always ask for confirmation"
-msgstr "常に確認ダイアログを表示する"
-
-#: eeschema/dialogs/dialog_annotate_base.cpp:215
-msgid "Clear Annotation"
-msgstr "アノテーション クリア"
-
-#: eeschema/dialogs/dialog_annotate_base.cpp:218
-msgid "Annotate"
-msgstr "アノテーション"
-
-#: eeschema/dialogs/dialog_bom.cpp:321
-#, c-format
-msgid "Failed to open file '%s'"
-msgstr "ファイル '%s' が開けませんでした"
-
-#: eeschema/dialogs/dialog_bom.cpp:447
-msgid "Plugin name in plugin list"
-msgstr "プラグイン リストにあるプラグイン名"
-
-#: eeschema/dialogs/dialog_bom.cpp:448
-msgid "Plugin name"
-msgstr "プラグイン名"
-
-#: eeschema/dialogs/dialog_bom.cpp:458
-msgid "This name already exists. Abort"
-msgstr "このファイル名は既に使用されています。中止しました。"
-
-#: eeschema/dialogs/dialog_bom.cpp:486 eeschema/dialogs/dialog_netlist.cpp:840
-msgid "Plugin files:"
-msgstr "プラグイン ファイル:"
-
-#: eeschema/dialogs/dialog_bom.cpp:578
-msgid "Plugin file name not found. Cannot edit plugin file"
-msgstr ""
-"プラグインファイル名が見つかりませんでした。プラグインファイルの編集はできま"
-"せん。"
-
-#: eeschema/dialogs/dialog_bom.cpp:588
-msgid "No text editor selected in KiCad. Please choose it"
-msgstr "エディタが設定されていません。一つ選択してください。"
-
-#: eeschema/dialogs/dialog_bom.cpp:593
-msgid "Bom Generation Help"
-msgstr "部品表生成に関するヘルプ"
-
-#: eeschema/dialogs/dialog_bom_base.cpp:37
-msgid "Plugins"
-msgstr "プラグイン"
-
-#: eeschema/dialogs/dialog_bom_base.cpp:58
-#: eeschema/dialogs/dialog_netlist_base.cpp:46
-msgid "Generate"
-msgstr "生成"
-
-#: eeschema/dialogs/dialog_bom_base.cpp:65
-#: common/dialogs/dialog_env_var_config_base.cpp:73
-msgid "Help"
-msgstr "ヘルプ"
-
-#: eeschema/dialogs/dialog_bom_base.cpp:71
-#: eeschema/dialogs/dialog_netlist_base.cpp:52
-msgid "Add Plugin"
-msgstr "プラグインの追加"
-
-#: eeschema/dialogs/dialog_bom_base.cpp:74
-#: eeschema/dialogs/dialog_netlist_base.cpp:55
-msgid "Remove Plugin"
-msgstr "プラグインの削除"
-
-#: eeschema/dialogs/dialog_bom_base.cpp:77
-msgid "Edit Plugin File"
-msgstr "プラグインファイルの編集"
-
-#: eeschema/dialogs/dialog_bom_base.cpp:89
-msgid "Command line:"
-msgstr "コマンドライン:"
-
-#: eeschema/dialogs/dialog_bom_base.cpp:102
-msgid "Plugin Info:"
-msgstr "プラグイン情報:"
-
-#: eeschema/dialogs/dialog_choose_component.cpp:252
-msgid "Description\n"
-msgstr "説明\n"
-
-#: eeschema/dialogs/dialog_choose_component.cpp:265
-msgid "Keywords\n"
-msgstr "キーワード\n"
-
-#: eeschema/dialogs/dialog_choose_component.cpp:279
-msgid "Alias of "
-msgstr "エイリアス: "
-
-#: eeschema/dialogs/dialog_color_config.cpp:61
-msgid "Wire"
-msgstr "ワイヤ"
-
-#: eeschema/dialogs/dialog_color_config.cpp:62
-msgid "Bus"
-msgstr "バス"
-
-#: eeschema/dialogs/dialog_color_config.cpp:63 eeschema/sch_junction.h:86
-msgid "Junction"
-msgstr "ジャンクション (接続点)"
-
-#: eeschema/dialogs/dialog_color_config.cpp:65
-msgid "Global label"
-msgstr "グローバル ラベル"
-
-#: eeschema/dialogs/dialog_color_config.cpp:66
-msgid "Net name"
-msgstr "ネット名"
-
-#: eeschema/dialogs/dialog_color_config.cpp:67
-msgid "Notes"
-msgstr "注釈"
-
-#: eeschema/dialogs/dialog_color_config.cpp:68
-msgid "No Connect Symbol"
-msgstr "空き端子フラグ"
-
-#: eeschema/dialogs/dialog_color_config.cpp:74
-msgid "Body background"
-msgstr "ボディ背景色"
-
-#: eeschema/dialogs/dialog_color_config.cpp:76
-msgid "Pin number"
-msgstr "ピン ナンバー"
-
-#: eeschema/dialogs/dialog_color_config.cpp:77
-msgid "Pin name"
-msgstr "ピン名"
-
-#: eeschema/dialogs/dialog_color_config.cpp:85
-#: eeschema/dialogs/dialog_color_config.cpp:104
-msgid "Sheet"
-msgstr "シート"
-
-#: eeschema/dialogs/dialog_color_config.cpp:86
-msgid "Sheet file name"
-msgstr "シート ファイル名"
-
-#: eeschema/dialogs/dialog_color_config.cpp:87
-msgid "Sheet name"
-msgstr "シート名"
-
-#: eeschema/dialogs/dialog_color_config.cpp:88
-msgid "Sheet label"
-msgstr "シート ラベル"
-
-#: eeschema/dialogs/dialog_color_config.cpp:89
-msgid "Hierarchical label"
-msgstr "階層ラベル"
-
-#: eeschema/dialogs/dialog_color_config.cpp:94
-msgid "Erc warning"
-msgstr "ERC 警告"
-
-#: eeschema/dialogs/dialog_color_config.cpp:95
-msgid "Erc error"
-msgstr "ERC エラー"
-
-#: eeschema/dialogs/dialog_color_config.cpp:105
-msgid "Miscellaneous"
-msgstr "その他"
-
-#: eeschema/dialogs/dialog_color_config.cpp:191
-msgid "White"
-msgstr "白"
-
-#: eeschema/dialogs/dialog_color_config.cpp:192
-msgid "Black"
-msgstr "黒"
-
-#: eeschema/dialogs/dialog_color_config.cpp:193 3d-viewer/3d_toolbar.cpp:204
-msgid "Background Color"
-msgstr "背景色"
-
-#: eeschema/dialogs/dialog_color_config.cpp:288
-msgid ""
-"Warning:\n"
-"Some items have the same color as the background\n"
-"and they will not be seen on screen"
-msgstr ""
-"警告:\n"
-"いくつかのアイテムが背景色と同色です\n"
-"それらは画面上で見えないかもしれません"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:72
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.h:114
-msgid "Library Component Properties"
-msgstr "ライブラリ コンポーネントのプロパティ"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:81
-#, c-format
-msgid "Properties for %s (alias of %s)"
-msgstr "%s のプロパティ( %s のエイリアス)"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:86
-#, c-format
-msgid "Properties for %s"
-msgstr "%s のプロパティ"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:165
-#, c-format
-msgid "Number of Units (max allowed %d)"
-msgstr "ユニット数(最大値は %d)"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:299
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:375
-#, c-format
-msgid "Alias <%s> cannot be removed while it is being edited!"
-msgstr "エイリアス <%s> は編集中に削除できません！"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:305
-msgid "Remove all aliases from list?"
-msgstr "リストから全てのエイリアスを削除しますか？"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:326
-msgid "New alias:"
-msgstr "新規エイリアス:"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:326
-msgid "Component Alias"
-msgstr "コンポーネント エイリアス"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:340
-#, c-format
-msgid "Alias or component name <%s> already in use."
-msgstr "エイリアス又はコンポーネント名 <%s> は既に使用中です。"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:349
-#, c-format
-msgid "Alias or component name <%s> already exists in library <%s>."
-msgstr ""
-"エイリアスかコンポーネント名 <%s> は既にライブラリ <%s> 中に存在します。"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:406
-msgid "Delete extra parts from component?"
-msgstr "コンポーネントから余計なパーツを削除しますか？"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:426
-msgid "Add new pins for alternate body style ( DeMorgan ) to component?"
-msgstr ""
-"(ド・モルガン) 代替ボディスタイル用にコンポーネントに新しいピンを追加します"
-"か？"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:431
-msgid "Delete alternate body style (DeMorgan) draw items from component?"
-msgstr ""
-"(ド・モルガン) 代替ボディスタイル用の図形アイテムをコンポーネントから削除しま"
-"すか？"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:456 common/eda_doc.cpp:144
-msgid "Doc Files"
-msgstr "ドキュメント ファイル"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:493
-msgid "OK to delete the footprint filter list ?"
-msgstr "フットプリントフィルタの一覧を削除して宜しいですか?"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:514
-msgid "Add Footprint Filter"
-msgstr "フットプリント フィルタの追加"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:514
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:244
-msgid "Footprint Filter"
-msgstr "フットプリント フィルター"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:531
-#, c-format
-msgid "Foot print filter <%s> is already defined."
-msgstr "フットプリント フィルタ <%s> は既に定義されています。"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib.cpp:567
-msgid "Edit footprint filter"
-msgstr "フットプリントフィルタの編集"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:30
-msgid "Has alternate symbol (DeMorgan)"
-msgstr "(ド・モルガン)代替ボディスタイルが存在します"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:31
-msgid ""
-"Check this option if the component has an alternate body style (De Morgan)"
-msgstr ""
-"コンポーネントが代替表示形式(ド・モルガン)を持っている場合に、チェックを入れ"
-"て下さい"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:35
-msgid "Show pin number"
-msgstr "ピン番号の表示"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:37
-msgid "Show or hide pin numbers"
-msgstr "ピン番号を表示/非表示"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:41
-msgid "Show pin name"
-msgstr "ピン名を表示"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:43
-msgid "Show or hide pin names"
-msgstr "ピン名の表示/非表示"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:47
-msgid "Place pin names inside"
-msgstr "ピン名を内側に配置"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:49
-msgid ""
-"Check this option to have pin names inside the body and pin number outside.\n"
-"If not checked pins names and pins numbers are outside."
-msgstr ""
-"ピン名をボディ内側に表示し、ピン番号を外側に表示する場合にチェックしてくださ"
-"い。\n"
-"チェックがない場合、ピン名とピン番号は外側に表示されます。"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:65
-msgid "Number of Units"
-msgstr "ユニット数"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:67
-msgid ""
-"Enter the number of units for a component that contains more than one unit"
-msgstr ""
-"1つのコンポーネントが複数の部品を保つ場合、いくつの部品を持つか数を入力して下"
-"さい"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:80
-msgid "Pin Name Position Offset"
-msgstr "ピン名の位置オフセット"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:82
-msgid ""
-"Margin (in 0.001 inches) between a pin name position and the component "
-"body.\n"
-"A value from 10 to 40 is usually good."
-msgstr ""
-"ピン名とコンポーネントのボディ間の余白 (0.001インチ単位指定) \n"
-"通常は10～40を推奨します。"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:98
-msgid "Define as power symbol"
-msgstr "電源シンボルとして定義"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:99
-msgid "Check this option when the component is a power symbol"
-msgstr ""
-"電源シンボルとしてコンポーネントを作成するとき、このオプションをチェック"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:103
-msgid "All units are not interchangeable"
-msgstr "複数ユニットでのユニット交換不可"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:104
-msgid ""
-"Check this option when creating multiple unit components and all units are "
-"not interchangeable"
-msgstr ""
-"複数ユニットから成るコンポーネントの場合、ユニットの入れ替えを許可しない場合"
-"にチェックを入れて下さい。"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:119
-msgid ""
-"A short description that is displayed in Eeschema.\n"
-"Can be a very good help when selecting components in libraries components "
-"lists."
-msgstr ""
-"Eeschema に表示される短い説明です。\n"
-"ライブラリコンポーネントリストからコンポーネントを選択する際の助けになりま"
-"す。"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:129
-msgid ""
-"Enter key words that can be used to select this component.\n"
-"Key words cannot have spaces and are separated by a space."
-msgstr ""
-"コンポーネントを選択するのに使うキーワードの入力。\n"
-"キーワードはスペース区切りで入力できます。"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:137
-msgid "Documentation File Name"
-msgstr "ドキュメントファイル名"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:139
-msgid ""
-"Enter the documentation file (a .pdf document) associated to the component."
-msgstr ""
-"コンポーネントに関連付けるドキュメントファイル (1つのpdfドキュメント) を入力"
-"します。"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:150
-msgid "Copy Document from Parent"
-msgstr "親要素からドキュメント情報をコピー"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:153
-msgid "Browse Files"
-msgstr "ファイルを開く"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:171
-msgid "Alias List"
-msgstr "エイリアスの一覧"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:173
-msgid ""
-"An alias is a component that uses the body of its root component.\n"
-"It has its own documentation and keywords.\n"
-"A fast way to extend a library with similar components"
-msgstr ""
-"エイリアスとは、元となるコンポーネントの形状を引き継いだ、別名のコンポーネン"
-"トです。\n"
-"エイリアスは形状は元コンポーネントのものを使用しますが、独自のドキュメントと"
-"キーワードを持ちます。\n"
-"同じコンポーネント形状を用いてライブラリを拡張する早い方法です。"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:192
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:234
-msgid "Delete All"
-msgstr "全て削除"
-
-#: eeschema/dialogs/dialog_edit_component_in_lib_base.cpp:212
-msgid ""
-"A list of footprints names that can be used for this component.\n"
-"Footprints names can used jockers.\n"
-"(like sm* to allow all footprints names starting by sm)."
-msgstr ""
-"このコンポーネントに使用できるフットプリント名のリストです。\n"
-"フットプリント名にはワイルドカードを使用できます。\n"
-"(sm で始まる全てのフットプリント名を許可するには sm* のように)"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:220
-#, c-format
-msgid "Component '%s' found in library '%s'"
-msgstr "コンポーネント '%s' はライブラリ '%s' 中に見つかりました"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:226
-#, c-format
-msgid "Component '%s' not found in any library"
-msgstr "コンポーネント '%s' がどのライブラリにも見つかりませんでした"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:242
-msgid "However, some candidates are found:"
-msgstr "他のいくつかの候補が見つかりました:"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:248
-#, c-format
-msgid "'%s' found in library '%s'"
-msgstr "'%s' はライブラリ '%s' から見つかりました"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:310
-msgid "No Component Name!"
-msgstr "コンポーネント名がありません。"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:319
-#, c-format
-msgid "Component '%s' not found!"
-msgstr "コンポーネント '%s' が見つかりません!"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:393
-msgid "Illegal reference. A reference must start with a letter"
-msgstr "無効なリファレンスです。リファレンスは英字で始める必要があります。"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:419
-#, c-format
-msgid ""
-"The field name <%s> does not have a value and is not defined in the field "
-"template list.  Empty field values are invalid an will be removed from the "
-"component.  Do you wish to remove this and all remaining undefined fields?"
-msgstr ""
-"フィールド名 <%s> は値を持っておらず、フィールドテンプレートリストにも定義さ"
-"れていません。空のフィールド値は無効であり、コンポーネントから削除されます。"
-"これと残りの未定義フィールド全てを削除しますか？"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:426
-msgid "Remove Fields"
-msgstr "フィールドの削除"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:845
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:216
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:697
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:124
-msgid "Show in Browser"
-msgstr "ブラウザ内に表示"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic.cpp:847
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:699
-msgid "Assign Footprint"
-msgstr "フットプリントの割り当て"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:37
-msgid "Units are interchangeable:"
-msgstr "変換可能な単位系:"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:48
-msgid "+90"
-msgstr "+90"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:50
-msgid "Orientation (Degrees)"
-msgstr "角度 (度)"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:52
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:58
-msgid "Select if the component is to be rotated when drawn"
-msgstr "描画時にコンポーネントを回転する場合に選択"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:56
-msgid "Mirror ---"
-msgstr "横軸ミラー"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:56
-msgid "Mirror |"
-msgstr "縦軸ミラー"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:60
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:66
-msgid ""
-"Pick the graphical transformation to be used when displaying the component, "
-"if any"
-msgstr "コンポーネントを表示する際に使用するグラフィック変換を指定します。"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:64
-msgid "Converted Shape"
-msgstr "変換された形状"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:65
-msgid ""
-"Use the alternate shape of this component.\n"
-"For gates, this is the \"De Morgan\" conversion"
-msgstr ""
-"ゲート用にコンポーネントの代替シェイプを使う\n"
-"\"ド・モルガン\"変換を行います。"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:70
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:670
-msgid "Chip Name"
-msgstr "シンボル名"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:74
-msgid "The name of the symbol in the library from which this component came"
-msgstr "このコンポーネントを持ってきたライブラリ中のシンボル名です。"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:81
-msgid "Test"
-msgstr "テスト"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:84
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:41
-msgid "Select"
-msgstr "選択"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:105
-msgid "Reset to Library Defaults"
-msgstr "ライブラリのデフォルト値にリセット"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:106
-msgid ""
-"Set position and style of fields and component orientation  to default lib "
-"value.\n"
-"Fields texts are not modified."
-msgstr ""
-"フィールドの書式と位置およびコンポーネントの角度を、デフォルトのライブラリ値"
-"にセット\n"
-"フィールド文字は修正されません。"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:124
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:30
-msgid "Add Field"
-msgstr "フィールドの追加"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:125
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:31
-msgid "Add a new custom field"
-msgstr "フィールドを新規追加"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:129
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:35
-msgid "Delete Field"
-msgstr "フィールドの削除"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:130
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:36
-msgid "Delete one of the optional fields"
-msgstr "選択したフィールドを削除"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:135
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:41
-msgid "Move the selected optional fields up one position"
-msgstr "選択したオプションフィールドを一つ上と入れ替え"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:150
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:56
-msgid "Horiz. Justify"
-msgstr "水平に整列"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:154
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:62
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:103
-msgid "Bottom"
-msgstr "下"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:154
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:62
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:103
-msgid "Top"
-msgstr "上"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:156
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:64
-msgid "Vert. Justify"
-msgstr "垂直に整列"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:169
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:79
-msgid "Show"
-msgstr "表示する"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:170
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:80
-msgid "Check if you want this field visible"
-msgstr "このフィールドを可視化するならチェック"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:175
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:85
-msgid "Check if you want this field's text rotated 90 degrees"
-msgstr "このフィールドのテキストを90度回転させたいならチェック"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:186
-msgid "The style of the currently selected field's text in the schemati"
-msgstr "選択中のフィールドの文字書式"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:196
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:104
-#: eeschema/dialogs/dialog_eeschema_options.cpp:47
-msgid "Field Name"
-msgstr "フィールド名"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:202
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:212
-msgid ""
-"The name of the currently selected field\n"
-"Some fixed fields names are not editable"
-msgstr ""
-"現在選択中のフォールドの名前\n"
-"いくつかの固定フィールド名は編集不可"
+#: pcbnew/zones_by_polygon.cpp:539
+msgid "Error: a keepout area is allowed only on copper layers"
+msgstr "エラー: キープアウト(禁止)エリアは導体レイヤ上のみに配置できます。"
 
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:206
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:114
-msgid "Field Value"
-msgstr "フィールドの値"
+#: pcbnew/zones_by_polygon.cpp:686
+msgid "DRC error: this start point is inside or too close an other area"
+msgstr "DRCエラー: 開始点が内部にあるか、他のエリアに近すぎます"
 
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:217
-msgid ""
-"If your datasheet is an http:// link or a complete file path, then it may "
-"show in your browser by pressing this button."
-msgstr ""
-"もし設定されているデータシートのパスが、http://から始まるリンクや、完全なファ"
-"イルパスであった場合、このボタンをクリックすることでブラウザで表示させること"
-"ができます。"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:236
-msgid "The size of the currently selected field's text in the schematic"
-msgstr "選択中のフィールドの文字サイズ"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:244
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:152
-msgid "PosX"
-msgstr "X座標"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:250
-msgid "The X coordinate of the text relative to the component"
-msgstr "コンポーネントからテキストの相対X位置"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:258
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:164
-msgid "PosY"
-msgstr "Y座標"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.cpp:264
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:170
-msgid "The Y coordinate of the text relative to the component"
-msgstr "コンポーネントからテキストの相対Y位置"
-
-#: eeschema/dialogs/dialog_edit_label.cpp:151
-msgid "Global Label Properties"
-msgstr "グローバルラベルのプロパティ"
-
-#: eeschema/dialogs/dialog_edit_label.cpp:155
-msgid "Hierarchical Label Properties"
-msgstr "階層ラベルのプロパティ"
-
-#: eeschema/dialogs/dialog_edit_label.cpp:159
-msgid "Label Properties"
-msgstr "ラベルのプロパティ"
-
-#: eeschema/dialogs/dialog_edit_label.cpp:163
-msgid "Hierarchical Sheet Pin Properties."
-msgstr "階層シートピンのプロパティ"
-
-#: eeschema/dialogs/dialog_edit_label.cpp:167
-#: pcbnew/dialogs/dialog_pcb_text_properties_base.h:76
-msgid "Text Properties"
-msgstr "テキストのプロパティ"
-
-#: eeschema/dialogs/dialog_edit_label.cpp:228
-#, c-format
-msgid "H%s x W%s"
-msgstr "高さ%s x 幅%s"
-
-#: eeschema/dialogs/dialog_edit_label.cpp:294
-msgid "Empty Text!"
-msgstr "空のテキスト !"
-
-#: eeschema/dialogs/dialog_edit_label_base.cpp:25
-msgid "&Text:"
-msgstr "テキスト(&T):"
-
-#: eeschema/dialogs/dialog_edit_label_base.cpp:27
-msgid "Enter the text to be used within the schematic"
-msgstr "回路図内で使用されるテキストの入力"
-
-#: eeschema/dialogs/dialog_edit_label_base.cpp:47
-#: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:64
-msgid "&Size:"
-msgstr "サイズ(&S):"
-
-#: eeschema/dialogs/dialog_edit_label_base.cpp:57
-#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:125
-#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:137
-#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:149
-#: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.cpp:47
-#: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.cpp:59
-#: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:49
-#: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:72 common/common.cpp:179
-msgid "units"
-msgstr "ユニット"
-
-#: eeschema/dialogs/dialog_edit_label_base.cpp:72
-msgid "O&rientation"
-msgstr "角度(&R)"
-
-#: eeschema/dialogs/dialog_edit_label_base.cpp:78
-msgid "St&yle"
-msgstr "スタイル(&Y)"
-
-#: eeschema/dialogs/dialog_edit_label_base.cpp:84
-msgid "S&hape"
-msgstr "シェイプ(&H)"
-
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:243
-msgid "Illegal reference prefix. A reference must start by a letter"
-msgstr ""
-"無効なリファレンス接頭字です。リファレンスはアルファベット文字で始まる必要が"
-"あります。"
-
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib.cpp:259
-#, c-format
-msgid ""
-"A new name is entered for this component\n"
-"An alias %s already exists!\n"
-"Cannot update this component"
-msgstr ""
-"コンポーネントに入力された新しい名前\n"
-"エイリアス %s は既に存在します！\n"
-"コンポーネントを更新できません"
-
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:110
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:120
-msgid "The text (or value) of the currently selected field"
-msgstr "現在選択中のフィールドのテキスト (または値)"
-
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:125
-msgid ""
-"If your datasheet is given as an http:// link, then pressing this button "
-"should bring it up in your webbrowser."
-msgstr ""
-"もし設定されているデータシートのパスが、http://から始まるリンクであった場合、"
-"このボタンをクリックすることでブラウザで表示させることができます。"
-
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.cpp:144
-msgid ""
-"The vertical height of the currently selected field's text in the schematic"
-msgstr "選択中のフィールドの文字の文字高さ"
-
-#: eeschema/dialogs/dialog_edit_one_field.cpp:172
-#, c-format
-msgid ""
-"Whitespace is not permitted inside references or values (symbol names in "
-"lib).\n"
-"The text you entered has been converted to use underscores: %s"
-msgstr ""
-"空白文字の使用は、リファレンスと定数(ライブラリ内のシンボル名)の内部で許され"
-"ていません.\n"
-"入力された文字列内の空白文字はアンダースコアへ変換されます(: %s )"
-
-#: eeschema/dialogs/dialog_eeschema_config.cpp:137
-#, c-format
-msgid "Project '%s'"
-msgstr "プロジェクト '%s'"
-
-#: eeschema/dialogs/dialog_eeschema_config.cpp:315
-msgid "Library files:"
-msgstr "ライブラリ ファイル:"
-
-#: eeschema/dialogs/dialog_eeschema_config.cpp:375
-#, c-format
-msgid "'%s' : library already in use"
-msgstr "ライブラリ '%s' は使用中です"
-
-#: eeschema/dialogs/dialog_eeschema_config.cpp:390
-msgid "Default Path for Libraries"
-msgstr "ライブラリのデフォルト パス"
-
-#: eeschema/dialogs/dialog_eeschema_config.cpp:417
-msgid "Use a relative path?"
-msgstr "相対パスを使用しますか？"
-
-#: eeschema/dialogs/dialog_eeschema_config.cpp:437
-msgid "Path already in use"
-msgstr "パスは既に使用中です"
-
-#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:22
-msgid "Component library files"
-msgstr "コンポーネント ライブラリ ファイル:"
-
-#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:30
-msgid ""
-"List of active library files.\n"
-"Only library files in this list are loaded by Eeschema.\n"
-"The order of this list is important:\n"
-"Eeschema searchs for a given component using this list order priority."
-msgstr ""
-"アクティブなライブラリファイルのリスト\n"
-"Eeschema に読み込まれているライブラリファイルのリストを表示します。\n"
-"このリストの順番は重要です。\n"
-"Eeschema はこのリストの優先順序でフットプリントを検索します。"
-
-#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:39
-msgid "Add a new library after the selected library, and load it"
-msgstr "指定したライブラリを一覧の最後に追加"
-
-#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:44
-msgid "Add a new library before the selected library, and load it"
-msgstr "選択した項目の前に、指定したライブラリを追加"
-
-#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:49
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:40
-msgid "Unload the selected library"
-msgstr "選択したライブラリを削除"
-
-#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:71
-msgid "User defined search path"
-msgstr "ユーザ定義の検索パス"
-
-#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:79
-msgid ""
-"Additional paths used in this project. The priority is higher than default "
-"KiCad paths."
-msgstr ""
-"このプロジェクトに追加するパスを記述します。これらはデフォルトのKicadパスより"
-"も高い優先度となります。"
-
-#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:108
-msgid "Current search path list"
-msgstr "現在の検索パスのリスト"
-
-#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:113
-msgid ""
-"System and user paths used to search and load library files and component "
-"doc files.\n"
-"Sorted by decreasing priority order."
-msgstr ""
-"ライブラリファイルとコンポーネントドキュメントファイルの読み込みと検索に使用"
-"するシステムパスとユーザパスです。\n"
-"これは降順の優先度でソートされます。"
-
-#: eeschema/dialogs/dialog_eeschema_config_fbp.cpp:123
-msgid "Check for cache/library conflicts at schematic load"
-msgstr "回路図の読込み時にキャッシュ/ライブラリの衝突をチェック"
-
-#: eeschema/dialogs/dialog_eeschema_options.cpp:51
-msgid "Default Value"
-msgstr "標準値"
-
-#: eeschema/dialogs/dialog_eeschema_options.cpp:192
-msgid "Hidden"
-msgstr "非表示"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:53
-msgid "&Measurement units:"
-msgstr "計測単位(&M):"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:65
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:36
-msgid "&Grid size:"
-msgstr "グリッド サイズ(&G):"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:74
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:85
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:96
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:107
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:118
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:129
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:45
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:56
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:67
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:78
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:89
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:100
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:111
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:125
-msgid "mils"
-msgstr "mil"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:78
-msgid "&Default bus thickness:"
-msgstr "デフォルトのバス線幅(&D):"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:89
-msgid "D&efault line thickness:"
-msgstr "デフォルトの線幅(&e):"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:100
-msgid "De&fault text size:"
-msgstr "デフォルトのテキストサイズ(&f):"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:111
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:93
-msgid "&Horizontal pitch of repeated items:"
-msgstr "繰り返し配置の水平間隔(&H):"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:122
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:104
-msgid "&Vertical pitch of repeated items:"
-msgstr "繰り返し配置の垂直間隔(&V):"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:133
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:129
-msgid "&Increment of repeated labels:"
-msgstr "繰り返しラベルの増分値(&I):"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:143
-msgid "&Auto-save time interval"
-msgstr "自動保存の時間間隔(&A)"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:150
-msgid "minutes"
-msgstr "分"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:165
-msgid "&Part id notation:"
-msgstr "部品IDの表記方法(&P):"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:169
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:276
-msgid "A"
-msgstr "A"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:169
-msgid ".A"
-msgstr ".A"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:169
-msgid "-A"
-msgstr "-A"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:169
-msgid "_A"
-msgstr "_A"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:169
-msgid ".1"
-msgstr ".1"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:169
-msgid "-1"
-msgstr "-1"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:169
-msgid "_1"
-msgstr "_1"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:187
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:159
-msgid "&Show grid"
-msgstr "グリッドの表示(&S)"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:190
-msgid "Sho&w hidden pins"
-msgstr "非表示ピンを表示(&w)"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:198
-msgid "&Use middle mouse button to pan"
-msgstr "画面のパンにマウスの中ボタンを使う(&U)"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:203
-msgid "&Limit panning to scroll size"
-msgstr "パン可能な領域を、スクロールバーサイズ範囲内に制限する"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:208
-msgid "Pan while moving ob&ject"
-msgstr "オブジェクト移動時に表示領域を移動(&J)"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:211
-msgid "&Restrict buses and wires to H and V orientation"
-msgstr "バス、配線を90度入力に制限(&R)"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:214
-msgid "Show page limi&ts"
-msgstr "ページの境界を表示(&t)"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:227
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:95
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:617
-msgid "General Options"
-msgstr "全般 オプション"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:229
-msgid "User defined field names for schematic components. "
-msgstr "回路図コンポーネントに定義されたフィールド名を使用"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:240
-msgid "Field Settings"
-msgstr "フィールドの設定"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:242
-msgid "&Name"
-msgstr "名前(&N)"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:249
-msgid "D&efault Value"
-msgstr "デフォルト値(&e)"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:256
-#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:95
-msgid "&Visible"
-msgstr "可視化(&V)"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:262
-msgid "&Add"
-msgstr "追加(&A)"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.cpp:272
-msgid "Template Field Names"
-msgstr "フィールド名のテンプレート"
-
-#: eeschema/dialogs/dialog_erc.cpp:207
-msgid "Marker not found"
-msgstr "マーカーが見つかりません"
-
-#: eeschema/dialogs/dialog_erc.cpp:331
-msgid "No error or warning"
-msgstr "エラー/警告無し"
-
-#: eeschema/dialogs/dialog_erc.cpp:336
-msgid "Generate warning"
-msgstr "警告を生成"
-
-#: eeschema/dialogs/dialog_erc.cpp:341
-msgid "Generate error"
-msgstr "生成エラー"
-
-#: eeschema/dialogs/dialog_erc.cpp:446
-msgid "Annotation required!"
-msgstr "アノテーションの実行が必要です！"
-
-#: eeschema/dialogs/dialog_erc.cpp:551
-msgid "ERC File"
-msgstr "ERC ファイル"
-
-#: eeschema/dialogs/dialog_erc.cpp:552
-msgid "Electronic rule check file (.erc)|*.erc"
-msgstr "エレクトリック ルール チェック ファイル (.erc)|*.erc"
-
-#: eeschema/dialogs/dialog_erc_base.cpp:40
-msgid "ERC Report:"
-msgstr "ERCレポート:"
-
-#: eeschema/dialogs/dialog_erc_base.cpp:45
-msgid "Total:"
-msgstr "合計:"
-
-#: eeschema/dialogs/dialog_erc_base.cpp:52
-msgid "Warnings:"
-msgstr "警告:"
-
-#: eeschema/dialogs/dialog_erc_base.cpp:59
-msgid "Errors:"
-msgstr "エラー:"
-
-#: eeschema/dialogs/dialog_erc_base.cpp:69
-msgid "Create ERC file report"
-msgstr "ERCレポートファイルの生成"
-
-#: eeschema/dialogs/dialog_erc_base.cpp:91
-msgid "Error list:"
-msgstr "エラー一覧:"
-
-#: eeschema/dialogs/dialog_erc_base.cpp:103
-msgid "&Delete Markers"
-msgstr "マーカーの削除(&D)"
-
-#: eeschema/dialogs/dialog_erc_base.cpp:106
-msgid "&Run"
-msgstr "実行(&R)"
-
-#: eeschema/dialogs/dialog_erc_base.cpp:120
-msgid "ERC"
-msgstr "ERC"
-
-#: eeschema/dialogs/dialog_erc_base.cpp:125
-#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:86
-msgid "Reset"
-msgstr "リセット"
-
-#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:34
-msgid "&Width:"
-msgstr "幅(&W):"
-
-#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:52
-#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:81
-msgid "Sharing"
-msgstr "共有"
-
-#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:64
-#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:83
-msgid "Common to all &units in component"
-msgstr "コンポーネント内のすべてのパーツで共通化(&u)"
-
-#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:76
-#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:86
-msgid "Common to all body &styles (DeMorgan)"
-msgstr "全てのボディスタイル(ド・モルガン)で共有する(&S)"
-
-#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:85
-msgid "Fill Style"
-msgstr "塗りつぶしのスタイル"
-
-#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:100
-msgid "Do &not fill"
-msgstr "塗りつぶし無し(&N)"
-
-#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:104
-msgid "Fill &foreground"
-msgstr "前面色で塗りつぶし(&F)"
-
-#: eeschema/dialogs/dialog_lib_edit_draw_item_base.cpp:107
-msgid "Fill &background"
-msgstr "背景色で塗りつぶし(&B)"
-
-#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:33
-msgid "Pin &name:"
-msgstr "ピン名(&N):"
-
-#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:41
-msgid "Pin n&umber:"
-msgstr "ピン番号(&U)"
-
-#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:43
-msgid "Pin number: 1 to 4 ASCII letters and/or digits"
-msgstr "ピン番号: 1から4文字のASCII文字および数字"
-
-#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:51
-msgid "&Orientation:"
-msgstr "角度(&O):"
-
-#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:58
-msgid "&Electrical type:"
-msgstr "エレクトリック タイプ(&E):"
-
-#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:60
-msgid "Used by the ERC."
-msgstr "ERCで使用"
-
-#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:67
-msgid "Graphic &Style:"
-msgstr "グラフィック スタイル(&S):"
-
-#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:93
-msgid "Schematic Properties"
-msgstr "回路図上のプロパティ"
-
-#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:117
-msgid "N&ame text size:"
-msgstr "ピン名の文字サイズ(&A):"
-
-#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:129
-msgid "Number te&xt size:"
-msgstr "ピン番号の文字サイズ(&X):"
-
-#: eeschema/dialogs/dialog_lib_edit_pin_base.cpp:141
-msgid "&Length:"
-msgstr "長さ(&L):"
-
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:67
-msgid "Power component value text cannot be modified!"
-msgstr "電源コンポーネントの定数テキストは変更できません！"
-
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:85
-msgid "Common to all units"
-msgstr "全てのユニットで統一化"
+#: pcbnew/zones_by_polygon.cpp:745
+msgid "DRC error: closing this area creates a drc error with an other area"
+msgstr "DRCエラー: このゾーンを閉じると他のエリアとのDRCエラーが発生します"
 
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:88
-msgid "Common to all body styles"
-msgstr "全てのボディスタイルで統一化"
-
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:103
-msgid "Align left"
-msgstr "左寄せ"
-
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:103
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:109
-msgid "Align center"
-msgstr "中央寄せ"
-
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:103
-msgid "Align right"
-msgstr "右寄せ"
-
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:105
-msgid "Horizontal Justify"
-msgstr "水平に整列"
-
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:109
-msgid "Align bottom"
-msgstr "下寄せ"
-
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:109
-msgid "Align top"
-msgstr "上寄せ"
-
-#: eeschema/dialogs/dialog_lib_edit_text_base.cpp:111
-msgid "Vertical Justify"
-msgstr "垂直に整列"
-
-#: eeschema/dialogs/dialog_lib_new_component_base.cpp:22
-#: pcbnew/dialogs/dialog_general_options_BoardEditor_base.h:97
-msgid "General Settings"
-msgstr "一般設定"
-
-#: eeschema/dialogs/dialog_lib_new_component_base.cpp:34
-msgid "Component &name:"
-msgstr "コンポーネント名(&N):"
-
-#: eeschema/dialogs/dialog_lib_new_component_base.cpp:36
-msgid ""
-"This is the component name in library,\n"
-"and also the default component value when loaded in the schematic."
-msgstr ""
-"これはライブラリ中のコンポーネント名であり、\n"
-"回路図に読込む際のデフォルトのコンポーネントの値でもあります。"
-
-#: eeschema/dialogs/dialog_lib_new_component_base.cpp:44
-msgid "Default reference designator:"
-msgstr "デフォルトのリファレンス記号:"
-
-#: eeschema/dialogs/dialog_lib_new_component_base.cpp:48
-msgid "U"
-msgstr "U"
-
-#: eeschema/dialogs/dialog_lib_new_component_base.cpp:51
-msgid "Number of units per package:"
-msgstr "パッケージ内のユニット数:"
-
-#: eeschema/dialogs/dialog_lib_new_component_base.cpp:64
-msgid "Create component with alternate body style (DeMorgan)"
-msgstr "(ド・モルガン) 代替ボディスタイルを使ってコンポーネントを作成"
-
-#: eeschema/dialogs/dialog_lib_new_component_base.cpp:67
-msgid "Create component as power symbol"
-msgstr "電源シンボルとしてコンポーネントを作成する"
-
-#: eeschema/dialogs/dialog_lib_new_component_base.cpp:70
-msgid "Units are not interchangeable"
-msgstr "変換できない単位系です"
-
-#: eeschema/dialogs/dialog_lib_new_component_base.cpp:85
-msgid "General Pin Settings"
-msgstr "一般ピン設定"
-
-#: eeschema/dialogs/dialog_lib_new_component_base.cpp:96
-msgid "Pin text position offset:"
-msgstr "ピンテキストの位置オフセット"
-
-#: eeschema/dialogs/dialog_lib_new_component_base.cpp:109
-msgid "Show pin number text"
-msgstr "ピン番号のテキストの表示"
-
-#: eeschema/dialogs/dialog_lib_new_component_base.cpp:113
-msgid "Show pin name text"
-msgstr "ピン名テキストの表示"
-
-#: eeschema/dialogs/dialog_lib_new_component_base.cpp:117
-msgid "Pin name inside"
-msgstr "ピン名を内側に配置"
-
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:49
-msgid "&Default line width:"
-msgstr "デフォルトの線幅(&D):"
-
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:60
-msgid "D&efault pin length:"
-msgstr "デフォルトのピンの長さ(&e): "
-
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:71
-msgid "De&fault pin number size:"
-msgstr "デフォルトのピン番号サイズ(&f): "
-
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:82
-msgid "Def&ault pin name size:"
-msgstr "デフォルトのピン名サイズ(&a):"
-
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:115
-msgid "&Pitch of repeated pins:"
-msgstr "繰り返しピンのピッチ(&P):"
-
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:119
-msgid "100"
-msgstr "100"
-
-#: eeschema/dialogs/dialog_libedit_options_base.cpp:119
-msgid "50"
-msgstr "50"
-
-#: eeschema/dialogs/dialog_netlist.cpp:299
-msgid "Default format"
-msgstr "デフォルトの出力形式に設定"
-
-# NET作成して動作確認済み
-#: eeschema/dialogs/dialog_netlist.cpp:381
-msgid "Prefix references 'U' and 'IC' with 'X'"
-msgstr "リファレンス 'U' と 'IC' の前に接頭字 'X' を付ける"
-
-#: eeschema/dialogs/dialog_netlist.cpp:386
-msgid "Use net number as net name"
-msgstr "ネット名にネット番号を使用"
-
-#: eeschema/dialogs/dialog_netlist.cpp:390
-msgid "Simulator command:"
-msgstr "シミュレータ コマンド:"
-
-#: eeschema/dialogs/dialog_netlist.cpp:403
-msgid "&Run Simulator"
-msgstr "シミュレータの起動(&R)"
-
-#: eeschema/dialogs/dialog_netlist.cpp:443
-#: eeschema/dialogs/dialog_netlist_base.cpp:105
-msgid "Netlist command:"
-msgstr "ネットリスト コマンド:"
-
-#: eeschema/dialogs/dialog_netlist.cpp:456
-msgid "Title:"
-msgstr "タイトル:"
-
-#: eeschema/dialogs/dialog_netlist.cpp:536
-msgid "Save Netlist File"
-msgstr "ネットリスト ファイルの保存"
-
-#: eeschema/dialogs/dialog_netlist.cpp:571
-#, c-format
-msgid "%s Export"
-msgstr "エクスポート %s"
-
-#: eeschema/dialogs/dialog_netlist.cpp:622
-msgid "SPICE netlist file (.cir)|*.cir"
-msgstr "SPICEネットリスト ファイル (.cir)|*.cir"
-
-#: eeschema/dialogs/dialog_netlist.cpp:627
-msgid "CadStar netlist file (.frp)|*.frp"
-msgstr "CadStarネットリスト ファイル (.frp)|*.frp"
-
-#: eeschema/dialogs/dialog_netlist.cpp:783
-msgid "This plugin already exists. Abort"
-msgstr "このプラグインは既に存在するため、中止します。"
-
-#: eeschema/dialogs/dialog_netlist.cpp:810
-msgid "Error. You must provide a command String"
-msgstr "エラー: コマンド文字列を設定する必要があります"
-
-#: eeschema/dialogs/dialog_netlist.cpp:816
-msgid "Error. You must provide a Title"
-msgstr "エラー タイトルを設定してください"
-
-#: eeschema/dialogs/dialog_netlist.cpp:874
-msgid "Do not forget to choose a title for this netlist control page"
-msgstr ""
-"このネットリストのコントロールページからタイトルを選択することを忘れないでく"
-"ださい"
-
-#: eeschema/dialogs/dialog_netlist_base.cpp:61
-msgid "Use default netname"
-msgstr "デフォルトのネット名を使用"
-
-#: eeschema/dialogs/dialog_netlist_base.cpp:70
-msgid "Default Netlist Filename:"
-msgstr "デフォルトのネットリスト ファイル名:"
-
-#: eeschema/dialogs/dialog_netlist_base.cpp:136
-msgid "Browse Plugins"
-msgstr "プラグインの参照"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:33
-msgid ""
-"Target directory for plot files. Can be absolute or relative to the "
-"schematic main file location."
-msgstr ""
-"出図ファイルのターゲットディレクトリです。ボードファイルの位置に絶対パス、ま"
-"たは相対パスが使用できます。"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:48
-msgid "Paper Options"
-msgstr "用紙設定"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:50
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
-msgid "Schematic size"
-msgstr "回路図の大きさ"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:50
-msgid "Force size A4"
-msgstr "サイズを強制的にA4へ"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:50
-msgid "Force size A"
-msgstr "サイズを強制的にAへ"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:52
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:58
-msgid "Page Size:"
-msgstr "ページ サイズ:"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
-msgid "Page size A4"
-msgstr "ページ サイズ A4"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
-msgid "Page size A3"
-msgstr "ページ サイズ A3"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
-msgid "Page size A2"
-msgstr "ページ サイズ A2"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
-msgid "Page size A1"
-msgstr "ページ サイズ A1"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
-msgid "Page size A0"
-msgstr "ページ サイズ A0"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
-msgid "Page size A"
-msgstr "ページ サイズ A"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
-msgid "Page size B"
-msgstr "ページ サイズ B"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
-msgid "Page size C"
-msgstr "ページ サイズ C"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
-msgid "Page size D"
-msgstr "ページ サイズ D"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:62
-msgid "Page size E"
-msgstr "ページ サイズ E"
-
-# orペア下層
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:68
-msgid "Bottom left corner"
-msgstr "左下の角"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:68
-msgid "Center of the page"
-msgstr "ページ中央"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:74
-msgid "Pen width"
-msgstr "ペン幅"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:97
-msgid "Default line thickness"
-msgstr "標準の線幅"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:103
-msgid ""
-"Selection of the default pen thickness used to draw items, when their "
-"thickness is set to 0."
-msgstr ""
-"太さが０にセットされているアイテムを描画する時の、デフォルトのペン太さを選択"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:115
-msgid "Plot border and title block"
-msgstr "シートの図枠を印刷"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:126
-msgid "Plot Current Page"
-msgstr "現在のページをプロット"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.cpp:130
-msgid "Plot All Pages"
-msgstr "全てのページをプロット"
-
-#: eeschema/dialogs/dialog_print_using_printer.cpp:304
-msgid "Print Schematic"
-msgstr "回路図の印刷"
-
-#: eeschema/dialogs/dialog_print_using_printer.cpp:309
-msgid "An error occurred attempting to print the schematic."
-msgstr "回路図の印刷中にエラーが発生しました。"
-
-#: eeschema/dialogs/dialog_print_using_printer.cpp:310
-#: pagelayout_editor/dialogs/dialogs_for_printing.cpp:225
-msgid "Printing"
-msgstr "印刷中"
-
-#: eeschema/dialogs/dialog_print_using_printer.cpp:323
+#: pcbnew/zones_by_polygon_fill_functions.cpp:46
 #, c-format
-msgid "Print page %d"
-msgstr "印刷 (ページ:%d)"
-
-#: eeschema/dialogs/dialog_print_using_printer_base.cpp:22
-msgid "Print options:"
-msgstr "印刷設定:"
-
-#: eeschema/dialogs/dialog_print_using_printer_base.cpp:28
-msgid "Print sheet &reference and title block"
-msgstr "シートのリファレンスと図枠の印刷(&R)"
-
-#: eeschema/dialogs/dialog_print_using_printer_base.cpp:34
-msgid "Print in &black and white only"
-msgstr "モノクロ印刷(&B)"
-
-#: eeschema/dialogs/dialog_print_using_printer_base.cpp:44
-msgid "Page Setup"
-msgstr "用紙設定"
-
-#: eeschema/dialogs/dialog_rescue_each.cpp:85
-msgid ""
-"It looks like this project was made using older schematic component "
-"libraries.\n"
-"Some parts may need to be relinked to a different symbol name, and some "
-"symbols\n"
-"may need to be \"rescued\" (cloned and renamed) into a new library.\n"
-"\n"
-"The following changes are recommended to update the project."
-msgstr ""
-"このプロジェクトは古い回路図用のコンポーネントライブラリを使って作られている"
-"ようです。\n"
-"いくつかの部品は別のシンボル名へ再リンクする必要があると思われ, またいくつか"
-"のシンボルは\n"
-"新しいライブラリへ \"レスキュー\" (クローン化とリネーム) が必要と思われま"
-"す。\n"
-"\n"
-"次の変更はプロジェクトをアップデートするために推奨されるものです。"
-
-#: eeschema/dialogs/dialog_rescue_each.cpp:104
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:192
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:609
-msgid "Accept"
-msgstr "適用"
-
-#: eeschema/dialogs/dialog_rescue_each.cpp:105
-msgid "Symbol"
-msgstr "シンボル"
-
-#: eeschema/dialogs/dialog_rescue_each.cpp:106
-msgid "Action"
-msgstr "アクション"
-
-#: eeschema/dialogs/dialog_rescue_each.cpp:280
-msgid ""
-"Stop showing this tool?\n"
-"No changes will be made.\n"
-"\n"
-"This setting can be changed from the \"Component Libraries\" dialog,\n"
-"and the tool can be activated manually from the \"Tools\" menu."
-msgstr ""
-"このツールを終了しますか？\n"
-"何も変更されません. \n"
-"\n"
-"この設定は \"コンポーネント ライブラリ\" ダイアログから変更でき, \n"
-"ツールは \"ツール\" メニューから実行できます."
-
-#: eeschema/dialogs/dialog_rescue_each.cpp:284
-msgid "Rescue Components"
-msgstr "レスキュー コンポーネント"
-
-#: eeschema/dialogs/dialog_rescue_each_base.cpp:23
-msgid "Symbols to update:"
-msgstr "シンボルの更新"
-
-#: eeschema/dialogs/dialog_rescue_each_base.cpp:32
-msgid "Instances of this symbol:"
-msgstr "このシンボルのインスタンス"
-
-#: eeschema/dialogs/dialog_rescue_each_base.cpp:47
-msgid "Cached Part:"
-msgstr "キャッシュされた部品:"
-
-#: eeschema/dialogs/dialog_rescue_each_base.cpp:64
-msgid "Library Part:"
-msgstr "ライブラリの部品:"
-
-#: eeschema/dialogs/dialog_rescue_each_base.cpp:84
-msgid "Never Show Again"
-msgstr "再表示しない"
+msgid "Filling zone %d out of %d (net %s)..."
+msgstr "ゾーンの塗りつぶし中 %d out of %d (ネット %s)..."
 
-#: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.cpp:39
-msgid "Text height:"
-msgstr "テキスト高さ:"
+#: pcbnew/zones_by_polygon_fill_functions.cpp:140
+msgid "Fill All Zones"
+msgstr "全ゾーンの塗りつぶし"
 
-#: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.cpp:51
-msgid "Text width:"
-msgstr "テキスト幅:"
+#: pcbnew/zones_by_polygon_fill_functions.cpp:146
+msgid "Starting zone fill..."
+msgstr "ゾーンの塗りつぶしを開始しています..."
 
-#: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.cpp:63
-msgid "Connection type:"
-msgstr "接続のタイプ:"
+#: pcbnew/zones_by_polygon_fill_functions.cpp:175
+msgid "Updating ratsnest..."
+msgstr "ラッツネストの更新中..."
 
-#: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:28
-msgid "&File name:"
-msgstr "ファイル名(&F):"
+#: 3d-viewer/dialogs/dialog_3D_view_option_base.h:79
+msgid "3D Display Options"
+msgstr "3D表示オプション"
 
-#: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:41
-msgid "Si&ze:"
-msgstr "サイズ(&Z):"
+#: bitmap2component/bitmap2cmp_gui_base.h:92
+msgid "Bitmap to Component Converter"
+msgstr "ビットマップ - コンポーネント変換"
 
-#: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:53
-msgid "&Sheet name:"
-msgstr "シート名(&S):"
+#: common/dialog_about/dialog_about_base.h:51
+msgid "About..."
+msgstr "このソフトウェアについて(&A)"
 
-#: eeschema/dialogs/dialog_sch_sheet_props_base.cpp:94
-msgid "Unique timestamp:"
-msgstr "固有のタイムスタンプ:"
+#: common/dialogs/dialog_env_var_config_base.h:53
+msgid "Path Configuration"
+msgstr "環境変数の設定"
 
-#: eeschema/dialogs/dialog_schematic_find.cpp:39
-#: pcbnew/dialogs/dialog_find_base.h:54
-#: eeschema/dialogs/dialog_schematic_find_base.h:76
-msgid "Find"
-msgstr "検索"
+#: common/dialogs/dialog_hotkeys_editor_base.h:53
+msgid "Hotkeys Editor"
+msgstr "ホットキー エディタ"
 
-#: eeschema/dialogs/dialog_schematic_find.cpp:48
-msgid "Find and Replace"
-msgstr "検索と置換"
+#: common/dialogs/dialog_image_editor_base.h:64
+msgid "Image Editor"
+msgstr "イメージ エディタ"
 
-#: eeschema/dialogs/dialog_schematic_find_base.cpp:28
-msgid "&Search for:"
-msgstr "検索(&S):"
+#: common/dialogs/dialog_page_settings_base.h:121
+msgid "Page Settings"
+msgstr "ページ設定"
 
-#: eeschema/dialogs/dialog_schematic_find_base.cpp:33
-msgid "Text with optional wildcards"
-msgstr "検索文字列"
-
-# 置換か
-#: eeschema/dialogs/dialog_schematic_find_base.cpp:38
-msgid "Replace &with:"
-msgstr "交換(&W):"
-
-#: eeschema/dialogs/dialog_schematic_find_base.cpp:49
-msgid "Direction:"
-msgstr "向き:"
-
-#: eeschema/dialogs/dialog_schematic_find_base.cpp:58
-msgid "F&orward"
-msgstr "前へ(&O)"
-
-#: eeschema/dialogs/dialog_schematic_find_base.cpp:63
-msgid "&Backward"
-msgstr "後へ(&B)"
-
-#: eeschema/dialogs/dialog_schematic_find_base.cpp:74
-msgid "Match whole wor&d"
-msgstr "全体一致のみ(&D)"
-
-#: eeschema/dialogs/dialog_schematic_find_base.cpp:78
-msgid "&Match case"
-msgstr "大文字/小文字を区別(&M)"
-
-#: eeschema/dialogs/dialog_schematic_find_base.cpp:81
-msgid "Search &using simple wildcard matching"
-msgstr "ワイルドカードを使用(&U)"
-
-#: eeschema/dialogs/dialog_schematic_find_base.cpp:84
-msgid "Wrap around &end of search list"
-msgstr "先頭から検索(&E)"
-
-#: eeschema/dialogs/dialog_schematic_find_base.cpp:88
-msgid "Search all com&ponent fields"
-msgstr "全てのコンポーネントフィールドを検索(&P)"
-
-#: eeschema/dialogs/dialog_schematic_find_base.cpp:91
-msgid "Search all pin &names and numbers"
-msgstr "全てのピン名と番号を検索(&N)"
-
-#: eeschema/dialogs/dialog_schematic_find_base.cpp:94
-msgid "Search the current &sheet onl&y"
-msgstr "現在のシートのみを検索(&S)"
-
-#: eeschema/dialogs/dialog_schematic_find_base.cpp:97
-msgid "Replace componen&t reference designators"
-msgstr "コンポーネントのリファレンス記号の置換(&t)"
-
-#: eeschema/dialogs/dialog_schematic_find_base.cpp:102
-msgid "D&o not warp cursor to found item"
-msgstr "検索したアイテムにカーソルを移動しない(&O)"
-
-# 置換か
-#: eeschema/dialogs/dialog_schematic_find_base.cpp:115
-msgid "&Replace"
-msgstr "入れ替え(&R)"
-
-#: eeschema/dialogs/dialog_schematic_find_base.cpp:120
-msgid "Replace &All"
-msgstr "全て置換(&A)"
-
-#: cvpcb/autosel.cpp:106
-#, c-format
-msgid "Equ file '%s' could not be found in the default search paths."
-msgstr ""
-"フットプリント エイリアス ライブラリファイル '%s' はデフォルトの検索パス中に"
-"ありませんでした。"
-
-#: cvpcb/autosel.cpp:127
-#, c-format
-msgid "Error opening equ file '%s'."
-msgstr "Equファイルを開く際にエラーが発生しました '%s'."
-
-#: cvpcb/autosel.cpp:179
-msgid "Equ files Load Error"
-msgstr "Equファイルの読み込みエラー"
-
-#: cvpcb/autosel.cpp:187
-#, c-format
-msgid "%d footprint/cmp equivalences found."
-msgstr "%d フットプリント/コンポーネントの関連付けが見つかりました."
-
-#: cvpcb/autosel.cpp:253
-#, c-format
-msgid ""
-"Component %s: footprint %s not found in any of the project footprint "
-"libraries."
+#: cvpcb/common_help_msg.h:28
+msgid "Save footprint association in schematic component footprint fields"
 msgstr ""
-"コンポーネント %s: フットプリント %s は、どのプロジェクトフットプリントライブ"
-"ラリにも存在しません。"
-
-#: cvpcb/autosel.cpp:287
-msgid "CvPcb Warning"
-msgstr "CvPcbの警告"
-
-#: cvpcb/cfg.cpp:79 cvpcb/dialogs/dialog_config_equfiles.cpp:52
-#, c-format
-msgid "Project file: '%s'"
-msgstr "プロジェクトファイル: '%s'"
-
-#: cvpcb/cfg.cpp:84
-#, c-format
-msgid "Project file '%s' is not writable"
-msgstr "プロジェクトファイル '%s' は書き込み禁止されています"
-
-#: cvpcb/class_DisplayFootprintsFrame.cpp:75
-msgid "Footprint Viewer"
-msgstr "フットプリント ビューア"
-
-#: cvpcb/class_DisplayFootprintsFrame.cpp:201
-msgid "Show texts in line mode"
-msgstr "テキストをラインモードで表示"
-
-#: cvpcb/class_DisplayFootprintsFrame.cpp:205
-msgid "Show outlines in line mode"
-msgstr "外形をラインモードで表示"
+"回路図のコンポーネントのフットプリント フィールドへ関連付けてフットプリントを"
+"保存する"
 
-#: cvpcb/class_DisplayFootprintsFrame.cpp:220
+#: cvpcb/dialogs/dialog_display_options_base.h:63
 #: pcbnew/dialogs/dialog_display_options_base.h:72
-msgid "Display options"
+msgid "Display Options"
 msgstr "表示オプション"
 
-#: cvpcb/class_DisplayFootprintsFrame.cpp:225
-msgid "Zoom in (F1)"
-msgstr "ズーム イン (F1)"
-
-#: cvpcb/class_DisplayFootprintsFrame.cpp:228
-msgid "Zoom out (F2)"
-msgstr "ズーム アウト (F2)"
-
-#: cvpcb/class_DisplayFootprintsFrame.cpp:231
-msgid "Redraw view (F3)"
-msgstr "ビューの再描画 (F3)"
-
-#: cvpcb/class_DisplayFootprintsFrame.cpp:234
-msgid "Zoom auto (Home)"
-msgstr "自動ズーム (Home)"
-
-#: cvpcb/class_DisplayFootprintsFrame.cpp:238
-msgid "3D Display (Alt+3)"
-msgstr "3D表示 (Alt+3)"
-
-#: cvpcb/class_DisplayFootprintsFrame.cpp:250
-msgid "Show texts in filled mode"
-msgstr "テキストを塗りつぶしモードで表示"
-
-#: cvpcb/class_DisplayFootprintsFrame.cpp:251
-msgid "Show texts in sketch mode"
-msgstr "テキストをスケッチモードで表示"
-
-#: cvpcb/class_DisplayFootprintsFrame.cpp:265
-msgid "Show outlines in filled mode"
-msgstr "外形を塗りつぶしモードで表示"
-
-#: cvpcb/class_DisplayFootprintsFrame.cpp:266
-msgid "Show outlines in sketch mode"
-msgstr "外形をスケッチモードで表示"
-
-#: cvpcb/class_DisplayFootprintsFrame.cpp:472
-#, c-format
-msgid "Footprint '%s' not found"
-msgstr "フットプリント '%s' が見つかりません。"
-
-#: cvpcb/class_DisplayFootprintsFrame.cpp:488
-#, c-format
-msgid "Footprint: %s"
-msgstr "フットプリント: %s"
-
-#: cvpcb/class_DisplayFootprintsFrame.cpp:500
-#, c-format
-msgid "Lib: %s"
-msgstr "ライブラリ: %s"
-
-#: cvpcb/cvframe.cpp:246
-msgid ""
-"Component to Footprint links modified.\n"
-"Save before exit ?"
-msgstr ""
-"コンポーネントとフットプリントとの関連付けが変更されています。。\n"
-"終了前に保存しますか？"
-
-#: cvpcb/cvframe.cpp:373
-msgid "Delete selections"
-msgstr "選択の削除"
-
-#: cvpcb/cvframe.cpp:453
-#, c-format
-msgid ""
-"Error occurred saving the global footprint library table:\n"
-"'%s'\n"
-"%s"
-msgstr ""
-"グローバル フットプリント ライブラリ テーブルの保存中にエラーが発生しまし"
-"た:\n"
-"'%s'\n"
-"%s"
-
-#: cvpcb/cvframe.cpp:473
-#, c-format
-msgid ""
-"Error occurred saving the project footprint library table:\n"
-"'%s'\n"
-"%s"
-msgstr ""
-"プロジェクト フットプリント ライブラリ テーブルの保存中にエラーが発生しまし"
-"た:\n"
-"'%s'\n"
-"%s"
-
-#: cvpcb/cvframe.cpp:605
-#, c-format
-msgid "Components: %d, unassigned: %d"
-msgstr "コンポーネント: %d  (未割付: %d)"
-
-#: cvpcb/cvframe.cpp:623
-msgid "Filter list: "
-msgstr "フィルター: "
-
-#: cvpcb/cvframe.cpp:639
-msgid "Key words: "
-msgstr "キーワード: "
-
-#: cvpcb/cvframe.cpp:650
-msgid "key words"
-msgstr "キーワード"
-
-#: cvpcb/cvframe.cpp:657
-msgid "pin count"
-msgstr "ピン数"
-
-#: cvpcb/cvframe.cpp:665
-msgid "library"
-msgstr "ライブラリ"
-
-#: cvpcb/cvframe.cpp:669
-msgid "No filtering"
-msgstr "絞り込みなし"
-
-#: cvpcb/cvframe.cpp:671
-#, c-format
-msgid "Filtered by %s"
-msgstr "フィルター: %s"
-
-#: cvpcb/cvframe.cpp:687
-msgid ""
-"No PCB footprint libraries are listed in the current footprint library table."
-msgstr ""
-"現在の フットプリント ライブラリ テーブルには、 PCB フットプリントライブラリ"
-"がありません。"
-
-#: cvpcb/cvframe.cpp:688
-msgid "Configuration Error"
-msgstr "構成エラー"
-
-#: cvpcb/cvframe.cpp:711
-#, c-format
-msgid "Project: '%s'"
-msgstr "プロジェクト: '%s'"
-
-#: cvpcb/cvframe.cpp:719
-msgid "[no project]"
-msgstr "[プロジェクトなし]"
-
-#: cvpcb/cvpcb.cpp:57
-msgid "Component/footprint equ files (*.equ)|*.equ"
-msgstr "コンポーネント/フットプリントのequファイル (*.equ)|*.equ"
-
-#: cvpcb/cvpcb.cpp:170
-msgid ""
-"You have run CvPcb for the first time using the new footprint library table "
-"method for finding footprints.  CvPcb has either copied the default table or "
-"created an empty table in your home folder.  You must first configure the "
-"library table to include all footprint libraries not included with KiCad.  "
-"See the \"Footprint Library Table\" section of the CvPcb documentation for "
-"more information."
-msgstr ""
-"始めにフットプリントの検索に新しいフットプリントライブラリテーブルを使うよう "
-"CvPcb を実行します。 CvPcb はデフォルト テーブルをコピーし、あなたのホーム"
-"フォルダへ空のテーブルを作ります。あなたはまず KiCad がデフォルトで含んでいな"
-"い全てのフットプリントを含んだライブラリテーブルを設定しなければなりません。"
-"詳細は CvPcb マニュアルの \"フットプリント ライブラリ テーブル\" の章を参照し"
-"て下さい。"
-
-#: cvpcb/menubar.cpp:69
-msgid "&Save Edits\tCtrl+S"
-msgstr "編集を保存(&S)\tCtrl+S"
-
-#: cvpcb/menubar.cpp:76
-msgid "Close CvPcb"
-msgstr "CvPcbの終了"
-
-#: cvpcb/menubar.cpp:83
-msgid "Footprint Li&braries"
-msgstr "フットプリントライブラリ(&B)"
-
-#: cvpcb/menubar.cpp:94
-msgid "Edit &Equ Files List"
-msgstr "Equファイルリストの編集(&E)"
-
-#: cvpcb/menubar.cpp:95
-msgid ""
-"Setup equ files list (.equ files)\n"
-"They are files which give the footprint name from the component value"
-msgstr ""
-"等価ファイル (.equ ファイル) のセットアップ\n"
-"これはコンポーネントの名前からフットプリント名を割り当てるためのファイルです"
-
-#: cvpcb/menubar.cpp:104
-msgid "&Keep Open On Save"
-msgstr "保存後に終了しない(&K)"
-
-#: cvpcb/menubar.cpp:105
-msgid "Prevent CvPcb from exiting after saving netlist file"
-msgstr "ネットリストファイル保存後もCvPcbを継続"
-
-#: cvpcb/menubar.cpp:113
-msgid "&Save Project File"
-msgstr "プロジェクトへ設定を保存(&S)"
-
-#: cvpcb/menubar.cpp:114
-msgid "Save changes to the project configuration file"
-msgstr "プロジェクト設定ファイルの変更を保存"
-
-#: cvpcb/menubar.cpp:124
-msgid "&CvPcb Manual"
-msgstr "CvPcbマニュアル(&C)"
-
-#: cvpcb/menubar.cpp:125
-msgid "Open CvPcb manual"
-msgstr "CvPcbのマニュアルを開く"
-
-#: cvpcb/menubar.cpp:130
-msgid "&About CvPcb"
-msgstr "CvPcbについて(&A)"
-
-#: cvpcb/menubar.cpp:131
-msgid "About CvPcb footprint selector"
-msgstr "CvPcbフットプリントセレクタについて"
-
-#: cvpcb/readwrite_dlgs.cpp:196
-msgid ""
-"Some of the assigned footprints are legacy entries (are missing lib "
-"nicknames). Would you like CvPcb to attempt to convert them to the new "
-"required FPID format? (If you answer no, then these assignments will be "
-"cleared out and you will have to re-assign these footprints yourself.)"
-msgstr ""
-"配置されたフットプリントのいくつかは、(ライブラリの別名がない)古い形式です. "
-"CvPcb を使って新しく必要な FPID フォーマットへの変換を試みますか？ (ノーを選"
-"択した場合、これらの配置は消去され、各々のフットプリントを手動で再配置する必"
-"要があります.)"
-
-#: cvpcb/readwrite_dlgs.cpp:229
-#, c-format
-msgid "Component '%s' footprint '%s' was <b>not found</b> in any library.\n"
-msgstr ""
-"コンポーネント '%s' フットプリント '%s' がどのライブラリからも<b>見つかりませ"
-"んでした</b>\n"
-
-#: cvpcb/readwrite_dlgs.cpp:237
-#, c-format
-msgid "Component '%s' footprint '%s' was found in <b>multiple</b> libraries.\n"
-msgstr ""
-"コンポーネント '%s' フットプリント '%s' が<b>複数のライブラリから</b>見つかり"
-"ました\n"
-
-#: cvpcb/readwrite_dlgs.cpp:250
-msgid "First check your footprint library table entries."
-msgstr "最初にフットプリントライブラリ一覧の内容を確認して下さい。"
-
-#: cvpcb/readwrite_dlgs.cpp:252
-msgid "Problematic Footprint Library Tables"
-msgstr "フットプリントライブラリのエラー"
-
-#: cvpcb/readwrite_dlgs.cpp:260
-msgid ""
-"The following errors occurred attempting to convert the footprint "
-"assignments:\n"
-"\n"
-msgstr ""
-"フットプリントの割り当て処理中に下記のエラーが発生しました:\n"
-"\n"
-
-#: cvpcb/readwrite_dlgs.cpp:263
-msgid ""
-"\n"
-"You will need to reassign them manually if you want them to be updated "
-"correctly the next time you import the netlist in Pcbnew."
-msgstr ""
-"\n"
-"次回 Pcbnew にネットリストをインポートする時に正しくアップデートされているた"
-"めには、手動で再配置する必要があります"
-
-#: cvpcb/readwrite_dlgs.cpp:379
-msgid "Edits sent to Eeschema"
-msgstr "Eeschema へ編集内容を送る"
-
-#: cvpcb/tool_cvpcb.cpp:57
-msgid "Edit footprint library table"
-msgstr "フットプリントライブラリ一覧の編集"
-
-#: cvpcb/tool_cvpcb.cpp:62
-msgid "View selected footprint"
-msgstr "選択したフットプリントを見る"
-
-#: cvpcb/tool_cvpcb.cpp:67
-msgid "Select previous unlinked component"
-msgstr "前の関連付けの無いコンポーネントを選択"
-
-#: cvpcb/tool_cvpcb.cpp:71
-msgid "Select next unlinked component"
-msgstr "次の関連付けの無いコンポーネントを選択"
-
-#: cvpcb/tool_cvpcb.cpp:76
-msgid "Perform automatic footprint association"
-msgstr "フットプリントの関連付けを自動実行する"
-
-# what is associations
-#: cvpcb/tool_cvpcb.cpp:80
-msgid "Delete all associations (links)"
-msgstr "全ての関連付けを削除"
-
-#: cvpcb/tool_cvpcb.cpp:85
-msgid "Display footprint documentation"
-msgstr "フットプリントのドキュメントを表示"
-
-#: cvpcb/tool_cvpcb.cpp:92
-msgid "Filter footprint list by keywords"
-msgstr "キーワードでフットプリントを絞込み"
-
-#: cvpcb/tool_cvpcb.cpp:99
-msgid "Filter footprint list by pin count"
-msgstr "ピン数でフットプリントを絞込み"
-
-#: cvpcb/tool_cvpcb.cpp:105
-msgid "Filter footprint list by library"
-msgstr "ライブラリでフットプリントを絞込み"
-
-#: cvpcb/dialogs/dialog_config_equfiles.cpp:99
-msgid "No editor defined in Kicad. Please chose it"
-msgstr "エディタが設定されていません。一つ選択してください。"
-
-#: cvpcb/dialogs/dialog_config_equfiles.cpp:259
-msgid "Equ files:"
-msgstr "Equファイル:"
-
-#: cvpcb/dialogs/dialog_config_equfiles.cpp:304
-#, c-format
-msgid "File '%s' already exists in list"
-msgstr "ファイル '%s' は既にリスト中に存在します"
-
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:20
-msgid "Footprint/Component equ files (.equ files)"
-msgstr "フットプリント/コンポーネントequファイル(.equ ファイル)"
-
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:50
-msgid "Edit Equ File"
-msgstr "Equファイルの編集"
-
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:65
-msgid "Available environment variables for relative paths:"
-msgstr "相対パス用の有効な環境変数:"
-
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:101
-msgid "Absolute path"
-msgstr "絶対パス"
-
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:101
-msgid "Relative path"
-msgstr "相対パス"
-
-#: cvpcb/dialogs/dialog_config_equfiles_base.cpp:103
-msgid "Path option:"
-msgstr "環境変数の設定:"
-
-#: cvpcb/dialogs/dialog_display_options_base.cpp:23
-msgid "Draw options"
-msgstr "表示オプション"
-
-#: cvpcb/dialogs/dialog_display_options_base.cpp:31
-msgid "Pad sketch mode"
-msgstr "パッドをスケッチモードで描画"
-
-#: cvpcb/dialogs/dialog_display_options_base.cpp:34
-msgid "Show pad &number"
-msgstr "パッド番号を表示(&N)"
-
-#: cvpcb/dialogs/dialog_display_options_base.cpp:43
-msgid "Do not center and warp cusor on zoom"
-msgstr "拡大縮小時にカーソルを中心へ移動させない"
-
-#: cvpcb/dialogs/dialog_display_options_base.cpp:48
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:91
-msgid "Use middle mouse button to pan"
-msgstr "画面のパンにマウスの中ボタンを使う"
-
-#: cvpcb/dialogs/dialog_display_options_base.cpp:51
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:94
-msgid "Limit panning to scroll size"
-msgstr "パン可能な領域を、スクロールバーサイズ範囲内に制限する"
-
-#: cvpcb/dialogs/fp_conflict_assignment_selector.cpp:37
-msgid "Ref"
-msgstr "リファレンス"
-
-#: cvpcb/dialogs/fp_conflict_assignment_selector.cpp:38
-msgid "Schematic assignment"
-msgstr "回路図の割り当て"
-
-#: cvpcb/dialogs/fp_conflict_assignment_selector.cpp:41
-msgid "Cmp file assignment"
-msgstr "Cmpファイルの割り当て"
-
-#: gerbview/class_GERBER.cpp:347
-msgid "Image name"
-msgstr "画像名"
-
-#: gerbview/class_GERBER.cpp:352
-msgid "Graphic layer"
-msgstr "図形レイヤ"
-
-#: gerbview/class_GERBER.cpp:356
-msgid "Img Rot."
-msgstr "イメージの回転"
-
-#: gerbview/class_GERBER.cpp:359 bitmap2component/bitmap2cmp_gui_base.cpp:135
-msgid "Negative"
-msgstr "ネガ"
-
-#: gerbview/class_GERBER.cpp:360 gerbview/class_gerber_draw_item.cpp:568
-msgid "Polarity"
-msgstr "極性"
-
-#: gerbview/class_GERBER.cpp:364
-msgid "X Justify"
-msgstr "X位置調整"
-
-#: gerbview/class_GERBER.cpp:367
-msgid "Y Justify"
-msgstr "Y位置調整"
-
-#: gerbview/class_GERBER.cpp:375
-msgid "Image Justify Offset"
-msgstr "イメージのオフセット"
-
-#: gerbview/class_GERBER.cpp:469
-#, c-format
-msgid "Layer %d (%s, %s, %s)"
-msgstr "レイヤ %d (%s, %s, %s)"
-
-#: gerbview/class_GERBER.cpp:476
-#, c-format
-msgid "Layer %d (%s, %s)"
-msgstr "レイヤ %d (%s, %s)"
-
-#: gerbview/class_GERBER.cpp:482
-#, c-format
-msgid "Layer %d *"
-msgstr "レイヤ %d *"
-
-#: gerbview/class_GERBER.cpp:485 gerbview/select_layers_to_pcb.cpp:183
-#, c-format
-msgid "Layer %d"
-msgstr "レイヤ %d"
-
-#: gerbview/class_gerber_draw_item.cpp:553
-msgid "D Code"
-msgstr "D コード"
-
-#: gerbview/class_gerber_draw_item.cpp:557
-msgid "Graphic Layer"
-msgstr "図形レイヤ"
-
-#: gerbview/class_gerber_draw_item.cpp:567
-msgid "Clear"
-msgstr "クリア"
-
-#: gerbview/class_gerber_draw_item.cpp:567
-msgid "Dark"
-msgstr "ダーク"
-
-#: gerbview/class_gerber_draw_item.cpp:578
-msgid "AB axis"
-msgstr "AB軸"
-
-#: gerbview/class_gerbview_layer_widget.cpp:111
-msgid "DCodes"
-msgstr "Dコード"
-
-#: gerbview/class_gerbview_layer_widget.cpp:111
-msgid "Show DCodes identification"
-msgstr "Dコード表の表示"
-
-#: gerbview/class_gerbview_layer_widget.cpp:112
-msgid "Neg. Obj."
-msgstr "ネガのオブジェクト"
-
-#: gerbview/class_gerbview_layer_widget.cpp:113
-msgid "Show negative objects in this color"
-msgstr "ネガのオブジェクトをこの色で表示します"
-
-#: gerbview/class_gerbview_layer_widget.cpp:152
-msgid "Show All Layers"
-msgstr "全てのレイヤを表示"
-
-#: gerbview/class_gerbview_layer_widget.cpp:155
-msgid "Hide All Layers But Active"
-msgstr "アクティブでない全てのレイヤを隠す"
-
-#: gerbview/class_gerbview_layer_widget.cpp:158
-msgid "Always Hide All Layers But Active"
-msgstr "アクティブでない全てのレイヤを隠す"
-
-#: gerbview/class_gerbview_layer_widget.cpp:161
-msgid "Hide All Layers"
-msgstr "全てのレイヤを非表示"
-
-#: gerbview/class_gerbview_layer_widget.cpp:165
-msgid "Sort Layers if X2 Mode"
-msgstr "X2 モードならレイヤをソートする"
-
-#: gerbview/events_called_functions.cpp:268
-msgid "No editor defined. Please select one"
-msgstr "エディタが定義されていません。一つ選択してください。"
-
-#: gerbview/events_called_functions.cpp:274
-#, c-format
-msgid "No file loaded on the active layer %d"
-msgstr "アクティブなレイヤ%d上にファイルが読み込まれていません"
-
-#: gerbview/excellon_read_drill_file.cpp:189
-msgid "No room to load file"
-msgstr "ファイルをロードできません"
-
-#: gerbview/excellon_read_drill_file.cpp:214
-msgid "Files not found"
-msgstr "ファイルが見つかりません"
-
-#: gerbview/excellon_read_drill_file.cpp:388
-msgid "METRIC command has no parameter"
-msgstr "METRIC コマンドはパラメータを持ちません"
-
-#: gerbview/excellon_read_drill_file.cpp:406
-msgid "INCH command has no parameter"
-msgstr "INCH コマンドはパラメータを持ちません"
-
-#: gerbview/excellon_read_drill_file.cpp:434
-msgid "ICI command has no parameter"
-msgstr "ICIコメントはパラメータを持っていません"
-
-#: gerbview/excellon_read_drill_file.cpp:444
-msgid "ICI command has incorrect parameter"
-msgstr "ICIコメントは不正なパラメータを持っています"
-
-#: gerbview/excellon_read_drill_file.cpp:482
-#, c-format
-msgid "Tool definition <%c> not supported"
-msgstr "ツール定義 <%c> はサポートされていません。"
-
-#: gerbview/excellon_read_drill_file.cpp:534
-#, c-format
-msgid "Tool <%d> not defined"
-msgstr "ツール <%d> は定義されていません"
-
-#: gerbview/excellon_read_drill_file.cpp:661
-#, c-format
-msgid "Unknown Excellon G Code: &lt;%s&gt;"
-msgstr "不明な Excellon G Code です : &lt;%s&gt;"
-
-#: gerbview/export_to_pcbnew.cpp:172
-msgid "None of the Gerber layers contain any data"
-msgstr "ガーバーレイヤにデータが含まれていません。"
-
-#: gerbview/export_to_pcbnew.cpp:179
-msgid "Board file name:"
-msgstr "ボード ファイル名:"
-
-#: gerbview/export_to_pcbnew.cpp:200
-msgid "OK to change the existing file ?"
-msgstr "既存のファイルを変更します、宜しいですか？"
-
-#: gerbview/export_to_pcbnew.cpp:220
-#, c-format
-msgid "Cannot create file '%s'"
-msgstr "ファイル '%s' を作成できません"
-
-#: gerbview/files.cpp:46
-msgid "Gerber files"
-msgstr "ガーバー ファイル"
-
-#: gerbview/files.cpp:60
-msgid "Drill files"
-msgstr "ドリル ファイル"
-
-#: gerbview/files.cpp:121
-msgid "Gerber files (.g* .lgr .pho)"
-msgstr "ガーバーファイル (.g*, .lgr, .pho)"
-
-#: gerbview/files.cpp:127
-msgid "Top layer (*.GTL)|*.GTL;*.gtl|"
-msgstr "表面レイヤ (*.GTL)|*.GTL;*.gtl|"
-
-#: gerbview/files.cpp:128
-msgid "Bottom layer (*.GBL)|*.GBL;*.gbl|"
-msgstr "裏面レイヤ (*.GBL)|*.GBL;*.gbl|"
-
-#: gerbview/files.cpp:129
-msgid "Bottom solder resist (*.GBS)|*.GBS;*.gbs|"
-msgstr "裏面ハンダレジスト (*.GBS)|*.GBS;*.gbs|"
-
-#: gerbview/files.cpp:130
-msgid "Top solder resist (*.GTS)|*.GTS;*.gts|"
-msgstr "表面ハンダレジスト (*.GTS)|*.GTS;*.gts|"
-
-#: gerbview/files.cpp:131
-msgid "Bottom overlay (*.GBO)|*.GBO;*.gbo|"
-msgstr "裏面オーバーレイ (*.GBO)|*.GBO;*.gbo|"
-
-#: gerbview/files.cpp:132
-msgid "Top overlay (*.GTO)|*.GTO;*.gto|"
-msgstr "表面オーバーレイ (*.GTO)|*.GTO;*.gto|"
-
-#: gerbview/files.cpp:133
-msgid "Bottom paste (*.GBP)|*.GBP;*.gbp|"
-msgstr "裏面ペースト (*.GBP)|*.GBP;*.gbp|"
-
-#: gerbview/files.cpp:134
-msgid "Top paste (*.GTP)|*.GTP;*.gtp|"
-msgstr "表面ペースト (*.GTP)|*.GTP;*.gtp|"
-
-#: gerbview/files.cpp:135
-msgid "Keep-out layer (*.GKO)|*.GKO;*.gko|"
-msgstr "キープアウト レイヤ (*.GKO)|*.GKO;*.gko|"
-
-#: gerbview/files.cpp:136
-msgid "Mechanical layers (*.GMx)|*.GM1;*.gm1;*.GM2;*.gm2;*.GM3;*.gm3|"
-msgstr "メカニカル レイヤ (*.GMx)|*.GM1;*.gm1;*.GM2;*.gm2;*.GM3;*.gm3|"
-
-#: gerbview/files.cpp:137
-msgid "Top Pad Master (*.GPT)|*.GPT;*.gpt|"
-msgstr "表面パッド マスター (*.GPT)|*.GPT;*.gpt|"
-
-#: gerbview/files.cpp:138
-msgid "Bottom Pad Master (*.GPB)|*.GPB;*.gpb|"
-msgstr "裏面パッド マスター (*.GPB)|*.GPB;*.gpb|"
-
-#: gerbview/files.cpp:150
-msgid "Open Gerber File"
-msgstr "ガーバー ファイルを開く"
-
-#: gerbview/files.cpp:232
-msgid "Open Drill File"
-msgstr "ドリルファイルを開く"
-
-#: gerbview/gerbview_frame.cpp:455
-msgid "D Codes"
-msgstr "D コード"
-
-#: gerbview/gerbview_frame.cpp:482
-#, c-format
-msgid "Layer %d not in use"
-msgstr "レイヤ %d は未使用です"
-
-#: gerbview/gerbview_frame.cpp:491
-msgid "(with X2 Attributes)"
-msgstr "(X2属性)"
-
-#: gerbview/gerbview_frame.cpp:497
-#, c-format
-msgid "Image name: '%s'  Layer name: '%s'"
-msgstr "イメージ名: '%s', レイヤ: '%s'"
-
-#: gerbview/gerbview_frame.cpp:510
-msgid "X2 attr"
-msgstr "X2 属性"
-
-#: gerbview/init_gbr_drawlayers.cpp:48
-msgid "Current data will be lost?"
-msgstr "現在のデータが失われます、宜しいですか？"
-
-#: gerbview/init_gbr_drawlayers.cpp:72
-#, c-format
-msgid "Clear layer %d?"
-msgstr "レイヤ %d をクリアしますか？"
-
-#: gerbview/menubar.cpp:64
-msgid "Load &Gerber File"
-msgstr "ガーバー ファイルを読み込む(&G)"
-
-#: gerbview/menubar.cpp:65 gerbview/toolbars_gerber.cpp:62
-msgid ""
-"Load a new Gerber file on the current layer. Previous data will be deleted"
-msgstr "現在のレイヤに新規ガーバーファイルを読込み。前のデータが削除されます"
-
-#: gerbview/menubar.cpp:71
-msgid "Load &EXCELLON Drill File"
-msgstr "EXCELLON ドリルファイルの読み込み(&E)"
-
-#: gerbview/menubar.cpp:72
-msgid "Load excellon drill file"
-msgstr "excellon ドリルファイルの読込み"
-
-#: gerbview/menubar.cpp:90
-msgid "Open &Recent Gerber File"
-msgstr "最近のガーバー ファイルを開く(&R)"
-
-#: gerbview/menubar.cpp:91
-msgid "Open a recent opened Gerber file"
-msgstr "最近開いたガーバーファイルを開く"
-
-#: gerbview/menubar.cpp:105
-msgid "Open Recent Dri&ll File"
-msgstr "最近のドリルファイルを開く(&L)"
-
-#: gerbview/menubar.cpp:106
-msgid "Open a recent opened drill file"
-msgstr "最近開いたドリルファイルを開く"
-
-#: gerbview/menubar.cpp:115
-msgid "Clear &All"
-msgstr "全てクリア(&A)"
-
-#: gerbview/menubar.cpp:116
-msgid "Clear all layers. All data will be deleted"
-msgstr "全てのレイヤをクリア。全てのデータが削除されます"
-
-#: gerbview/menubar.cpp:125
-msgid "E&xport to Pcbnew"
-msgstr "Pcbnew へエクスポート(&X)"
-
-#: gerbview/menubar.cpp:126
-msgid "Export data in Pcbnew format"
-msgstr "Pcbnew フォーマットでデータのエクスポート"
-
-#: gerbview/menubar.cpp:136
-msgid "Print gerber"
-msgstr "ガーバー印刷"
-
-#: gerbview/menubar.cpp:146
-msgid "Close GerbView"
-msgstr "GerbViewの終了"
-
-#: gerbview/menubar.cpp:167
-msgid "&Options"
-msgstr "オプション(&O)"
-
-#: gerbview/menubar.cpp:168
-msgid "Set options to draw items"
-msgstr "アイテム描画オプションの設定"
-
-#: gerbview/menubar.cpp:184
-msgid "&List DCodes"
-msgstr "Dコードのリスト(&L)"
-
-#: gerbview/menubar.cpp:185
-msgid "List and edit D-codes"
-msgstr "D-codesリスト表示、編集"
-
-#: gerbview/menubar.cpp:191
-msgid "&Show Source"
-msgstr "ソースの表示(&S)"
-
-#: gerbview/menubar.cpp:192
-msgid "Show source file for the current layer"
-msgstr "現在のレイヤのソースファイルを表示"
-
-#: gerbview/menubar.cpp:201
-msgid "&Clear Layer"
-msgstr "レイヤのクリア(&C)"
-
-#: gerbview/menubar.cpp:202
-msgid "Clear current layer"
-msgstr "現在のレイヤをクリアする"
-
-#: gerbview/menubar.cpp:211 pagelayout_editor/menubar.cpp:132
-msgid "&Text Editor"
-msgstr "テキストエディタ(&T)"
-
-#: gerbview/menubar.cpp:212 pagelayout_editor/menubar.cpp:133
-msgid "Select your preferred text editor"
-msgstr "使用するテキストエディタを指定"
-
-#: gerbview/menubar.cpp:225 pagelayout_editor/menubar.cpp:152
-msgid "Open the GerbView handbook"
-msgstr "GerbViewのマニュアルを開く"
-
-#: gerbview/menubar.cpp:231
-msgid "&About GerbView"
-msgstr "GerbViewについて(&A)"
-
-#: gerbview/menubar.cpp:232
-msgid "About GerbView gerber and drill viewer"
-msgstr "GerbView ガーバー&ドリルデータビューアについて"
-
-#: gerbview/menubar.cpp:238
-msgid "&Miscellaneous"
-msgstr "その他(&M)"
-
-#: gerbview/readgerb.cpp:69
-#, c-format
-msgid "File <%s> not found"
-msgstr "ファイル <%s> が見つかりません。"
-
-#: gerbview/readgerb.cpp:182
-msgid "Errors"
-msgstr "エラー"
-
-#: gerbview/readgerb.cpp:192
-msgid ""
-"Warning: this file has no D-Code definition\n"
-"It is perhaps an old RS274D file\n"
-"Therefore the size of items is undefined"
-msgstr ""
-"警告！ このファイルは D-Code 定義を持っていません\n"
-"古い RS274D ファイルだと思われます\n"
-"そのため、アイテムのサイズは未定義です"
-
-#: gerbview/rs274x.cpp:444
-msgid "RS274X: Command \"IR\" rotation value not allowed"
-msgstr "RS274X: コマンド \"IR\" 回転値は許可されていません。"
-
-#: gerbview/rs274x.cpp:535
-msgid "RS274X: Command KNOCKOUT ignored by GerbView"
-msgstr "RS274X: コマンド「KNOCKOUT」は GerbViewで無視されます。"
-
-#: gerbview/rs274x.cpp:597
-msgid "Too many include files!!"
-msgstr "含まれるファイル数が多過ぎます!!"
-
-#: gerbview/select_layers_to_pcb.cpp:222 gerbview/select_layers_to_pcb.cpp:338
-#: gerbview/select_layers_to_pcb.cpp:377
-#: gerbview/dialogs/dialog_select_one_pcb_layer.cpp:154
-msgid "Do not export"
-msgstr "エクスポートできません。"
-
-#: gerbview/select_layers_to_pcb.cpp:424
-msgid ""
-"The exported board has not enough copper layers to handle selected inner "
-"layers"
-msgstr ""
-"エクスポートされた基板は選択された内層を操作するための導体層が不足していま"
-"す。"
-
-#: gerbview/toolbars_gerber.cpp:59
-msgid "Erase all layers"
-msgstr "全レイヤを消去"
-
-#: gerbview/toolbars_gerber.cpp:66
-msgid ""
-"Load an excellon drill file on the current layer. Previous data will be "
-"deleted"
-msgstr ""
-"現在のレイヤにexcellonドリルファイルを読込みます。以前のデータは削除されま"
-"す。"
-
-#: gerbview/toolbars_gerber.cpp:70
-msgid "Show/hide frame reference and select paper size for printing"
-msgstr "フレームリファレンスの表示/非表示 及び 印刷用紙サイズ"
-
-#: gerbview/toolbars_gerber.cpp:74
-msgid "Print layers"
-msgstr "レイヤを印刷"
-
-#: gerbview/toolbars_gerber.cpp:101
-msgid "No tool"
-msgstr "ツールなし"
-
-#: gerbview/toolbars_gerber.cpp:105
-msgid "Tool "
-msgstr "ツール"
-
-#: gerbview/toolbars_gerber.cpp:155
-msgid "Turn polar coordinate on"
-msgstr "極座標表示に切り替え"
-
-#: gerbview/toolbars_gerber.cpp:159
-msgid "Set units to inches"
-msgstr "単位をインチ系に設定"
-
-#: gerbview/toolbars_gerber.cpp:163
-msgid "Set units to millimeters"
-msgstr "単位をmm系に設定"
-
-#: gerbview/toolbars_gerber.cpp:172
-msgid "Show spots in sketch mode"
-msgstr "スポットをスケッチモード表示"
-
-#: gerbview/toolbars_gerber.cpp:176
-msgid "Show lines in sketch mode"
-msgstr "ラインをスケッチモード表示"
-
-#: gerbview/toolbars_gerber.cpp:180
-msgid "Show polygons in sketch mode"
-msgstr "ポリゴンをスケッチモード表示"
-
-#: gerbview/toolbars_gerber.cpp:185
-msgid "Show negatives objects in ghost color"
-msgstr "ネガのオブジェクトをこの反転色で表示します"
-
-#: gerbview/toolbars_gerber.cpp:190
-msgid "Show dcode number"
-msgstr "Dコード番号を表示"
-
-# pls translate more better.
-#: gerbview/toolbars_gerber.cpp:196
-msgid ""
-"Show layers in raw mode (could have problems with negative items when more "
-"than one gerber file is shown)"
-msgstr ""
-"レイヤを実 (raw) モードで表示 (複数のガーバーファイルを表示する際にネガのアイ"
-"テムで問題が発生します)"
-
-#: gerbview/toolbars_gerber.cpp:201
-msgid ""
-"Show layers in stacked mode (show negative items without artifacts, "
-"sometimes slow)"
-msgstr ""
-"レイヤをスタックモードで表示(加工なしでネガのアイテムを表示、時々遅くなりま"
-"す)"
-
-# pls translate more better.
-#: gerbview/toolbars_gerber.cpp:206
-msgid ""
-"Show layers in transparency mode (show negative items without artifacts, "
-"sometimes slow)"
-msgstr ""
-"レイヤを透過 (transparency) モードで表示 (加工なしでネガのアイテムを表示、"
-"時々遅くなります)"
-
-#: gerbview/toolbars_gerber.cpp:215 pcbnew/help_common_strings.h:24
-msgid "Show/hide the layers manager toolbar"
-msgstr "レイヤ マネージャー ツールバーの表示/非表示"
-
-#: gerbview/toolbars_gerber.cpp:287
-msgid "Hide layers manager"
-msgstr "レイヤマネージャを非表示"
-
-#: gerbview/toolbars_gerber.cpp:289
-msgid "Show layers manager"
-msgstr "レイヤマネージャを表示"
-
-#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:31
-msgid "Layers selection:"
-msgstr "レイヤの選択:"
-
-#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:56
-msgid "Copper layers count:"
-msgstr "導体レイヤ数:"
-
-#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:60
-#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:61
-msgid "2 Layers"
-msgstr "２層"
-
-#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:62
-msgid "4 Layers"
-msgstr "４層"
-
-#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:63
-msgid "6 Layers"
-msgstr "６層"
-
-#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:64
-msgid "8 Layers"
-msgstr "８層"
-
-#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:65
-msgid "10 Layers"
-msgstr "１０層"
-
-#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:66
-msgid "12 Layers"
-msgstr "１２層"
-
-#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:67
-msgid "14 Layers"
-msgstr "１４層"
-
-#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:68
-msgid "16 Layers"
-msgstr "１６層"
-
-#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:80
-msgid "Store Choice"
-msgstr "選択内容の保存"
-
-#: gerbview/dialogs/dialog_layers_select_to_pcb_base.cpp:83
-msgid "Get Stored Choice"
-msgstr "保存された選択を取得する"
-
-#: gerbview/dialogs/dialog_print_using_printer_base.cpp:89
-msgid ""
-"Choose if you want to print sheets in color, or force the black and white "
-"mode."
-msgstr "シートをカラーまたは強制的にモノクロで印刷したい場合に選択"
-
-#: gerbview/dialogs/dialog_select_one_pcb_layer.cpp:113
-#: pcbnew/dialogs/dialog_layer_selection_base.h:50
-msgid "Select Layer:"
-msgstr "レイヤの選択: "
-
-#: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
-msgid "Full size. Do not show page limits"
-msgstr "フルサイズ、ページ区切り/非表示"
-
-#: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:77
-msgid "Full size"
-msgstr "フルサイズ"
-
-#: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:77
-msgid "Size A4"
-msgstr "A4サイズ"
-
-#: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:77
-msgid "Size A3"
-msgstr "A3サイズ"
-
-#: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:77
-msgid "Size A2"
-msgstr "A2サイズ"
-
-#: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:77
-msgid "Size A"
-msgstr "Aサイズ"
-
-#: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:77
-msgid "Size B"
-msgstr "Bサイズ"
-
-#: gerbview/dialogs/dialog_show_page_borders_base.cpp:25
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:77
-msgid "Size C"
-msgstr "Cサイズ"
-
-#: gerbview/dialogs/dialog_show_page_borders_base.cpp:27
-msgid "Show Page Limits:"
-msgstr "ページの境界を表示:"
-
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:43
-msgid "Show D codes"
-msgstr "Dコードの表示"
-
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:77
-msgid "Full size without limits"
-msgstr "フルサイズ、ページ区切り/非表示"
-
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:79
-msgid "Page"
-msgstr "ページ"
-
-#: gerbview/dialogs/gerbview_dialog_display_options_frame_base.cpp:86
-msgid "Do not center and warp cursor on zoom"
-msgstr "拡大縮小時にカーソルを中心へ移動させない"
-
-#: common/base_screen.cpp:188
-msgid "User Grid"
-msgstr "ユーザ グリッド"
-
-#: common/base_screen.cpp:194
-#, c-format
-msgid "Grid: %.4f mm (%.2f mils)"
-msgstr "グリッド: %.4f mm (%.2f mils)"
-
-#: common/base_screen.cpp:197
-#, c-format
-msgid "Grid: %.2f mils (%.4f mm)"
-msgstr "グリッド: %.2f mils (%.4f mm)"
-
-#: common/base_units.cpp:160
-msgid " mils"
-msgstr "mils"
-
-#: common/base_units.cpp:160
-msgid " in"
-msgstr "インチ"
-
-#: common/base_units.cpp:162 common/base_units.cpp:249
-msgid " mm"
-msgstr "mm"
-
-#: common/base_units.cpp:245
-msgid " \""
-msgstr "\""
-
-#: common/base_units.cpp:253
-msgid " deg"
-msgstr " 度"
-
-#: common/basicframe.cpp:137
-msgid ""
-"The program cannot be closed\n"
-"A quasi-modal dialog window is currently open, please close it first."
-msgstr ""
-"プログラムを終了することができませんでした\n"
-"現在表示されている他のダイアログを先に閉じてください。"
-
-#: common/basicframe.cpp:422
-#, c-format
-msgid ""
-"Html or pdf help file \n"
-"'%s'\n"
-" or\n"
-"'%s' could not be found."
-msgstr ""
-"HTML/PDF形式のヘルプファイル \n"
-"'%s'\n"
-" または\n"
-"'%s' が見つかりませんでした。"
-
-#: common/basicframe.cpp:439
-#, c-format
-msgid "Help file '%s' could not be found."
-msgstr "ヘルプファイル '%s' が見つかりません"
-
-#: common/basicframe.cpp:460
-#, c-format
-msgid "Executable file (%s)|%s"
-msgstr "実行ファイル (%s)|%s"
-
-#: common/basicframe.cpp:463
-msgid "Select Preferred Editor"
-msgstr "好みのエディタの選択"
-
-#: common/basicframe.cpp:489
-msgid "Copy &Version Information"
-msgstr "バージョン情報をコピー(&V)"
-
-#: common/basicframe.cpp:490
-msgid "Copy the version string to clipboard to send with bug reports"
-msgstr "バグレポートを送るためにクリップボードにバージョン文字列をコピーする"
-
-#: common/basicframe.cpp:543
-msgid "Could not open clipboard to write version information."
-msgstr "バージョン情報を書き込むためのクリップボードが開けません"
-
-#: common/basicframe.cpp:544
-msgid "Clipboard Error"
-msgstr "クリップボードのエラー"
-
-#: common/basicframe.cpp:618
-msgid "Version Information (copied to the clipboard)"
-msgstr "バージョン情報をクリップボードにコピー"
-
-#: common/basicframe.cpp:642
-#, c-format
-msgid "You do not have write permissions to folder <%s>."
-msgstr "フォルダー <%s> への書き込み権限がありません。"
-
-#: common/basicframe.cpp:647
-#, c-format
-msgid "You do not have write permissions to save file <%s> to folder <%s>."
-msgstr ""
-"ファイル <%s> をフォルダ <%s>に保存するための書き込み権限がありません。"
-
-#: common/basicframe.cpp:652
-#, c-format
-msgid "You do not have write permissions to save file <%s>."
-msgstr "ファイル <%s> を保存するための書き込み権限がありません。"
-
-#: common/basicframe.cpp:684
-#, c-format
-msgid ""
-"Well this is potentially embarrassing!\n"
-"It appears that the last time you were editing the file\n"
-"'%s'\n"
-"it was not saved properly.  Do you wish to restore the last saved edits you "
-"made?"
-msgstr ""
-"これはもしかすると厄介です！\n"
-"最後のファイル\n"
-"'%s'\n"
-"を修正した際に正しく保存されなかったようです。最後に行った編集内容を復元した"
-"いですか？"
-
-#: common/basicframe.cpp:712
-#, c-format
-msgid "Could not create backup file <%s>"
-msgstr "バックアップファイル <%s> が作成できませんでした"
-
-#: common/basicframe.cpp:720
-msgid "The auto save file could not be renamed to the board file name."
-msgstr "オートセーブファイルをボードファイル名にリネームできませんでした。"
-
-#: common/block_commande.cpp:68
-msgid "Block Move"
-msgstr "ブロックを移動"
-
-#: common/block_commande.cpp:72
-msgid "Block Drag"
-msgstr "ブロックをドラッグ"
-
-#: common/block_commande.cpp:76
-msgid "Drag item"
-msgstr "アイテムのドラッグ"
-
-#: common/block_commande.cpp:80
-msgid "Block Copy"
-msgstr "ブロックをコピー"
-
-#: common/block_commande.cpp:84
-msgid "Block Delete"
-msgstr "ブロックを削除"
-
-#: common/block_commande.cpp:88
-msgid "Block Save"
-msgstr "ブロックを保存"
-
-#: common/block_commande.cpp:92
-msgid "Block Paste"
-msgstr "ブロックを貼り付け"
-
-#: common/block_commande.cpp:96
-msgid "Win Zoom"
-msgstr "選択範囲の拡大"
-
-#: common/block_commande.cpp:100
-msgid "Block Rotate"
-msgstr "ブロックを回転"
-
-#: common/block_commande.cpp:104
-msgid "Block Flip"
-msgstr "ブロックを裏返し"
-
-#: common/block_commande.cpp:109
-msgid "Block Mirror"
-msgstr "ブロックをミラー反転"
-
-#: common/class_marker_base.cpp:203
-msgid "Marker Info"
-msgstr "マーカーの情報"
-
-#: common/common.cpp:140
-msgid "\""
-msgstr "\""
-
-#: common/common.cpp:171 common/dialogs/dialog_page_settings.cpp:466
-#: pagelayout_editor/pl_editor_frame.cpp:463
-msgid "inches"
-msgstr "インチ"
-
-#: common/common.cpp:175
-msgid "millimeters"
-msgstr "ミリメートル"
-
-#: common/common.cpp:198
-msgid "in"
-msgstr "インチ"
-
-#: common/common.cpp:414
-#, c-format
-msgid "Cannot make path '%s' absolute with respect to '%s'."
-msgstr "絶対パス '%s' を '%s' について設定できません."
-
-#: common/common.cpp:432
-#, c-format
-msgid "Output directory '%s' created.\n"
-msgstr "出力ディレクトリ '%s' が生成されました。\n"
-
-#: common/common.cpp:441
-#, c-format
-msgid "Cannot create output directory '%s'.\n"
-msgstr "出力ディレクトリが作成できませんでした！ '%s'.\n"
-
-#: common/confirm.cpp:94
-msgid "Info"
-msgstr "情報"
-
-#: common/confirm.cpp:114
-msgid "Confirmation"
-msgstr "確認"
-
-#: common/draw_frame.cpp:322
-msgid "Show grid"
-msgstr "グリッドの表示"
-
-#: common/dsnlexer.cpp:39
-msgid "clipboard"
-msgstr "クリップボード"
-
-#: common/dsnlexer.cpp:360 common/dsnlexer.cpp:368
-#, c-format
-msgid "Expecting '%s'"
-msgstr "例外 '%s'"
-
-#: common/dsnlexer.cpp:376 common/dsnlexer.cpp:392
-#, c-format
-msgid "Unexpected '%s'"
-msgstr "例外 '%s'"
-
-#: common/dsnlexer.cpp:384
-#, c-format
-msgid "%s is a duplicate"
-msgstr "%s は重複しています"
-
-#: common/dsnlexer.cpp:437
-#, c-format
-msgid "need a NUMBER for '%s'"
-msgstr "'%s'　のための番号が必要です"
-
-#: common/dsnlexer.cpp:709 common/dsnlexer.cpp:769
-msgid "Un-terminated delimited string"
-msgstr "区切り文字で囲まれていません"
-
-#: common/dsnlexer.cpp:731
-msgid "String delimiter must be a single character of ', \", or $"
-msgstr "区切り文字は', \", か $の1文字にしてください"
-
-#: common/eda_doc.cpp:159
-#, c-format
-msgid "Doc File '%s' not found"
-msgstr "ドキュメントファイル '%s' が見つかりません"
-
-#: common/eda_doc.cpp:202
-#, c-format
-msgid "Unknown MIME type for doc file <%s>"
-msgstr "ドキュメント ファイル <%s> の不明なMIMEタイプ"
-
-#: common/eda_text.cpp:380
-msgid "Bold+Italic"
-msgstr "<b><i>斜太字</i></b>"
-
-#: common/footprint_info.cpp:320 common/footprint_info.cpp:341
-msgid "Errors were encountered loading footprints"
-msgstr "フットプリント読み込み中にエラーが発生しました"
-
-#: common/footprint_info.cpp:339
-msgid "Load Error"
-msgstr "読込みエラー"
-
-#: common/fp_lib_table.cpp:373
-#, c-format
-msgid "'%s' is a duplicate footprint library nickName"
-msgstr "フットプリントライブラリのニックネーム<%s>は重複しています"
-
-#: common/fp_lib_table.cpp:620
-#, c-format
-msgid "fp-lib-table files contain no lib with nickname '%s'"
-msgstr "fp-lib-table ファイルは別名 '%s' のライブラリを含んでいません"
-
-#: common/fp_lib_table.cpp:716
-#, c-format
-msgid "Cannot create global library table path '%s'."
-msgstr "グローバル ライブラリ テーブルのパス '%s' が生成できません."
-
-#: common/fpid.cpp:185 common/fpid.cpp:202
-msgid "Illegal character found in FPID string"
-msgstr "FPID文字列中に不正な文字があります"
-
-#: common/fpid.cpp:306
-msgid "Illegal character found in logical library name"
-msgstr "論理的なライブラリ名の中に不正な文字があります"
-
-#: common/fpid.cpp:323 new/sch_lpid.cpp:440
-msgid "Illegal character found in revision"
-msgstr "リビジョン中に不正な文字があります"
-
-#: common/gestfich.cpp:226
-#, c-format
-msgid "Command <%s> could not found"
-msgstr "コマンド <%s> は見つかりません"
-
-#: common/gestfich.cpp:421
-#, c-format
-msgid ""
-"Problem while running the PDF viewer\n"
-"Command is '%s'"
-msgstr ""
-"PDFビューア実行中に問題が発生しました\n"
-"コマンド: '%s'"
-
-#: common/gestfich.cpp:429
-#, c-format
-msgid "Unable to find a PDF viewer for <%s>"
-msgstr "<%s> を開くためのPDFビューアが見つかりませんでした"
-
-#: common/grid_tricks.cpp:113
-msgid "Cut\tCTRL+X"
-msgstr "切り取り\tCTRL+X"
-
-#: common/grid_tricks.cpp:113
-msgid "Clear selected cells pasting original contents to clipboard"
-msgstr "クリップボードへ元の内容を保存して、選択したセルをクリア"
-
-#: common/grid_tricks.cpp:114
-msgid "Copy\tCTRL+C"
-msgstr "コピー\tCTRL+C"
-
-#: common/grid_tricks.cpp:114
-msgid "Copy selected cells to clipboard"
-msgstr "選択範囲をコピー"
-
-#: common/grid_tricks.cpp:115
-msgid "Paste\tCTRL+V"
-msgstr "ペースト\tCTRL+V"
-
-#: common/grid_tricks.cpp:115
-msgid "Paste clipboard cells to matrix at current cell"
-msgstr "現在のセル位置へ、クリップボードの内容を貼り付け"
-
-#: common/grid_tricks.cpp:116
-msgid "Select All\tCTRL+A"
-msgstr "全て選択\tCtrl+A"
-
-#: common/grid_tricks.cpp:116
-msgid "Select all cells"
-msgstr "すべてのセルを洗濯"
-
-#: common/hotkeys_basic.cpp:464 common/hotkeys_basic.cpp:493
-#: common/hotkeys_basic.cpp:497
-msgid "Hotkeys List"
-msgstr "ホットキーの一覧"
-
-#: common/hotkeys_basic.cpp:761
-msgid "Read Hotkey Configuration File:"
-msgstr "ホットキー設定ファイルの読込み:"
-
-#: common/hotkeys_basic.cpp:791
-msgid "Write Hotkey Configuration File:"
-msgstr "ホットキー設定ファイルの保存:"
-
-#: common/hotkeys_basic.cpp:819
-msgid "&List Current Keys"
-msgstr "現在のキー設定の一覧(&L)"
-
-#: common/hotkeys_basic.cpp:820
-msgid "Displays the current hotkeys list and corresponding commands"
-msgstr "現在のホットキーリストと割り付けコマンドの表示"
-
-#: common/hotkeys_basic.cpp:825
-msgid "&Edit Hotkeys"
-msgstr "ホットキーの編集(&E)"
-
-#: common/hotkeys_basic.cpp:826
-msgid "Call the hotkeys editor"
-msgstr "ホットキーエディタの呼び出し"
-
-#: common/hotkeys_basic.cpp:833
-msgid "E&xport Hotkeys"
-msgstr "ホットキー設定のエクスポート(&X)"
-
-#: common/hotkeys_basic.cpp:834
-msgid "Create a hotkey configuration file to export the current hotkeys"
-msgstr ""
-"現在のホットキー構成をエクスポートするため、ホットキー設定ファイルを作成"
-
-#: common/hotkeys_basic.cpp:839
-msgid "&Import Hotkeys"
-msgstr "ホットキー設定のインポート(&I)"
-
-#: common/hotkeys_basic.cpp:840
-msgid "Load an existing hotkey configuration file"
-msgstr "既存のホットキー構成ファイルを読込む"
-
-#: common/hotkeys_basic.cpp:845
-msgid "&Hotkeys"
-msgstr "ホットキー(&H)"
-
-#: common/hotkeys_basic.cpp:846
-msgid "Hotkeys configuration and preferences"
-msgstr "ホットキーの設定と詳細"
-
-#: common/pcbcommon.cpp:47
-msgid "No layers"
-msgstr "レイヤがありません"
-
-#: common/pcbcommon.cpp:67
-msgid "Internal"
-msgstr "内層"
-
-#: common/pcbcommon.cpp:70
-msgid "Non-copper"
-msgstr "非導体層"
-
-#: common/pgm_base.cpp:126
-msgid "French"
-msgstr "フランス語"
-
-#: common/pgm_base.cpp:134
-msgid "Finnish"
-msgstr "フィンランド語"
-
-#: common/pgm_base.cpp:142
-msgid "Spanish"
-msgstr "スペイン語"
-
-#: common/pgm_base.cpp:150
-msgid "Portuguese"
-msgstr "ポルトガル語"
-
-#: common/pgm_base.cpp:158
-msgid "Italian"
-msgstr "イタリア語"
-
-#: common/pgm_base.cpp:166
-msgid "German"
-msgstr "ドイツ語"
-
-#: common/pgm_base.cpp:174
-msgid "Greek"
-msgstr "ギリシャ語"
-
-#: common/pgm_base.cpp:182
-msgid "Slovenian"
-msgstr "スロベニア語"
-
-#: common/pgm_base.cpp:190
-msgid "Hungarian"
-msgstr "ハンガリー語"
-
-#: common/pgm_base.cpp:198
-msgid "Polish"
-msgstr "ポーランド語"
-
-#: common/pgm_base.cpp:206
-msgid "Czech"
-msgstr "チェコスロバキア語"
-
-#: common/pgm_base.cpp:214
-msgid "Russian"
-msgstr "ロシア語"
-
-#: common/pgm_base.cpp:222
-msgid "Korean"
-msgstr "韓国語"
-
-#: common/pgm_base.cpp:230
-msgid "Chinese simplified"
-msgstr "簡体中国語"
-
-#: common/pgm_base.cpp:238
-msgid "Catalan"
-msgstr "カタロニア語"
-
-#: common/pgm_base.cpp:246
-msgid "Dutch"
-msgstr "オランダ語"
-
-#: common/pgm_base.cpp:254
-msgid "Japanese"
-msgstr "日本語"
-
-#: common/pgm_base.cpp:262
-msgid "Bulgarian"
-msgstr "ブルガリア語"
-
-#: common/pgm_base.cpp:332
-msgid "No default editor found, you must choose it"
-msgstr "デフォルトのエディタが指定されていません。エディタを指定して下さい。"
-
-#: common/pgm_base.cpp:339
-msgid "Preferred Editor:"
-msgstr "エディタの指定:"
-
-#: common/pgm_base.cpp:368
-#, c-format
-msgid "%s is already running, Continue?"
-msgstr "%s は既に起動しています。続けますか？"
-
-#: common/pgm_base.cpp:748
-msgid "Language"
-msgstr "言語"
-
-#: common/pgm_base.cpp:749
-msgid "Select application language (only for testing!)"
-msgstr "アプリケーション言語の設定 (テスト用)"
-
-#: common/pgm_base.cpp:824
-msgid ""
-"Warning!  Some of paths you have configured have been defined \n"
-"externally to the running process and will be temporarily overwritten."
-msgstr ""
-"警告！ あなたが設定したいくつかのパスは、実行中のプロセスへ\n"
-"外部から定義され、現状のものを上書きします."
-
-#: common/pgm_base.cpp:826
-msgid ""
-"The next time KiCad is launched, any paths that have already\n"
-"been defined are honored and any settings defined in the path\n"
-"configuration dialog are ignored.  If you did not intend for this\n"
-"behavior, either rename any conflicting entries or remove the\n"
-"external environment variable definition(s) from your system."
-msgstr ""
-"次に kiCad を起動する時、既に定義されたパスは\n"
-"受け入れられ、パス設定ダイアログでの設定は全て\n"
-"無視されます。このような動作を望まないので\n"
-"あれば、衝突している項目をリネームし、システム\n"
-"の環境変数定義を削除して下さい。"
-
-#: common/pgm_base.cpp:833
-msgid "Do not show this message again."
-msgstr "二度とこのメッセージを表示しない"
-
-#: common/project.cpp:243
-#, c-format
-msgid "Unable to find '%s' template config file."
-msgstr "'%s' テンプレート設定ファイルが見つかりませんでした。"
-
-#: common/project.cpp:266
-#, c-format
-msgid "Cannot create prj file '%s' (Directory not writable)"
-msgstr ""
-"プロジェクトファイル '%s' を作成できません (ディレクトリは書き込み禁止)"
-
-#: common/richio.cpp:197
-#, c-format
-msgid "Unable to open filename '%s' for reading"
-msgstr "読み込み用にファイル '%s' を開けません。"
-
-#: common/richio.cpp:241 common/richio.cpp:338
-msgid "Maximum line length exceeded"
-msgstr "ライン長が超過しています。"
-
-#: common/richio.cpp:303
-msgid "Line length exceeded"
-msgstr "ライン長が超過しています。"
-
-#: common/richio.cpp:569
-#, c-format
-msgid "cannot open or save file '%s'"
-msgstr "ファイル \"%s\" を読み込み、または保存できません"
-
-#: common/richio.cpp:609
-msgid "OUTPUTSTREAM_OUTPUTFORMATTER write error"
-msgstr "OUTPUTSTREAM_OUTPUTFORMATTER 書き出しエラー"
-
-#: common/selcolor.cpp:85
-msgid "Colors"
-msgstr "カラー"
-
-#: common/wildcards_and_files_ext.cpp:70
-msgid "KiCad drawing symbol file (*.sym)|*.sym"
-msgstr "Kicad図形シンボル ファイル (*.sym)|*.sym"
-
-#: common/wildcards_and_files_ext.cpp:71
-msgid "KiCad component library file (*.lib)|*.lib"
-msgstr "Kicadコンポーネント ライブラリ ファイル (*.lib)|*.lib"
-
-#: common/wildcards_and_files_ext.cpp:72
-msgid "KiCad project files (*.pro)|*.pro"
-msgstr "KiCad プロジェクト ファイル (*.pro)|*.pro"
-
-#: common/wildcards_and_files_ext.cpp:73
-msgid "KiCad schematic files (*.sch)|*.sch"
-msgstr "KiCad 回路図ファイル (*.sch)|*.sch"
-
-#: common/wildcards_and_files_ext.cpp:74
-msgid "KiCad netlist files (*.net)|*.net"
-msgstr "KiCad ネットリスト ファイル (*.net)|*.net"
-
-#: common/wildcards_and_files_ext.cpp:75
-msgid "Gerber files (*.pho)|*.pho"
-msgstr "ガーバー ファイル (.pho)|*.pho)"
-
-#: common/wildcards_and_files_ext.cpp:76
-msgid "KiCad printed circuit board files (*.brd)|*.brd"
-msgstr "KiCad プリント基板ファイル (*.brd)|*.brd"
-
-#: common/wildcards_and_files_ext.cpp:77
-msgid "Eagle ver. 6.x XML PCB files (*.brd)|*.brd"
-msgstr "Eagle ver. 6.x XML PCBファイル (*.brd)|*.brd"
-
-#: common/wildcards_and_files_ext.cpp:78
-msgid "P-Cad 200x ASCII PCB files (*.pcb)|*.pcb"
-msgstr "P-Cad 200x ASCII PCBファイル (*.pcb)|*.pcb"
-
-#: common/wildcards_and_files_ext.cpp:79
-msgid "KiCad s-expr printed circuit board files (*.kicad_pcb)|*.kicad_pcb"
-msgstr "KiCad s-expre プリント基板ファイル (*.kicad_pcb)|*.kicad_pcb"
-
-#: common/wildcards_and_files_ext.cpp:80
-msgid "KiCad footprint s-expre file (*.kicad_mod)|*.kicad_mod"
-msgstr ""
-"Kicadフットプリント s-expre ライブラリファイル (*.kicad_mod)|*.kicad_mod"
-
-#: common/wildcards_and_files_ext.cpp:81
-msgid "KiCad footprint s-expre library path (*.pretty)|*.pretty"
-msgstr "Kicadフットプリント s-expre ライブラリパス  (*.pretty)|*.pretty"
-
-#: common/wildcards_and_files_ext.cpp:82
-msgid "Legacy footprint library file (*.mod)|*.mod"
-msgstr "レガシーフットプリントライブラリファイル (*.mod)|*.mod"
-
-#: common/wildcards_and_files_ext.cpp:83
-msgid "Eagle ver. 6.x XML library files (*.lbr)|*.lbr"
-msgstr "Eagle ver. 6.x XML ライブラリファイル (*.lbr)|*.lbr"
-
-#: common/wildcards_and_files_ext.cpp:84
-msgid "Geda PCB footprint library file (*.fp)|*.fp"
-msgstr "Geda PCB フットプリントライブラリファイル (*.fp)|*.fp"
-
-#: common/wildcards_and_files_ext.cpp:85
-msgid "KiCad recorded macros (*.mcr)|*.mcr"
-msgstr "KiCad マクロ記録 (*.mcr)|*.mcr"
-
-#: common/wildcards_and_files_ext.cpp:86
-msgid "Component-footprint link file (*.cmp)|*cmp"
-msgstr "コンポーネント-フットプリント関連付けファイル (*.cmp)|*.cmp"
-
-#: common/wildcards_and_files_ext.cpp:87
-msgid "Page layout descr file (*.kicad_wks)|*kicad_wks"
-msgstr "図枠ファイル (*.kicad_wks)|*kicad_wks"
-
-#: common/wildcards_and_files_ext.cpp:89
-msgid "All files (*)|*"
-msgstr "全てのファイル (*)|*"
-
-#: common/wildcards_and_files_ext.cpp:92
-msgid "KiCad cmp/footprint link files (*.cmp)|*.cmp"
-msgstr "Kicad コンポーネント-フットプリント関連付けファイル (*.cmp)|*.cmp"
-
-#: common/wildcards_and_files_ext.cpp:95
-msgid "Drill files (*.drl)|*.drl;*.DRL"
-msgstr "ドリル ファイル (*.drl)|*.drl"
-
-#: common/wildcards_and_files_ext.cpp:96
-msgid "SVG files (*.svg)|*.svg;*.SVG"
-msgstr "SVGファイル (*.svg)|*.svg;*.SVG"
-
-#: common/wildcards_and_files_ext.cpp:97
-msgid "HTML files (*.html)|*.htm;*.html"
-msgstr "HTML ファイル (*.html)|*.htm;*.html"
-
-#: common/wildcards_and_files_ext.cpp:98
-msgid "Portable document format files (*.pdf)|*.pdf"
-msgstr "PDFファイル (*.pdf)|*.pdf"
-
-#: common/wildcards_and_files_ext.cpp:99
-msgid "PostScript files (.ps)|*.ps"
-msgstr "PostScript ファイル (.ps)|*.ps"
-
-#: common/wildcards_and_files_ext.cpp:100
-msgid "Report files (*.rpt)|*.rpt"
-msgstr "レポートファイル (.rpt)|*.rpt"
-
-#: common/wildcards_and_files_ext.cpp:101
-msgid "Footprint place files (*.pos)|*.pos"
-msgstr "Footprint配置情報 (*.pos)|*.pos"
-
-#: common/wildcards_and_files_ext.cpp:102
-msgid "Vrml and x3d files (*.wrl *.x3d)|*.wrl;*.x3d"
-msgstr "Vrml / x3d ファイル (*.wrl *.x3d)|*.wrl;*.x3d"
-
-#: common/wildcards_and_files_ext.cpp:103
-msgid "IDFv3 component files (*.idf)|*.idf"
-msgstr "IDFv3 コンポーネントファイル (*.idf)|*.idf"
-
-#: common/wildcards_and_files_ext.cpp:104
-msgid "Text files (*.txt)|*.txt"
-msgstr "テキストファイル (*.txt)|*.txt"
-
-#: common/wxunittext.cpp:199
-msgid "default "
-msgstr "標準"
-
-#: common/wxwineda.cpp:61
-#, c-format
-msgid "Size%s"
-msgstr "サイズ %s"
-
-#: common/wxwineda.cpp:166 common/wxwineda.cpp:180
-msgid "Pos "
-msgstr "座標"
-
-#: common/zoom.cpp:260
-msgid "Zoom select"
-msgstr "ズームの選択"
-
-#: common/zoom.cpp:273
-msgid "Zoom: "
-msgstr "ズーム:"
-
-#: common/zoom.cpp:284
-msgid "Grid Select"
-msgstr "グリッドの選択:"
-
-#: common/dialog_about/AboutDialog_main.cpp:134
-msgid ""
-"The KiCad EDA Suite is a set of open source applications for the creation of "
-"electronic schematics and to design printed circuit boards."
-msgstr ""
-"The KiCad EDA Suite は電気回路図作成及びプリント基板設計のための、オープン・"
-"ソース アプリケーション セットです。"
-
-#: common/dialog_about/AboutDialog_main.cpp:141
-msgid "KiCad on the web"
-msgstr "web上のKiCad"
-
-#: common/dialog_about/AboutDialog_main.cpp:147
-msgid "The original site of the initiator of Kicad"
-msgstr "KiCad 創始者のオリジナルサイト"
-
-#: common/dialog_about/AboutDialog_main.cpp:150
-msgid "Project on Launchpad"
-msgstr "Launchpad上のプロジェクト"
-
-#: common/dialog_about/AboutDialog_main.cpp:154
-msgid "The new KiCad site"
-msgstr "新しいKiCadのWebサイト"
-
-#: common/dialog_about/AboutDialog_main.cpp:157
-msgid "Repository with additional component libraries"
-msgstr "追加のコンポーネント ライブラリのリポジトリ"
-
-#: common/dialog_about/AboutDialog_main.cpp:163
-msgid "Contribute to KiCad"
-msgstr "Kicadに貢献"
-
-#: common/dialog_about/AboutDialog_main.cpp:169
-msgid "Report bugs if you found any"
-msgstr "どんなバグでも見つけたらレポートしてください"
-
-#: common/dialog_about/AboutDialog_main.cpp:172
-msgid "File an idea for improvement"
-msgstr "改善のためのアイデアのファイル"
-
-#: common/dialog_about/AboutDialog_main.cpp:176
-msgid "KiCad links to user groups, tutorials and much more"
-msgstr "KiCadユーザグループへのリンク、チュートリアルなど"
-
-#: common/dialog_about/AboutDialog_main.cpp:189
-msgid "The complete KiCad EDA Suite is released under the"
-msgstr "KiCad EDAソフトウエアは、下記のラインセンスのもと提供されています："
-
-#: common/dialog_about/AboutDialog_main.cpp:191
-msgid "GNU General Public License (GPL) version 2 or any later version"
-msgstr "GNU 一般公衆ライセンス (GPL) バージョン 2 以降"
-
-#: common/dialog_about/dialog_about.cpp:83
-msgid "Information"
-msgstr "情報"
-
-#: common/dialog_about/dialog_about.cpp:86
-msgid "Developers"
-msgstr "開発者"
-
-#: common/dialog_about/dialog_about.cpp:87
-msgid "Doc Writers"
-msgstr "ドキュメント作成者"
-
-#: common/dialog_about/dialog_about.cpp:89
-msgid "Artists"
-msgstr "アーティスト"
-
-#: common/dialog_about/dialog_about.cpp:90
-msgid "Translators"
-msgstr "翻訳者"
-
-#: common/dialog_about/dialog_about.cpp:93
-msgid "License"
-msgstr "ライセンス"
-
-#: common/dialog_about/dialog_about_base.cpp:31
-msgid "App Title"
-msgstr "アプリケーション タイトル"
-
-#: common/dialog_about/dialog_about_base.cpp:37
-msgid "Copyright Info"
-msgstr "著作権情報"
-
-#: common/dialog_about/dialog_about_base.cpp:41
-msgid "Build Version Info"
-msgstr "ビルド バージョン情報"
-
-#: common/dialog_about/dialog_about_base.cpp:45
-msgid "Lib Version Info"
-msgstr "ライブラリ バージョン情報"
-
-#: common/dialogs/dialog_env_var_config.cpp:105
-msgid "Invalid Input"
-msgstr "不正な入力"
-
-#: common/dialogs/dialog_env_var_config.cpp:119
-msgid "Environment variable name cannot be empty."
-msgstr "環境変数名は空欄にできません。"
-
-#: common/dialogs/dialog_env_var_config.cpp:129
-msgid "Environment variable value cannot be empty."
-msgstr "環境変数値は空欄にできません。"
-
-#: common/dialogs/dialog_env_var_config.cpp:140
-msgid ""
-"The first character of an environment variable name cannot be a digit (0-9)."
-msgstr "環境変数名の最初の文字に数字 (0-9) は使用できません。"
-
-#: common/dialogs/dialog_env_var_config.cpp:152
-msgid "Cannot have duplicate environment variable names."
-msgstr "重複した環境変数名を持つことはできません。"
-
-#: common/dialogs/dialog_env_var_config.cpp:255
-msgid ""
-"Enter the name and path for each environment variable.  Grey entries are "
-"names that have been defined externally at the system or user level.  "
-"Environment variables defined at the system or user level take precedence "
-"over the ones defined in this table.  This means the values in this table "
-"are ignored."
-msgstr ""
-"各々の環境変数へ名前とパスを入力して下さい。灰色の項目は、システムまたはユー"
-"ザーによって外部で定義された名前です。システムまたはユーザーによって定義され"
-"た環境変数は、このテーブルの定義に優先します。これは、このテーブルの定義が無"
-"視されることを意味します。"
-
-#: common/dialogs/dialog_env_var_config.cpp:261
-msgid ""
-"To ensure environment variable names are valid on all platforms, the name "
-"field will only accept upper case letters, digits, and the underscore "
-"characters."
-msgstr ""
-"全てのプラットフォームで有効な環境変数名とするため、名前フィールドは大文字、"
-"数字、アンダースコアだけを受け付けます。"
-
-#: common/dialogs/dialog_env_var_config.cpp:264
-msgid ""
-"<b>KIGITHUB</b> is used by KiCad to define the URL of the repository of the "
-"official KiCad libraries."
-msgstr ""
-"<b>KIGITHUB</b> は 、公式 KiCad ライブラリのリポジトリの URL を定義するために"
-"KiCad で使用されます。"
-
-#: common/dialogs/dialog_env_var_config.cpp:267
-msgid ""
-"<b>KISYS3DMOD</b> is the base path of system footprint 3D shapes (.3Dshapes "
-"folders)."
-msgstr ""
-"<b>KISYS3DMOD</b> は、フットプリント 3D シェイプ用のシステムの基本パスです "
-"(.3Dshapes フォルダ)。"
-
-#: common/dialogs/dialog_env_var_config.cpp:270
-msgid ""
-"<b>KISYSMOD</b> is the base path of locally installed system footprint "
-"libraries (.pretty folders)."
-msgstr ""
-"<b>KISYSMOD</b> は、フットプリント・ライブラリ用にローカルでインストールされ"
-"たシステムの基本パスです (.pretty フォルダ)。"
-
-#: common/dialogs/dialog_env_var_config.cpp:273
-msgid ""
-"<b>KIPRJMOD</b> is internally defined by KiCad (cannot be edited) and is set "
-"to the absolute path of the currently loaded project file.  This environment "
-"variable can be used to define files and paths relative to the currently "
-"loaded project.  For instance, ${KIPRJMOD}/libs/footprints.pretty can be "
-"defined as a folder containing a project specific footprint library named "
-"footprints.pretty."
-msgstr ""
-"<b>KIPRJMOD</b> は、KiCad によって内部定義され (編集できません) 、現在読み込"
-"まれているプロジェクト・ファイルの絶対パスがセットされます。この環境変数は、"
-"読み込まれているプロジェクトへの相対的なファイルやパスを定義するために使用で"
-"きます。例えば、${KIPRJMOD}/libs/footprints.pretty は footprints.pretty と名"
-"付けられたプロジェクト固有のフットプリント・ライブラリを含むフォルダとして定"
-"義できます。"
-
-#: common/dialogs/dialog_env_var_config.cpp:279
-msgid ""
-"<b>KICAD_PTEMPLATES</b> is optional and can be defined if you want to create "
-"your own project templates folder."
-msgstr ""
-"<b>KICAD_PTEMPLATES</b> は、オプションです。独自のプロジェクト・テンプレー"
-"ト・フォルダを作りたい場合に定義します。"
-
-#: common/dialogs/dialog_env_var_config.cpp:282
-msgid "Environment Variable Help"
-msgstr "環境変数に関するヘルプ"
-
-#: common/dialogs/dialog_env_var_config_base.cpp:36
-msgid "Path"
-msgstr "パス"
-
-#: common/dialogs/dialog_env_var_config_base.cpp:64
-msgid "Add a new entry to the table."
-msgstr "テーブルへ項目を新規追加"
-
-#: common/dialogs/dialog_env_var_config_base.cpp:69
-msgid "Remove the selectect entry from the table."
-msgstr "一覧より選択した項目を削除します。"
-
-#: common/dialogs/dialog_exit_base.cpp:34
-msgid "Save the changes before closing?"
-msgstr "閉じる前に変更を保存しますか？"
-
-#: common/dialogs/dialog_exit_base.cpp:43
-msgid "If you don't save, all your changes will be permanently lost."
-msgstr "保存しない場合、変更はすべて失われます．"
-
-#: common/dialogs/dialog_exit_base.cpp:62
-msgid "Save and Exit"
-msgstr "保存して終了"
-
-#: common/dialogs/dialog_exit_base.cpp:66
-msgid "Exit without Save"
-msgstr "保存しないで終了"
-
-#: common/dialogs/dialog_get_component_base.cpp:30
-msgid "History list:"
-msgstr "履歴リスト:"
-
-#: common/dialogs/dialog_get_component_base.cpp:49
-msgid "Search by Keyword"
-msgstr "キーワードで検索"
-
-#: common/dialogs/dialog_get_component_base.cpp:55
-msgid "List All"
-msgstr "全てのリスト"
-
-#: common/dialogs/dialog_get_component_base.cpp:58
-msgid "Select by Browser"
-msgstr "ブラウザーで選択"
-
-#: common/dialogs/dialog_hotkeys_editor.cpp:45
-msgid "Command"
-msgstr "コマンド"
-
-#: common/dialogs/dialog_hotkeys_editor.cpp:46
-msgid "Hotkey"
-msgstr "ホットキー"
-
-#: common/dialogs/dialog_hotkeys_editor.cpp:375
-#, c-format
-msgid ""
-"<%s> is already assigned to \"%s\" in section \"%s\". Are you sure you want "
-"to change its assignment?"
-msgstr ""
-"<%s>は既に \"%s\" のセクション \"%s\" へ割り当てられています。現在の割り当て"
-"を変更して宜しいですか？"
-
-#: common/dialogs/dialog_hotkeys_editor.cpp:380
-msgid "Confirm change"
-msgstr "変更の確認"
-
-#: common/dialogs/dialog_hotkeys_editor_base.cpp:19
-msgid "Select a row and press a new key combination to alter the binding."
-msgstr "項目を選択し、新しいキーを押して割り当てを変更してください。"
-
-#: common/dialogs/dialog_hotkeys_editor_base.cpp:36
-msgid "Undo"
-msgstr "元に戻す"
-
-#: common/dialogs/dialog_image_editor.cpp:130
-msgid "Incorrect scale number"
-msgstr "無効な倍率です"
-
-#: common/dialogs/dialog_image_editor.cpp:138
-msgid "Scale is too small for this image"
-msgstr "このイメージに対してスケール値が小さすぎます。"
-
-#: common/dialogs/dialog_image_editor.cpp:143
-msgid "Scale is too large for this image"
-msgstr "このイメージに対してスケール値が大きすぎます。"
-
-#: common/dialogs/dialog_image_editor_base.cpp:33
-msgid "Mirror X"
-msgstr "X軸で反転"
-
-#: common/dialogs/dialog_image_editor_base.cpp:36
-msgid "Mirror Y"
-msgstr "Y軸で反転"
-
-#: common/dialogs/dialog_image_editor_base.cpp:42
-msgid "Grey"
-msgstr "グレースケール"
-
-#: common/dialogs/dialog_image_editor_base.cpp:45
-msgid "Half Size"
-msgstr "半分のサイズ"
-
-#: common/dialogs/dialog_image_editor_base.cpp:49
-msgid "Undo Last"
-msgstr "一つ前のコマンドを元に戻す"
-
-#: common/dialogs/dialog_image_editor_base.cpp:52
-msgid "Image Scale:"
-msgstr "画像の倍率:"
-
-#: common/dialogs/dialog_list_selector_base.cpp:21
-msgid ""
-"Enter a string to filter items.\n"
-"Only names containing this string will be listed"
-msgstr ""
-"アイテムを抽出するために文字列を入力してください．\n"
-"入力した文字列を含む名前だけがリストされます．"
-
-#: common/dialogs/dialog_list_selector_base.cpp:28
-msgid "Items:"
-msgstr "アイテム: "
-
-#: common/dialogs/dialog_page_settings.cpp:61
-msgid "A4 210x297mm"
-msgstr "A4 210x297mm"
-
-#: common/dialogs/dialog_page_settings.cpp:62
-msgid "A3 297x420mm"
-msgstr "A3 297x420mm"
-
-#: common/dialogs/dialog_page_settings.cpp:63
-msgid "A2 420x594mm"
-msgstr "A2 420x594mm"
-
-#: common/dialogs/dialog_page_settings.cpp:64
-msgid "A1 594x841mm"
-msgstr "A1 594x841mm"
-
-#: common/dialogs/dialog_page_settings.cpp:65
-msgid "A0 841x1189mm"
-msgstr "A0 841x1189mm"
-
-#: common/dialogs/dialog_page_settings.cpp:66
-msgid "A 8.5x11in"
-msgstr "A 8.5x11in"
-
-#: common/dialogs/dialog_page_settings.cpp:67
-msgid "B 11x17in"
-msgstr "B 11x17in"
-
-#: common/dialogs/dialog_page_settings.cpp:68
-msgid "C 17x22in"
-msgstr "C 17x22in"
-
-#: common/dialogs/dialog_page_settings.cpp:69
-msgid "D 22x34in"
-msgstr "D 22x34in"
-
-#: common/dialogs/dialog_page_settings.cpp:70
-msgid "E 34x44in"
-msgstr "E 34x44in"
-
-#: common/dialogs/dialog_page_settings.cpp:71
-msgid "USLetter 8.5x11in"
-msgstr "USLetter 8.5x11in"
-
-#: common/dialogs/dialog_page_settings.cpp:72
-msgid "USLegal 8.5x14in"
-msgstr "USLegal 8.5x14in"
-
-#: common/dialogs/dialog_page_settings.cpp:73
-msgid "USLedger 11x17in"
-msgstr "USLedger 11x17in"
-
-#: common/dialogs/dialog_page_settings.cpp:74
-msgid "User (Custom)"
-msgstr "ユーザ設定 (カスタム)"
-
-#: common/dialogs/dialog_page_settings.cpp:267
-#: common/dialogs/dialog_page_settings.cpp:713
-#: common/dialogs/dialog_page_settings_base.cpp:46
-msgid "Portrait"
-msgstr "縦向き"
-
-#: common/dialogs/dialog_page_settings.cpp:431
-#, c-format
-msgid "Page layout description file <%s> not found. Abort"
-msgstr "図枠ファイル <%s> が見つかりませんでした。中断します。"
-
-#: common/dialogs/dialog_page_settings.cpp:462
-#, c-format
-msgid ""
-"Selected custom paper size\n"
-"is out of the permissible limits\n"
-"%.1f - %.1f %s!\n"
-"Select another custom paper size?"
-msgstr ""
-"選択された用紙サイズは\n"
-"使用できる限界を超えています。\n"
-"%.1f - %.1f %s!\n"
-"他の用紙サイズを選択しますか？"
-
-#: common/dialogs/dialog_page_settings.cpp:468
-msgid "Warning!"
-msgstr "警告!"
-
-#: common/dialogs/dialog_page_settings.cpp:715
-#: common/dialogs/dialog_page_settings_base.cpp:46
-msgid "Landscape"
-msgstr "横向き"
-
-#: common/dialogs/dialog_page_settings.cpp:801
-msgid "Select Page Layout Descr File"
-msgstr "図枠ファイルの洗濯"
-
-#: common/dialogs/dialog_page_settings.cpp:819
-#, c-format
-msgid ""
-"The page layout descr filename has changed.\n"
-"Do you want to use the relative path:\n"
-"'%s'\n"
-"instead of\n"
-"'%s'"
-msgstr ""
-"図枠ファイルの指定が変更されました。\n"
-"相対パスを使用して図枠ファイルを参照しますか:\n"
-"'%s'\n"
-"(以下に代わって) \n"
-"'%s'"
-
-#: common/dialogs/dialog_page_settings_base.cpp:25
-msgid "Paper"
-msgstr "紙"
-
-#: common/dialogs/dialog_page_settings_base.cpp:32
-#: bitmap2component/bitmap2cmp_gui_base.cpp:50
-#: bitmap2component/bitmap2cmp_gui_base.cpp:66 include/wxunittext.h:50
-msgid "Size:"
-msgstr "サイズ:"
-
-#: common/dialogs/dialog_page_settings_base.cpp:36
-msgid "dummy text"
-msgstr "ダミーテキスト"
-
-#: common/dialogs/dialog_page_settings_base.cpp:52
-msgid "Custom Size:"
-msgstr "カスタムサイズ:"
-
-#: common/dialogs/dialog_page_settings_base.cpp:68
-msgid "Custom paper height."
-msgstr "カスタム用紙の高さ"
-
-#: common/dialogs/dialog_page_settings_base.cpp:84
-msgid "Custom paper width."
-msgstr "カスタム用紙の幅"
-
-#: common/dialogs/dialog_page_settings_base.cpp:94
-msgid "Layout Preview"
-msgstr "レイアウトプレビュー"
-
-#: common/dialogs/dialog_page_settings_base.cpp:113
-msgid "Title Block Parameters"
-msgstr "図枠の設定"
-
-#: common/dialogs/dialog_page_settings_base.cpp:123
-#, c-format
-msgid "Number of sheets: %d"
-msgstr "シートの数: %d"
-
-#: common/dialogs/dialog_page_settings_base.cpp:130
-#, c-format
-msgid "Sheet number: %d"
-msgstr "シート番号: %d"
-
-#: common/dialogs/dialog_page_settings_base.cpp:140
-msgid "Issue Date"
-msgstr "変更日"
-
-#: common/dialogs/dialog_page_settings_base.cpp:159
-#: common/dialogs/dialog_page_settings_base.cpp:184
-#: common/dialogs/dialog_page_settings_base.cpp:209
-#: common/dialogs/dialog_page_settings_base.cpp:234
-#: common/dialogs/dialog_page_settings_base.cpp:259
-#: common/dialogs/dialog_page_settings_base.cpp:284
-#: common/dialogs/dialog_page_settings_base.cpp:309
-#: common/dialogs/dialog_page_settings_base.cpp:334
-msgid "Export to other sheets"
-msgstr "他のシートへエクスポート"
-
-#: common/dialogs/dialog_page_settings_base.cpp:171
-msgid "Revision"
-msgstr "リビジョン"
-
-#: common/dialogs/dialog_page_settings_base.cpp:196
-msgid "Title"
-msgstr "タイトル"
-
-#: common/dialogs/dialog_page_settings_base.cpp:221
-msgid "Company"
-msgstr "会社名"
-
-#: common/dialogs/dialog_page_settings_base.cpp:246
-msgid "Comment1"
-msgstr "コメント1"
-
-#: common/dialogs/dialog_page_settings_base.cpp:271
-msgid "Comment2"
-msgstr "コメント2"
-
-#: common/dialogs/dialog_page_settings_base.cpp:296
-msgid "Comment3"
-msgstr "コメント3"
-
-#: common/dialogs/dialog_page_settings_base.cpp:321
-msgid "Comment4"
-msgstr "コメント4"
-
-#: common/dialogs/dialog_page_settings_base.cpp:346
-msgid "Page layout description file"
-msgstr "図枠ファイル"
-
-#: common/dialogs/wx_html_report_panel.cpp:130
-msgid "<b>Error: </b></font><font size=2>"
-msgstr "<b>エラー: </b></font><font size=2>"
-
-#: common/dialogs/wx_html_report_panel.cpp:132
-msgid "<b>Warning: </b></font><font size=2>"
-msgstr "<b>警告: </b></font><font size=2>"
-
-#: common/dialogs/wx_html_report_panel.cpp:134
-msgid "<b>Info: </b>"
-msgstr "<b>情報: </b>"
-
-#: common/dialogs/wx_html_report_panel.cpp:148
-msgid "Error: "
-msgstr "エラー:"
-
-#: common/dialogs/wx_html_report_panel.cpp:150
-msgid "Warning: "
-msgstr "警告: "
-
-#: common/dialogs/wx_html_report_panel.cpp:152
-msgid "Info: "
-msgstr "情報: "
-
-#: common/dialogs/wx_html_report_panel.cpp:233
-msgid "Save report to file"
-msgstr "レポートをファイルに保存"
-
-#: common/dialogs/wx_html_report_panel.cpp:250
-#, c-format
-msgid "Cannot write report to file '%s'."
-msgstr "レポートをファイル '%s' へ書き出すことが出来ませんでした."
-
-#: common/dialogs/wx_html_report_panel.cpp:252
-msgid "File save error"
-msgstr "ファイル保存エラー"
-
-#: common/page_layout/page_layout_reader.cpp:816
-#, c-format
-msgid "The file <%s> was not fully read"
-msgstr "ファイル <%s> が最後まで読み込めませんでした"
-
-#: 3d-viewer/3d_canvas.cpp:390
-msgid "Zoom +"
-msgstr "ズーム イン"
-
-#: 3d-viewer/3d_canvas.cpp:394
-msgid "Zoom -"
-msgstr "ズーム アウト"
-
-#: 3d-viewer/3d_canvas.cpp:399
-msgid "Top View"
-msgstr "上から見る"
-
-#: 3d-viewer/3d_canvas.cpp:403
-msgid "Bottom View"
-msgstr "下から見る"
-
-#: 3d-viewer/3d_canvas.cpp:408
-msgid "Right View"
-msgstr "右から見る"
-
-#: 3d-viewer/3d_canvas.cpp:412
-msgid "Left View"
-msgstr "左から見る"
-
-#: 3d-viewer/3d_canvas.cpp:417
-msgid "Front View"
-msgstr "前から見る"
-
-#: 3d-viewer/3d_canvas.cpp:421
-msgid "Back View"
-msgstr "後ろから見る"
-
-#: 3d-viewer/3d_canvas.cpp:426
-msgid "Move left <-"
-msgstr "左へ移動 ←"
-
-#: 3d-viewer/3d_canvas.cpp:430
-msgid "Move right ->"
-msgstr "右へ移動 →"
-
-#: 3d-viewer/3d_canvas.cpp:434
-msgid "Move Up ^"
-msgstr "上へ移動 ↑"
-
-#: 3d-viewer/3d_canvas.cpp:518
-#, c-format
-msgid "Zoom: %3.1f"
-msgstr "ズーム: %3.1f"
-
-#: 3d-viewer/3d_canvas.cpp:654
-msgid "3D Image File Name:"
-msgstr "3D 画像ファイル名:"
-
-#: 3d-viewer/3d_canvas.cpp:710
-msgid "Failed to copy image to clipboard"
-msgstr "クリップボードからイメージをコピーできませんでした"
-
-#: 3d-viewer/3d_canvas.cpp:723
-msgid "Can't save file"
-msgstr "ファイルを保存できません"
-
-#: 3d-viewer/3d_draw.cpp:617
-#, c-format
-msgid "Build time %.3f s"
-msgstr "ビルド時間 %.3f 秒"
-
-#: 3d-viewer/3d_draw.cpp:660 3d-viewer/3d_draw_board_body.cpp:218
-#: 3d-viewer/3d_draw_board_body.cpp:505
-#, c-format
-msgid "Build layer %s"
-msgstr "ビルド レイヤ %s"
-
-#: 3d-viewer/3d_draw.cpp:986
-msgid "Load 3D Shapes"
-msgstr "3Dシェイプの読み込み"
-
-#: 3d-viewer/3d_draw_board_body.cpp:194 3d-viewer/3d_draw_board_body.cpp:471
-msgid ""
-"Unable to calculate the board outlines.\n"
-"Therefore use the board boundary box."
-msgstr ""
-"基板の外形を計算できません;\n"
-"そのためバウンダリボックスを使用します."
-
-#: 3d-viewer/3d_draw_board_body.cpp:369
-msgid "Build board body"
-msgstr "ボード本体の Build"
-
-#: 3d-viewer/3d_frame.cpp:534
-msgid "Background Color, Bottom"
-msgstr "背景色, 下層"
-
-#: 3d-viewer/3d_frame.cpp:539
-msgid "Background Color, Top"
-msgstr "背景色, 上層"
-
-#: 3d-viewer/3d_frame.cpp:788
-msgid "Silk Screen Color"
-msgstr "シルクの色"
-
-#: 3d-viewer/3d_frame.cpp:812 3d-viewer/3d_toolbar.cpp:216
-msgid "Solder Mask Color"
-msgstr "ハンダマスクの色"
-
-#: 3d-viewer/3d_frame.cpp:835
-msgid "Copper Color"
-msgstr "導体の色"
-
-#: 3d-viewer/3d_frame.cpp:861 3d-viewer/3d_toolbar.cpp:225
-msgid "Board Body Color"
-msgstr "基板本体の色"
-
-#: 3d-viewer/3d_frame.cpp:882 3d-viewer/3d_toolbar.cpp:219
-msgid "Solder Paste Color"
-msgstr "ハンダ ペーストの色"
-
-#: 3d-viewer/3d_toolbar.cpp:52
-msgid "Reload board"
-msgstr "ボードを再読み込み"
-
-#: 3d-viewer/3d_toolbar.cpp:58 3d-viewer/3d_toolbar.cpp:146
-msgid "Copy 3D Image to Clipboard"
-msgstr "クリップボードへ画像をコピー"
-
-#: 3d-viewer/3d_toolbar.cpp:64
-msgid "Set display options, and some layers visibility"
-msgstr "ディスプレイ オプションを設定してレイヤを可視化"
-
-#: 3d-viewer/3d_toolbar.cpp:78
-msgid "Fit in page"
-msgstr "ページに合わせる"
-
-#: 3d-viewer/3d_toolbar.cpp:83
-msgid "Rotate X <-"
-msgstr "X回転 ←"
-
-#: 3d-viewer/3d_toolbar.cpp:87
-msgid "Rotate X ->"
-msgstr "X回転 →"
-
-#: 3d-viewer/3d_toolbar.cpp:92
-msgid "Rotate Y <-"
-msgstr "Y回転 ←"
-
-#: 3d-viewer/3d_toolbar.cpp:96
-msgid "Rotate Y ->"
-msgstr "Y回転 →"
-
-#: 3d-viewer/3d_toolbar.cpp:101
-msgid "Rotate Z <-"
-msgstr "Z回転 ←"
-
-#: 3d-viewer/3d_toolbar.cpp:105
-msgid "Rotate Z ->"
-msgstr "Z回転 →"
-
-#: 3d-viewer/3d_toolbar.cpp:109
-msgid "Move left"
-msgstr "左へ移動 ←"
-
-#: 3d-viewer/3d_toolbar.cpp:112
-msgid "Move right"
-msgstr "右へ移動 →"
-
-#: 3d-viewer/3d_toolbar.cpp:115
-msgid "Move up"
-msgstr "上へ移動↑"
-
-#: 3d-viewer/3d_toolbar.cpp:118
-msgid "Move down"
-msgstr "下へ移動↓"
-
-#: 3d-viewer/3d_toolbar.cpp:122
-msgid "Enable/Disable orthographic projection"
-msgstr "正投影を有効化/無効化する"
-
-#: 3d-viewer/3d_toolbar.cpp:138
-msgid "Create Image (png format)"
-msgstr "PNG形式で画像保存"
-
-#: 3d-viewer/3d_toolbar.cpp:141
-msgid "Create Image (jpeg format)"
-msgstr "JPEG形式で画像保存"
-
-#: 3d-viewer/3d_toolbar.cpp:151
-msgid "&Exit"
-msgstr "終了(&E)"
-
-#: 3d-viewer/3d_toolbar.cpp:157
-msgid "Realistic Mode"
-msgstr "リアルモード"
-
-#: 3d-viewer/3d_toolbar.cpp:162
-msgid "Render Options"
-msgstr "レンダオプション"
-
-#: 3d-viewer/3d_toolbar.cpp:165
-msgid "Render Shadows"
-msgstr "影の表示"
-
-#: 3d-viewer/3d_toolbar.cpp:169
-msgid "Show Holes in Zones"
-msgstr "ゾーン中に穴を表示"
-
-#: 3d-viewer/3d_toolbar.cpp:170
-msgid ""
-"Holes inside a copper layer copper zones are shown, but the calculation time "
-"is longer"
-msgstr ""
-"導体レイヤ、導体ゾーンの内部にある穴が表示されていますが、計算時間は長くなり"
-"ます"
-
-#: 3d-viewer/3d_toolbar.cpp:175
-msgid "Render Textures"
-msgstr "テクスチャの表示"
-
-#: 3d-viewer/3d_toolbar.cpp:176
-msgid "Apply a grid/cloud textures to Board, Solder Mask and Silkscreen"
-msgstr "基板に対してグリッド、半田マスク、シルク等テクスチャを適用します"
-
-#: 3d-viewer/3d_toolbar.cpp:180
-msgid "Render Smooth Normals"
-msgstr "ノーマル表示でスムーズに描画"
-
-#: 3d-viewer/3d_toolbar.cpp:184
-msgid "Use Model Normals"
-msgstr "モデルをノーマル表示で使用"
-
-#: 3d-viewer/3d_toolbar.cpp:188
-msgid "Render Material Properties"
-msgstr "マテリアル(材質)の描画"
-
-#: 3d-viewer/3d_toolbar.cpp:192
-msgid "Show Model Bounding Boxes"
-msgstr "モデルをバウンディングボックスで表示"
-
-#: 3d-viewer/3d_toolbar.cpp:200
-msgid "Choose Colors"
-msgstr "色の選択"
-
-#: 3d-viewer/3d_toolbar.cpp:207
-msgid "Background Top Color"
-msgstr "背景上面色"
-
-#: 3d-viewer/3d_toolbar.cpp:210
-msgid "Background Bottom Color"
-msgstr "背景下面色"
-
-#: 3d-viewer/3d_toolbar.cpp:213
-msgid "Silkscreen Color"
-msgstr "シルクの色"
-
-#: 3d-viewer/3d_toolbar.cpp:222
-msgid "Copper/Surface Finish Color"
-msgstr "導体/表面の仕上がり色"
-
-#: 3d-viewer/3d_toolbar.cpp:228
-msgid "Show 3D &Axis"
-msgstr "3Dと軸の表示"
-
-#: 3d-viewer/3d_toolbar.cpp:233
-msgid "3D Grid"
-msgstr "3Dグリッド"
-
-#: 3d-viewer/3d_toolbar.cpp:234
-msgid "No 3D Grid"
-msgstr "3Dグリッド無し"
-
-#: 3d-viewer/3d_toolbar.cpp:235
-msgid "3D Grid 10 mm"
-msgstr "3Dグリッド 10mm"
-
-#: 3d-viewer/3d_toolbar.cpp:236
-msgid "3D Grid 5 mm"
-msgstr "3Dグリッド 5mm"
-
-#: 3d-viewer/3d_toolbar.cpp:237
-msgid "3D Grid 2.5 mm"
-msgstr "3Dグリッド 2.5mm"
-
-#: 3d-viewer/3d_toolbar.cpp:238
-msgid "3D Grid 1 mm"
-msgstr "3Dグリッド 1mm"
-
-#: 3d-viewer/3d_toolbar.cpp:254
-msgid "Show Board Bod&y"
-msgstr "基板の表示(&Y)"
-
-#: 3d-viewer/3d_toolbar.cpp:257
-msgid "Show Copper &Thickness"
-msgstr "銅箔の厚みを表示(&T)"
-
-#: 3d-viewer/3d_toolbar.cpp:260
-msgid "Show 3D F&ootprints"
-msgstr "3Dフットプリントの表示"
-
-#: 3d-viewer/3d_toolbar.cpp:263
-msgid "Show Zone &Filling"
-msgstr "ゾーン塗りつぶしを表示"
-
-#: 3d-viewer/3d_toolbar.cpp:269
-msgid "Show &Layers"
-msgstr "レイヤの表示(&L)"
-
-#: 3d-viewer/3d_toolbar.cpp:272
-msgid "Show &Adhesive Layers"
-msgstr "接着剤(Adhesive)レイヤの表示(&A)"
-
-#: 3d-viewer/3d_toolbar.cpp:275
-msgid "Show &Silkscreen Layer"
-msgstr "シルクレイヤの表示(&S)"
-
-#: 3d-viewer/3d_toolbar.cpp:278
-msgid "Show Solder &Mask Layers"
-msgstr "半田マスクレイヤの表示(&M)"
-
-#: 3d-viewer/3d_toolbar.cpp:281
-msgid "Show Solder &Paste Layers"
-msgstr "半田ペーストレイヤの表示(&P)"
-
-#: 3d-viewer/3d_toolbar.cpp:286
-msgid "Show &Comments and Drawings Layer"
-msgstr "コメント/図面描画レイヤの表示(&C)"
-
-#: 3d-viewer/3d_toolbar.cpp:289
-msgid "Show &Eco Layers"
-msgstr "ECOレイヤの表示(&E)"
-
-#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:30
-msgid "Realistic mode"
-msgstr "リアルモード"
-
-#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:36
-msgid "Show copper thickness"
-msgstr "銅箔の厚みを表示"
-
-#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:42
-msgid "Show component 3D shapes"
-msgstr "コンポーネントの3D形状を表示"
-
-#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:54
-msgid "Show silkscreen layers"
-msgstr "シルクレイヤを表示"
-
-#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:60
-msgid "Show solder mask layers"
-msgstr "半田マスクレイヤの表示"
-
-#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:66
-msgid "Show solder paste layers"
-msgstr "半田ペーストレイヤ"
-
-#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:72
-msgid "Show adhesive layers"
-msgstr "接着剤(Adhesive)レイヤの表示"
-
-#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:78
-msgid "Show comments and drawings layers"
-msgstr "コメント/図面描画レイヤの表示"
-
-#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:84
-msgid "Show ECO layers"
-msgstr "ECOレイヤの表示"
-
-#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:93
-msgid "Show All"
-msgstr "全てを表示"
-
-#: 3d-viewer/dialogs/dialog_3D_view_option_base.cpp:96
-msgid "Show None"
-msgstr "全てを非表示"
-
-#: bitmap2component/bitmap2cmp_gui.cpp:482
-msgid "Create a logo file"
-msgstr "ロゴファイルの作成"
-
-#: bitmap2component/bitmap2cmp_gui.cpp:501
-#: bitmap2component/bitmap2cmp_gui.cpp:539
-#: bitmap2component/bitmap2cmp_gui.cpp:576
-#: bitmap2component/bitmap2cmp_gui.cpp:613
-#, c-format
-msgid "File '%s' could not be created"
-msgstr "ファイル '%s' を作成できません。"
-
-#: bitmap2component/bitmap2cmp_gui.cpp:519
-msgid "Create a Postscript file"
-msgstr "Postscriptファイルの作成"
-
-#: bitmap2component/bitmap2cmp_gui.cpp:557
-msgid "Create a lib file for Eeschema"
-msgstr "Eeschema 用の libファイルを作成する"
-
-#: bitmap2component/bitmap2cmp_gui.cpp:594
-msgid "Create a footprint file for PcbNew"
-msgstr "Pcbnew 用フットプリントファイルの作成"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:24
-msgid "Original Picture"
-msgstr "オリジナルの画像"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:29
-msgid "Greyscale Picture"
-msgstr "グレースケール画像"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:32
-msgid "Black&&White Picture"
-msgstr "モノクロ画像(&W)"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:41
-msgid "Bitmap Info:"
-msgstr "ビットマップ情報:"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:54
-#: bitmap2component/bitmap2cmp_gui_base.cpp:58
-#: bitmap2component/bitmap2cmp_gui_base.cpp:70
-#: bitmap2component/bitmap2cmp_gui_base.cpp:74
-#: bitmap2component/bitmap2cmp_gui_base.cpp:86
-msgid "0000"
-msgstr "0000"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:62
-msgid "pixels"
-msgstr "ピクセル"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:82
-msgid "BPP:"
-msgstr "Bit/Pixel:"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:90
-msgid "bits"
-msgstr "ビット"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:97
-msgid "Resolution:"
-msgstr "解像度:"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:101
-#: bitmap2component/bitmap2cmp_gui_base.cpp:106
-msgid "300"
-msgstr "300"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:111
-msgid "DPI"
-msgstr "DPI"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:121
-msgid "Load Bitmap"
-msgstr "ビットマップの読み込み"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:125
-msgid ""
-"Create a library file for Eeschema\n"
-"This library contains only one component: logo"
-msgstr ""
-"Eeschema のライブラリファイルを作成する\n"
-"このライブラリは一つだけのコンポーネントロゴが含まれます。"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:129
-msgid "Eeschema (.lib file)"
-msgstr "Eeschema (.libファイル)"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:129
-msgid "Pcbnew (.kicad_mod file)"
-msgstr "Pcbnew (.kicad_modファイル)"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:129
-msgid "Postscript (.ps file)"
-msgstr "PostScript (.ps ファイル)"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:129
-msgid "Logo for title block (.kicad_wks file)"
-msgstr "タイトルブロック用のロゴ (.kicad_wksファイル)"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:141
-msgid "Threshold Value:"
-msgstr "しきい値:"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:146
-msgid ""
-"Adjust the level to convert the greyscale picture to a black and white "
-"picture."
-msgstr "グレースケール画像をモノクロ画像に変換する際のしきい値の調整"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:150
-msgid "User layer Eco1"
-msgstr "Eco1 ユーザーレイヤ"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:150
-msgid "User Layer Eco2"
-msgstr "Eco2 ユーザーレイヤ"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:152
-msgid "Board Layer for Outline:"
-msgstr "使用するレイヤ:"
-
-#: bitmap2component/bitmap2cmp_gui_base.cpp:154
-msgid ""
-"Choose the board layer to place the outline.\n"
-"The 2 invisible fields reference and value are always placed on the silk "
-"screen layer."
-msgstr ""
-"外形を配置する基板のレイヤを選択する.\n"
-"２つの不可視フィールド リファレンスと定数は常にシルク レイヤへ置かれます."
-
-#: pcb_calculator/attenuators.cpp:107
-#, c-format
-msgid "Attenuation more than %f dB"
-msgstr "減衰量は %f dB 以上に設定してください"
-
-#: pcb_calculator/datafile_read_write.cpp:76
-msgid "Data file error."
-msgstr "データファイルエラー"
-
-#: pcb_calculator/pcb_calculator_frame.cpp:144
-msgid ""
-"Data modified, and no data filename to save modifications\n"
-"Do you want to exit and abandon your change?"
-msgstr ""
-"変更されたデータが保存されていません。\n"
-"変更を破棄して終了してよいですか？"
-
-#: pcb_calculator/pcb_calculator_frame.cpp:146
-msgid "Regulator list change"
-msgstr "レギュレータが変更されています"
-
-#: pcb_calculator/pcb_calculator_frame.cpp:157
-#, c-format
-msgid ""
-"Unable to write file<%s>\n"
-"Do you want to exit and abandon your change?"
-msgstr ""
-"<%s>に書込めませんでした．\n"
-"変更を破棄して終了しますか？"
-
-#: pcb_calculator/pcb_calculator_frame.cpp:161
-msgid "Write Data File Error"
-msgstr "データファイル書き出しエラー"
-
-#: pcb_calculator/regulators_funct.cpp:100
-#: pcb_calculator/regulators_funct.cpp:274
-msgid "Bad or missing parameters!"
-msgstr "パラメータ設定値が不正です!"
-
-#: pcb_calculator/regulators_funct.cpp:226
-#, c-format
-msgid "PCB Calculator data  file (*.%s)|*.%s"
-msgstr "Pcb Calculatorデータファイル (*.%s)|*.%s"
-
-#: pcb_calculator/regulators_funct.cpp:231
-msgid "Select a PCB Calculator data file"
-msgstr "Pcb Calculator データファイルの選択"
-
-#: pcb_calculator/regulators_funct.cpp:246
-msgid "Do you want to load this file and replace current regulator list?"
-msgstr "ファイルを読み込み、現在のレギュレータ設定を置換えて良いですか？"
-
-#: pcb_calculator/regulators_funct.cpp:262
-#, c-format
-msgid "Unable to read data file <%s>"
-msgstr "ファイル <%s> が読み込めません"
-
-#: pcb_calculator/regulators_funct.cpp:293
-msgid "This regulator is already in list. Aborted"
-msgstr "指定されたレギュレータは既にリストへ登録されています。"
-
-#: pcb_calculator/regulators_funct.cpp:321
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:229
-msgid "Remove Regulator"
-msgstr "レギュレータの削除"
-
-#: pcb_calculator/regulators_funct.cpp:397
-msgid " Vout must be greater than vref"
-msgstr " Vout は　Vref 以上にしてください。"
-
-#: pcb_calculator/regulators_funct.cpp:403
-msgid " Vref set to 0 !"
-msgstr " Vref が 0 に設定されています！"
-
-#: pcb_calculator/regulators_funct.cpp:409
-msgid "Incorrect value for R1 R2"
-msgstr "R1 R2の値が正しくありません"
-
-#: pcb_calculator/tracks_width_versus_current.cpp:446
-msgid ""
-"If you specify the maximum current, then the trace widths will be calculated "
-"to suit."
-msgstr "最大電流を指定した場合、配線幅は適応するように計算されます。"
-
-#: pcb_calculator/tracks_width_versus_current.cpp:448
-msgid ""
-"If you specify one of the trace widths, the maximum current it can handle "
-"will be calculated. The width for the other trace to also handle this "
-"current will then be calculated."
-msgstr ""
-"配線幅の一つを指定した場合、流せる最大電流が計算されます。また、この電流を流"
-"すことができるように他の配線幅の計算が行われます。"
-
-#: pcb_calculator/tracks_width_versus_current.cpp:452
-msgid "The controlling value is shown in bold."
-msgstr "コントロール値は、ボールド体で表示されます。"
-
-#: pcb_calculator/tracks_width_versus_current.cpp:453
-msgid ""
-"The calculations are valid for currents up to 35A (external) or 17.5A "
-"(internal), temperature rises up to 100 deg C, and widths of up to 400mil "
-"(10mm)."
-msgstr ""
-"計算は、電流に対しては 35A (外部) または 17.5A (内部) まで、温度上昇は 100℃ "
-"まで、幅は 400mil (10mm) まで有効です。"
-
-#: pcb_calculator/tracks_width_versus_current.cpp:456
-msgid "The formula, from IPC 2221, is"
-msgstr "計算式 (IPC 2221 より) は"
-
-#: pcb_calculator/tracks_width_versus_current.cpp:458
-msgid "where:"
-msgstr "ここで:"
-
-#: pcb_calculator/tracks_width_versus_current.cpp:459
-msgid "maximum current in amps"
-msgstr "アンペア表記による最大電流"
-
-#: pcb_calculator/tracks_width_versus_current.cpp:461
-msgid "temperature rise above ambient in deg C"
-msgstr "℃ 表記による周囲に対する上昇温度"
-
-#: pcb_calculator/tracks_width_versus_current.cpp:463
-msgid "width and thickness in mils"
-msgstr "mil 表記による幅と厚さ"
-
-#: pcb_calculator/tracks_width_versus_current.cpp:465
-msgid "0.024 for internal traces or 0.048 for external traces"
-msgstr "内層配線 0.024 または外層配線 0.048"
-
-#: pcb_calculator/transline_dlg_funct.cpp:66
-msgid "Relative Dielectric Constants"
-msgstr "比誘電率"
-
-#: pcb_calculator/transline_dlg_funct.cpp:96
-msgid "Dielectric Loss Factor"
-msgstr "誘電損失"
-
-#: pcb_calculator/transline_dlg_funct.cpp:124
-msgid "Specific Resistance"
-msgstr "固有抵抗"
-
-#: pcb_calculator/transline_ident.cpp:142
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:648
-msgid "Er"
-msgstr "Er"
-
-#: pcb_calculator/transline_ident.cpp:142
-msgid "Epsilon R: substrate relative dielectric constant"
-msgstr "Epsilon R: 比誘電率"
-
-#: pcb_calculator/transline_ident.cpp:145
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:659
-msgid "TanD"
-msgstr "tanδ"
-
-#: pcb_calculator/transline_ident.cpp:145
-msgid "Tangent delta: dielectric loss factor."
-msgstr "Tanδ: 誘電損失"
-
-#: pcb_calculator/transline_ident.cpp:150
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:670
-msgid "Rho"
-msgstr "Rho"
-
-#: pcb_calculator/transline_ident.cpp:151
-msgid ""
-"Electrical resistivity or specific electrical resistance of conductor "
-"(Ohm*meter)"
-msgstr "電気抵抗率または導体固有の電気抵抗 (Ohm*meter)"
-
-#: pcb_calculator/transline_ident.cpp:156
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:776
-msgid "Frequency"
-msgstr "周波数"
-
-# 原文の関連付けエラー？
-#: pcb_calculator/transline_ident.cpp:156
-#: pcb_calculator/transline_ident.cpp:171
-#: pcb_calculator/transline_ident.cpp:208
-#: pcb_calculator/transline_ident.cpp:240
-#: pcb_calculator/transline_ident.cpp:341
-#: pcb_calculator/transline_ident.cpp:377
-msgid "Height of Substrate"
-msgstr "サブストレートの高さ"
-
-#: pcb_calculator/transline_ident.cpp:165
-#: pcb_calculator/transline_ident.cpp:202
-#: pcb_calculator/transline_ident.cpp:234
-#: pcb_calculator/transline_ident.cpp:268
-#: pcb_calculator/transline_ident.cpp:301
-#: pcb_calculator/transline_ident.cpp:371
-#: pcb_calculator/transline_ident.cpp:404
-msgid "ErEff"
-msgstr "実効誘電率"
-
-#: pcb_calculator/transline_ident.cpp:166
-#: pcb_calculator/transline_ident.cpp:203
-#: pcb_calculator/transline_ident.cpp:235
-#: pcb_calculator/transline_ident.cpp:269
-#: pcb_calculator/transline_ident.cpp:302
-#: pcb_calculator/transline_ident.cpp:372
-#: pcb_calculator/transline_ident.cpp:405
-msgid "Conductor Losses"
-msgstr "導体損失"
-
-#: pcb_calculator/transline_ident.cpp:167
-#: pcb_calculator/transline_ident.cpp:204
-#: pcb_calculator/transline_ident.cpp:236
-#: pcb_calculator/transline_ident.cpp:270
-#: pcb_calculator/transline_ident.cpp:303
-#: pcb_calculator/transline_ident.cpp:373
-#: pcb_calculator/transline_ident.cpp:406
-msgid "Dielectric Losses"
-msgstr "誘電体損失"
-
-#: pcb_calculator/transline_ident.cpp:168
-#: pcb_calculator/transline_ident.cpp:205
-#: pcb_calculator/transline_ident.cpp:237
-#: pcb_calculator/transline_ident.cpp:338
-#: pcb_calculator/transline_ident.cpp:374
-#: pcb_calculator/transline_ident.cpp:407
-msgid "Skin Depth"
-msgstr "表皮深さ"
-
-#: pcb_calculator/transline_ident.cpp:171
-#: pcb_calculator/transline_ident.cpp:208
-#: pcb_calculator/transline_ident.cpp:240
-#: pcb_calculator/transline_ident.cpp:341
-#: pcb_calculator/transline_ident.cpp:377
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:683
-msgid "H"
-msgstr "H"
-
-#: pcb_calculator/transline_ident.cpp:173
-#: pcb_calculator/transline_ident.cpp:343
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:696
-msgid "H_t"
-msgstr "H_t"
-
-#: pcb_calculator/transline_ident.cpp:173
-#: pcb_calculator/transline_ident.cpp:343
-msgid "Height of Box Top"
-msgstr "ボックスの高さ"
-
-#: pcb_calculator/transline_ident.cpp:175
-#: pcb_calculator/transline_ident.cpp:210
-#: pcb_calculator/transline_ident.cpp:242
-#: pcb_calculator/transline_ident.cpp:345
-#: pcb_calculator/transline_ident.cpp:382
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:709
-msgid "T"
-msgstr "T"
-
-#: pcb_calculator/transline_ident.cpp:175
-#: pcb_calculator/transline_ident.cpp:210
-#: pcb_calculator/transline_ident.cpp:242
-#: pcb_calculator/transline_ident.cpp:345
-#: pcb_calculator/transline_ident.cpp:382
-msgid "Strip Thickness"
-msgstr "銅箔厚"
-
-#: pcb_calculator/transline_ident.cpp:177
-#: pcb_calculator/transline_ident.cpp:347
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:722
-msgid "Rough"
-msgstr "表面荒さ"
-
-#: pcb_calculator/transline_ident.cpp:177
-#: pcb_calculator/transline_ident.cpp:347
-msgid "Conductor Roughness"
-msgstr "導体の荒さ"
-
-#: pcb_calculator/transline_ident.cpp:179
-msgid "mu Rel S"
-msgstr "μ (比透磁率) S (サブストレート)"
-
-#: pcb_calculator/transline_ident.cpp:180
-msgid "Relative Permeability (mu) of Substrate"
-msgstr "サブストレートの比透磁率 (μ)"
-
-#: pcb_calculator/transline_ident.cpp:182
-#: pcb_calculator/transline_ident.cpp:212
-#: pcb_calculator/transline_ident.cpp:244
-#: pcb_calculator/transline_ident.cpp:279
-#: pcb_calculator/transline_ident.cpp:310
-#: pcb_calculator/transline_ident.cpp:349
-#: pcb_calculator/transline_ident.cpp:384
-#: pcb_calculator/transline_ident.cpp:412
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:748
-msgid "mu Rel C"
-msgstr "μ (比透磁率) C (導体)"
-
-#: pcb_calculator/transline_ident.cpp:182
-#: pcb_calculator/transline_ident.cpp:212
-#: pcb_calculator/transline_ident.cpp:244
-#: pcb_calculator/transline_ident.cpp:279
-#: pcb_calculator/transline_ident.cpp:310
-#: pcb_calculator/transline_ident.cpp:349
-#: pcb_calculator/transline_ident.cpp:384
-#: pcb_calculator/transline_ident.cpp:412
-msgid "Relative Permeability (mu) of Conductor"
-msgstr "導体の比透磁率 (μ)"
-
-#: pcb_calculator/transline_ident.cpp:186
-#: pcb_calculator/transline_ident.cpp:216
-#: pcb_calculator/transline_ident.cpp:248
-#: pcb_calculator/transline_ident.cpp:353
-#: pcb_calculator/transline_ident.cpp:388
-msgid "W"
-msgstr "W"
-
-#: pcb_calculator/transline_ident.cpp:188
-#: pcb_calculator/transline_ident.cpp:220
-#: pcb_calculator/transline_ident.cpp:252
-#: pcb_calculator/transline_ident.cpp:287
-#: pcb_calculator/transline_ident.cpp:318
-#: pcb_calculator/transline_ident.cpp:357
-#: pcb_calculator/transline_ident.cpp:390
-#: pcb_calculator/transline_ident.cpp:422
-msgid "L"
-msgstr "L"
-
-#: pcb_calculator/transline_ident.cpp:188
-#: pcb_calculator/transline_ident.cpp:220
-#: pcb_calculator/transline_ident.cpp:252
-#: pcb_calculator/transline_ident.cpp:318
-#: pcb_calculator/transline_ident.cpp:357
-#: pcb_calculator/transline_ident.cpp:390
-msgid "Line Length"
-msgstr "線路長"
-
-#: pcb_calculator/transline_ident.cpp:191
-#: pcb_calculator/transline_ident.cpp:223
-#: pcb_calculator/transline_ident.cpp:255
-#: pcb_calculator/transline_ident.cpp:290
-#: pcb_calculator/transline_ident.cpp:321
-#: pcb_calculator/transline_ident.cpp:393
-#: pcb_calculator/transline_ident.cpp:425
-msgid "Z0"
-msgstr "Z0"
-
-#: pcb_calculator/transline_ident.cpp:191
-#: pcb_calculator/transline_ident.cpp:223
-#: pcb_calculator/transline_ident.cpp:255
-#: pcb_calculator/transline_ident.cpp:290
-#: pcb_calculator/transline_ident.cpp:321
-#: pcb_calculator/transline_ident.cpp:393
-#: pcb_calculator/transline_ident.cpp:425
-msgid "Characteristic Impedance"
-msgstr "特性インピーダンス"
-
-#: pcb_calculator/transline_ident.cpp:194
-#: pcb_calculator/transline_ident.cpp:226
-#: pcb_calculator/transline_ident.cpp:258
-#: pcb_calculator/transline_ident.cpp:293
-#: pcb_calculator/transline_ident.cpp:324
-#: pcb_calculator/transline_ident.cpp:364
-#: pcb_calculator/transline_ident.cpp:396
-#: pcb_calculator/transline_ident.cpp:428
-msgid "Ang_l"
-msgstr "Ang_l"
-
-#: pcb_calculator/transline_ident.cpp:194
-#: pcb_calculator/transline_ident.cpp:226
-#: pcb_calculator/transline_ident.cpp:258
-#: pcb_calculator/transline_ident.cpp:293
-#: pcb_calculator/transline_ident.cpp:324
-#: pcb_calculator/transline_ident.cpp:396
-#: pcb_calculator/transline_ident.cpp:428
-msgid "Electrical Length"
-msgstr "電気長"
-
-#: pcb_calculator/transline_ident.cpp:218
-#: pcb_calculator/transline_ident.cpp:250
-#: pcb_calculator/transline_ident.cpp:355
-msgid "S"
-msgstr "S"
-
-#: pcb_calculator/transline_ident.cpp:218
-#: pcb_calculator/transline_ident.cpp:250
-#: pcb_calculator/transline_ident.cpp:355
-msgid "Gap Width"
-msgstr "ギャップ幅"
-
-#: pcb_calculator/transline_ident.cpp:267
-msgid "ZF(H10) = Ey / Hx"
-msgstr "ZF(H10) = Ey / Hx"
-
-#: pcb_calculator/transline_ident.cpp:271
-#: pcb_calculator/transline_ident.cpp:304
-msgid "TE-Modes"
-msgstr "TEモード"
-
-#: pcb_calculator/transline_ident.cpp:272
-#: pcb_calculator/transline_ident.cpp:305
-msgid "TM-Modes"
-msgstr "TMモード"
-
-#: pcb_calculator/transline_ident.cpp:275
-#: pcb_calculator/transline_ident.cpp:308
-msgid "mu Rel I"
-msgstr "μ (比透磁率) I (絶縁体)"
-
-#: pcb_calculator/transline_ident.cpp:275
-#: pcb_calculator/transline_ident.cpp:308
-msgid "Relative Permeability (mu) of Insulator"
-msgstr "絶縁体の比透磁率 (μ)"
-
-#: pcb_calculator/transline_ident.cpp:277
-msgid "TanM"
-msgstr "TanM"
-
-#: pcb_calculator/transline_ident.cpp:277
-msgid "Magnetic Loss Tangent"
-msgstr "磁気損失正接"
-
-#: pcb_calculator/transline_ident.cpp:283
-#: pcb_calculator/transline_ident.cpp:379
-msgid "a"
-msgstr "a"
-
-#: pcb_calculator/transline_ident.cpp:283
-msgid "Width of Waveguide"
-msgstr "導波管の幅"
-
-#: pcb_calculator/transline_ident.cpp:285
-msgid "b"
-msgstr "b"
-
-#: pcb_calculator/transline_ident.cpp:285
-msgid "Height of Waveguide"
-msgstr "導波管の高さ"
-
-#: pcb_calculator/transline_ident.cpp:287
-msgid "Waveguide Length"
-msgstr "導波管長"
-
-#: pcb_calculator/transline_ident.cpp:314
-#: pcb_calculator/transline_ident.cpp:418
-msgid "Din"
-msgstr "Din"
-
-#: pcb_calculator/transline_ident.cpp:314
-#: pcb_calculator/transline_ident.cpp:418
-msgid "Inner Diameter (conductor)"
-msgstr "内径 (導体)"
-
-#: pcb_calculator/transline_ident.cpp:316
-#: pcb_calculator/transline_ident.cpp:420
-msgid "Dout"
-msgstr "Dout"
-
-#: pcb_calculator/transline_ident.cpp:316
-#: pcb_calculator/transline_ident.cpp:420
-msgid "Outer Diameter (insulator)"
-msgstr "外形 (絶縁体)"
-
-#: pcb_calculator/transline_ident.cpp:332
-msgid "ErEff Even"
-msgstr "実効比誘電率 Even"
-
-#: pcb_calculator/transline_ident.cpp:333
-msgid "ErEff Odd"
-msgstr "実効比誘電率 Odd"
-
-#: pcb_calculator/transline_ident.cpp:334
-msgid "Conductor Losses Even"
-msgstr "導体損 Even"
-
-#: pcb_calculator/transline_ident.cpp:335
-msgid "Conductor Losses Odd"
-msgstr "導体損 Odd"
-
-#: pcb_calculator/transline_ident.cpp:336
-msgid "Dielectric Losses Even"
-msgstr "誘電体損 Even"
-
-#: pcb_calculator/transline_ident.cpp:337
-msgid "Dielectric Losses Odd"
-msgstr "誘電体損 Odd"
-
-#: pcb_calculator/transline_ident.cpp:360
-msgid "Zeven"
-msgstr "Zeven (偶モードインピーダンス)"
-
-#: pcb_calculator/transline_ident.cpp:360
-msgid "Even mode impedance (lines driven by common voltages)"
-msgstr "偶モードインピーダンス (線路は同じ (同相) 電圧で駆動される)"
-
-#: pcb_calculator/transline_ident.cpp:362
-msgid "Zodd"
-msgstr "Zodd (奇モードインピーダンス)"
-
-#: pcb_calculator/transline_ident.cpp:362
-msgid "Odd mode impedance (lines driven by opposite (differential) voltages)"
-msgstr "奇モードインピーダンス (線路は逆 (差動) 電圧で駆動される)"
-
-#: pcb_calculator/transline_ident.cpp:364
-msgid "Electrical length"
-msgstr "電気長"
-
-#: pcb_calculator/transline_ident.cpp:379
-msgid "distance between strip and top metal"
-msgstr "ストリップラインと上部導体の距離"
-
-#: pcb_calculator/transline_ident.cpp:410
-msgid "Twists"
-msgstr "ツイスト数"
-
-#: pcb_calculator/transline_ident.cpp:410
-msgid "Number of Twists per Length"
-msgstr "長さあたりの撚り数"
-
-#: pcb_calculator/transline_ident.cpp:415
-msgid "ErEnv"
-msgstr "ErEnv"
-
-#: pcb_calculator/transline_ident.cpp:415
-msgid "Relative Permittivity of Environment"
-msgstr "環境の比誘電率"
-
-#: pcb_calculator/transline_ident.cpp:422
-msgid "Cable Length"
-msgstr "ケーブル長"
-
-#: pcb_calculator/UnitSelector.cpp:39
-msgid "um"
-msgstr "um"
-
-#: pcb_calculator/UnitSelector.cpp:40
-msgid "cm"
-msgstr "cm"
-
-#: pcb_calculator/UnitSelector.cpp:41
-msgid "mil"
-msgstr "mils"
-
-#: pcb_calculator/UnitSelector.cpp:70
-msgid "GHz"
-msgstr "GHz"
-
-#: pcb_calculator/UnitSelector.cpp:71
-msgid "MHz"
-msgstr "MHz"
-
-#: pcb_calculator/UnitSelector.cpp:72
-msgid "KHz"
-msgstr "KHz"
-
-#: pcb_calculator/UnitSelector.cpp:73
-msgid "Hz"
-msgstr "Hz"
-
-#: pcb_calculator/UnitSelector.cpp:99
-msgid "Radian"
-msgstr "ラジアン"
-
-#: pcb_calculator/UnitSelector.cpp:100
-msgid "Degree"
-msgstr "度"
-
-#: pcb_calculator/UnitSelector.cpp:124
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:389
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:478
-msgid "Ohm"
-msgstr "Ω"
-
-#: pcb_calculator/UnitSelector.cpp:125
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:97
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:112
-msgid "KOhm"
-msgstr "kΩ"
-
-#: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:36
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:134
-msgid "Vref"
-msgstr "Vref"
-
-#: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:43
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:401
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:490
-msgid "Volt"
-msgstr "V"
-
-#: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:51
-msgid "Separate sense pin"
-msgstr "Vref検出端子が独立(4端子)"
-
-#: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:51
-msgid "3 terminals regulator"
-msgstr "三端子レギュレータ"
-
-#: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:60
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:151
-msgid "Iadj"
-msgstr "Iadj"
-
-#: pcb_calculator/dialogs/dialog_regulator_data_base.cpp:67
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:161
-msgid "uA"
-msgstr "μA"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:62
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1183
-msgid "Formula"
-msgstr "計算式"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:64
-msgid "Vout = Vref * (R1 + R2) / R2"
-msgstr "Vout = Vref * (R1 + R2) / R2"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:89
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1130
-msgid "R1"
-msgstr "R1"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:104
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1142
-msgid "R2"
-msgstr "R2"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:119
-msgid "Vout"
-msgstr "Vout"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:127
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:144
-msgid "V"
-msgstr "V"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:136
-msgid ""
-"The internal reference voltage of the regulator.\n"
-"Should not be 0."
-msgstr ""
-"レギュレータ内部での基準電圧です。\n"
-"0を設定することはできません。"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:153
-msgid "For 3 terminal regulators only, the  Adjust pin current."
-msgstr "3端子レギュレータのみ、Adjustピンの電流。"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:170
-msgid ""
-"Type of the regulator.\n"
-"There are 2 types:\n"
-"- regulators which have a dedicated sense pin for the voltage regulation.\n"
-"- 3 terminal pins."
-msgstr ""
-"レギュレータの種類を設定します.n\n"
-"下記の2種類が想定されています: \n"
-"- 出力電圧設定のための独立したSensピンあるもの.n\n"
-"- 3端子レギュレータ."
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:174
-msgid "Standard Type"
-msgstr "スタンダード"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:174
-msgid "3 Terminal Type"
-msgstr "三端子タイプ"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:186
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1112
-msgid "Calculate"
-msgstr "計算"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:190
-msgid "Regulator"
-msgstr "レギュレータ"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:197
-msgid "Regulators data file:"
-msgstr "レギュレータデータファイル:"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:199
-msgid "The name of the data file which stores known regulators parameters."
-msgstr "既存のレギュレータのパラメータで保存されているデータファイル名。"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:219
-msgid "Edit Regulator"
-msgstr "レギュレータの編集"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:220
-msgid "Edit the current selected regulator."
-msgstr "選択されているレギュレータを編集"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:224
-msgid "Add Regulator"
-msgstr "レギュレータの追加"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:225
-msgid "Enter a new item to the current list of available regulators"
-msgstr "レギュレータリストへ新しい項目を追加します"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:230
-msgid "Remove an item from the current list of available regulators"
-msgstr "レギュレータのリストから項目を削除します"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:240
-msgid "Message"
-msgstr "メッセージ"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:251
-msgid "Regulators"
-msgstr "レギュレータ"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:260
-msgid "Parameters"
-msgstr "パラメータ"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:268
-msgid "Current"
-msgstr "電流"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:280
-msgid "Temperature rise"
-msgstr "温度上昇"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:288
-msgid "deg C"
-msgstr "℃"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:292
-msgid "Conductor length"
-msgstr "導体長"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:305
-msgid "Resistivity"
-msgstr "抵抗率"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:312
-msgid "Ohm-meter"
-msgstr "電気抵抗計"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:335
-msgid "External layer traces"
-msgstr "外層配線"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:343
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:432
-msgid "Trace width"
-msgstr "配線幅"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:356
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:445
-msgid "Trace thickness"
-msgstr "配線の銅箔厚"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:369
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:458
-msgid "Cross-section area"
-msgstr "断面積"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:377
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:466
-msgid "mm ^ 2"
-msgstr "mm^2"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:381
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:470
-msgid "Resistance"
-msgstr "抵抗"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:393
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:482
-msgid "Voltage drop"
-msgstr "電圧降下"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:405
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:494
-msgid "Power loss"
-msgstr "電力損失"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:413
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:502
-msgid "Watt"
-msgstr "W"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:424
-msgid "Internal layer traces"
-msgstr "内層配線"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:535
-msgid "Voltage > 500V:"
-msgstr "電圧 > 500V:"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:543
-msgid "Update Values"
-msgstr "値の更新"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:552
-msgid "Note: Values are minimal values (from IPC 2221)"
-msgstr ""
-"注: 値は最小値です (IPC 2221 より) 　設計時には他の規格も確認して下さい"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:571
-msgid "B1"
-msgstr "B1"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:572
-msgid "B2"
-msgstr "B2"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:573
-msgid "B3"
-msgstr "B3"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:574
-msgid "B4"
-msgstr "B4"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:575
-msgid "A5"
-msgstr "A5"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:576
-msgid "A6"
-msgstr "A6"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:577
-msgid "A7"
-msgstr "A7"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:584
-msgid "0 ... 15V"
-msgstr "0 ... 15V"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:585
-msgid "16 ... 30V"
-msgstr "16 ... 30V"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:586
-msgid "31 ... 50V"
-msgstr "31 ... 50V"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:587
-msgid "51 ... 100V"
-msgstr "51 ... 100V"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:588
-msgid "101 ... 150V"
-msgstr "101 ... 150V"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:589
-msgid "151 ... 170V"
-msgstr "151 ... 170V"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:590
-msgid "171 ... 250V"
-msgstr "171 ... 250V"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:591
-msgid "251 ... 300V"
-msgstr "251 ... 300V"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:592
-msgid "301 ... 500V"
-msgstr "301 ... 500V"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:593
-msgid " > 500V"
-msgstr " > 500V"
-
-# IPC2221 Table 6-1の説明
-# IEC60950など他の規格も参照する必要がある事は謳うべき？
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:602
-msgid ""
-"*  B1 - Internal Conductors\n"
-"*  B2 - External Conductors, uncoated, sea level to 3050 m\n"
-"*  B3 - External Conductors, uncoated, over 3050 m\n"
-"*  B4 - External Conductors, with permanent polymer coating (any elevation)\n"
-"*  A5 - External Conductors, with conformal coating over assembly (any "
-"elevation)\n"
-"*  A6 - External Component lead/termination, uncoated\n"
-"*  A7 - External Component lead termination, with conformal coating (any "
-"elevation)"
-msgstr ""
-"*  B1 - 内層導体\n"
-"*  B2 - 外層導体, コーティングなし, 海抜3050mまで\n"
-"*  B3 - 外層導体, コーティングなし, 海抜3050m以上\n"
-"*  B4 - 外層導体, 耐久ポリマーコーティング (海抜によらず)\n"
-"*  A5 - 外層導体, Assy全体に絶縁保護コーティング (海抜によらず)\n"
-"*  A6 - 外層　コンポーネント リード/終端, コーティングなし\n"
-"*  A7 - 外層　コンポーネント リード/終端, 絶縁保護コーティング (海抜によらず)"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:613
-msgid "Electrical Spacing"
-msgstr "導体間隔"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:621
-msgid "Microstrip Line"
-msgstr "マイクロストリップ ライン"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:621
-msgid "Coplanar wave guide"
-msgstr "コプレーナ導波路"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:621
-msgid "Coplanar wave guide with ground plane"
-msgstr "グランドプレーン付きコプレーナ導波路"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:621
-msgid "Rectangular Waveguide"
-msgstr "方形導波管"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:621
-msgid "Coaxial Line"
-msgstr "同軸線路"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:621
-msgid "Coupled Microstrip Line"
-msgstr "カップルド・マイクロストリップライン"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:621
-msgid "Stripline"
-msgstr "ストリップライン"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:621
-msgid "Twisted Pair"
-msgstr "ツイストペア"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:623
-msgid "Transmission Line Type:"
-msgstr "伝送線路のタイプ:"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:640
-msgid "Substrate Parameters"
-msgstr "基本パラメータ:"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:672
-msgid "Specific resistance in ohms * meters"
-msgstr "Ω・mでの抵抗率"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:735
-msgid "mu Rel"
-msgstr "ミュー (比透磁率)"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:768
-msgid "Component Parameters:"
-msgstr "コンポーネント パラメータ:"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:811
-msgid "Physical Parameters"
-msgstr "物理パラメータ:"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:822
-msgid "Prm1"
-msgstr "Prm1"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:838
-msgid "prm2"
-msgstr "prm2"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:854
-msgid "prm3"
-msgstr "prm3"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:888
-msgid "Analyze"
-msgstr "分析"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:891
-msgid "Synthetize"
-msgstr "合成"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:904
-msgid "Electrical Parameters:"
-msgstr "電気的パラメータ:"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:912
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:925
-msgid "Z"
-msgstr "Z"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:958
-msgid "Results:"
-msgstr "結果:"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1035
-msgid "TransLine"
-msgstr "伝送線路"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1038
-msgid "label"
-msgstr "ラベル"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1043
-msgid "PI"
-msgstr "パイ型"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1043
-msgid "Tee"
-msgstr "T型"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1043
-msgid "Bridged Tee"
-msgstr "ブリッジT型"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1043
-msgid "Resistive Splitter"
-msgstr "抵抗分割型"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1045
-msgid "Attenuators:"
-msgstr "アッテネータ:"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1059
-msgid "Parameters:"
-msgstr "パラメータ:"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1067
-msgid "Attenuation"
-msgstr "減衰量"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1075
-msgid "dB"
-msgstr "dB"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1079
-msgid "Zin"
-msgstr "Zin"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1087
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1099
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1138
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1150
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1162
-msgid "Ohms"
-msgstr "Ω"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1091
-msgid "Zout"
-msgstr "Zout"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1154
-msgid "R3"
-msgstr "R3"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1197
-msgid "RF Attenuators"
-msgstr "RFアッテネータ"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1202
-msgid "10%"
-msgstr "10%"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1202
-msgid "5%"
-msgstr "5%"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1202
-msgid "2%"
-msgstr "2%"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1202
-msgid "1%"
-msgstr "1%"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1202
-msgid "0.5%"
-msgstr "0.5%"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1202
-msgid "0.25%"
-msgstr "0.25%"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1202
-msgid "0.1%"
-msgstr "0.1%"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1202
-msgid "0.05%"
-msgstr "0.05%"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1204
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1233
-msgid "Tolerance"
-msgstr "誤差"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1213
-msgid "1st Band"
-msgstr "第１帯"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1217
-msgid "2nd Band"
-msgstr "第２帯"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1221
-msgid "3rd Band"
-msgstr "第３帯"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1225
-msgid "4rd Band"
-msgstr "第４帯"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1229
-msgid "Multiplier"
-msgstr "乗数"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1262
-msgid "Color Code"
-msgstr "カラーコード"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1275
-msgid "Note: Values are minimal values"
-msgstr "注: 値は最小値です。"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1294
-msgid "Class 1"
-msgstr "クラス 1"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1295
-msgid "Class 2"
-msgstr "クラス 2"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1296
-msgid "Class 3"
-msgstr "クラス 3"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1297
-msgid "Class 4"
-msgstr "クラス 4"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1298
-msgid "Class 5"
-msgstr "クラス 5"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1299
-msgid "Class 6"
-msgstr "クラス 6"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1306
-msgid "Lines width"
-msgstr "配線幅"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1307
-msgid "Min clearance"
-msgstr "最小クリアランス"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1308
-msgid "Via: (diam - drill)"
-msgstr "ビア: (直径 - ドリル径)"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1309
-msgid "Plated Pad: (diam - drill)"
-msgstr "PTHパッド:  (直径-ドリル)"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1310
-msgid "NP Pad: (diam - drill)"
-msgstr "NPTHパッド(直径-ドリル)"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.cpp:1329
-msgid "Board Classes"
-msgstr "ボードのクラス"
-
-#: pagelayout_editor/files.cpp:46
-msgid "Page Layout Description File"
-msgstr "図枠ファイル"
-
-#: pagelayout_editor/files.cpp:51 pagelayout_editor/files.cpp:85
-msgid ""
-"The current page layout has been modified.\n"
-"Do you wish to discard the changes?"
-msgstr ""
-"現在の図枠レイアウトは変更されています。\n"
-"変更を破棄しますか？"
-
-#: pagelayout_editor/files.cpp:60 pagelayout_editor/files.cpp:154
-#, c-format
-msgid "File <%s> loaded"
-msgstr "ファイル <%s> を読み込みました"
-
-#: pagelayout_editor/files.cpp:111 pagelayout_editor/onrightclick.cpp:52
-msgid "Append Page Layout Descr File"
-msgstr "図枠ファイルを追加"
-
-#: pagelayout_editor/files.cpp:122 pagelayout_editor/files.cpp:148
-#, c-format
-msgid "Unable to load %s file"
-msgstr "ファイル %s が読み込めませんでした"
-
-#: pagelayout_editor/files.cpp:130
-#, c-format
-msgid "File <%s> inserted"
-msgstr "ファイル %s を挿入しました"
-
-#: pagelayout_editor/files.cpp:138
-msgid "Open file"
-msgstr "ファイルを開く"
-
-#: pagelayout_editor/files.cpp:163
-#, c-format
-msgid "Unable to write <%s>"
-msgstr "<%s> を作成できません"
-
-#: pagelayout_editor/files.cpp:168 pagelayout_editor/files.cpp:200
-#, c-format
-msgid "File <%s> written"
-msgstr "ファイル <%s> に書き込みました"
-
-#: pagelayout_editor/files.cpp:175 pagelayout_editor/pl_editor_frame.cpp:243
-msgid "Create file"
-msgstr "ファイルの作成"
-
-#: pagelayout_editor/menubar.cpp:62
-msgid "&New Page Layout Design"
-msgstr "新規図枠(&N)"
-
-#: pagelayout_editor/menubar.cpp:65
-msgid "Load Page Layout &File"
-msgstr "図枠ファイルを読み込む(&F)"
-
-#: pagelayout_editor/menubar.cpp:68
-msgid "Load &Default Page Layout"
-msgstr "デフォルト図枠の読み込み(&D)"
-
-#: pagelayout_editor/menubar.cpp:85
-msgid "Open &Recent Page Layout File"
-msgstr "最近の図枠ファイルを開く(&R)"
-
-#: pagelayout_editor/menubar.cpp:91
-msgid "&Save Page Layout Design"
-msgstr "図枠の保存(&S)"
-
-#: pagelayout_editor/menubar.cpp:96
-msgid "Save Page Layout Design &As"
-msgstr "名前をつけて図枠を保存(&A)"
-
-#: pagelayout_editor/menubar.cpp:103
-msgid "Print Pre&view"
-msgstr "印刷プレビュー(&V)"
-
-#: pagelayout_editor/menubar.cpp:112
-msgid "&Close Page Layout Editor"
-msgstr "図枠エディタの終了(&C)"
-
-#: pagelayout_editor/menubar.cpp:121 pagelayout_editor/pl_editor_config.cpp:58
-msgid "&BackGround Black"
-msgstr "背景を黒色にする(&B)"
-
-#: pagelayout_editor/menubar.cpp:121 pagelayout_editor/pl_editor_config.cpp:59
-msgid "&BackGround White"
-msgstr "背景を白色にする(&B)"
-
-#: pagelayout_editor/menubar.cpp:126 pagelayout_editor/pl_editor_config.cpp:66
-msgid "Hide &Grid"
-msgstr "グリッドを非表示"
-
-#: pagelayout_editor/menubar.cpp:126 pagelayout_editor/pl_editor_config.cpp:67
-msgid "Show &Grid"
-msgstr "グリッドの表示"
-
-#: pagelayout_editor/menubar.cpp:158
-msgid "&About Page Layout Editor"
-msgstr "図枠エディタについて(&A)"
-
-#: pagelayout_editor/menubar.cpp:159
-msgid "About page layout description editor"
-msgstr "図枠エディタについて"
-
-#: pagelayout_editor/onrightclick.cpp:47
-msgid "Add Rectangle"
-msgstr "矩形を追加"
-
-#: pagelayout_editor/onrightclick.cpp:55
-msgid "Add Bitmap"
-msgstr "ビットマップを追加"
-
-#: pagelayout_editor/onrightclick.cpp:83
-msgid "Move Start Point"
-msgstr "始点を移動"
-
-#: pagelayout_editor/onrightclick.cpp:91
-msgid "Move End Point"
-msgstr "終点を移動"
-
-#: pagelayout_editor/onrightclick.cpp:97
-#: pcbnew/dialogs/dialog_move_exact_base.h:74
-msgid "Move Item"
-msgstr "アイテムの移動"
-
-#: pagelayout_editor/onrightclick.cpp:111
-msgid "Place Item"
-msgstr "アイテムの配置"
-
-#: pagelayout_editor/page_layout_writer.cpp:103
-#: pagelayout_editor/page_layout_writer.cpp:130
-msgid "Error writing page layout descr file"
-msgstr "図枠ファイル書き込み中のエラー"
-
-#: pagelayout_editor/pl_editor.cpp:149
-msgid "pl_editor is already running. Continue?"
-msgstr "図枠エディタは既に起動しています。続けますか？"
-
-#: pagelayout_editor/pl_editor.cpp:186
-#, c-format
-msgid "Error when loading file <%s>"
-msgstr "<%s> ファイルの読み込み中エラー"
-
-#: pagelayout_editor/pl_editor_frame.cpp:114
-msgid "coord origin: Right Bottom page corner"
-msgstr "原点位置: 用紙の左下角"
-
-#: pagelayout_editor/pl_editor_frame.cpp:146
-msgid "Design"
-msgstr "デザイン"
-
-#: pagelayout_editor/pl_editor_frame.cpp:200
-#, c-format
-msgid "Error when loading file '%s'"
-msgstr "'%s' ファイルの読み込み中のエラー"
-
-#: pagelayout_editor/pl_editor_frame.cpp:222
-msgid "Save changes in a new file before closing?"
-msgstr "終了前に、変更を新規ファイルに保存しますか？"
-
-#: pagelayout_editor/pl_editor_frame.cpp:224
-#, c-format
-msgid ""
-"Save the changes in\n"
-"<%s>\n"
-"before closing?"
-msgstr ""
-"閉じる前に変更を保存しますか？\n"
-"<%s>"
-
-#: pagelayout_editor/pl_editor_frame.cpp:456
-#, c-format
-msgid "Page size: width %.4g height %.4g"
-msgstr "ページサイズ: 幅 %.4g 高さ %.4g"
-
-#: pagelayout_editor/pl_editor_frame.cpp:501
-#, c-format
-msgid "coord origin: %s"
-msgstr "原点位置: %s"
-
-#: pagelayout_editor/pl_editor_frame.cpp:731
-msgid "(start or end point)"
-msgstr "(始点または終点)"
-
-#: pagelayout_editor/pl_editor_frame.cpp:735
-msgid "(start point)"
-msgstr "(始点)"
-
-#: pagelayout_editor/pl_editor_frame.cpp:738
-msgid "(end point)"
-msgstr "(終点)"
-
-#: pagelayout_editor/toolbars_pl_editor.cpp:51
-msgid "New page layout design"
-msgstr "新規図枠"
-
-#: pagelayout_editor/toolbars_pl_editor.cpp:54
-msgid "Load a page layout file. Previous data will be deleted"
-msgstr "図枠ファイルを読み込みます。以前の図枠は削除されます。"
-
-#: pagelayout_editor/toolbars_pl_editor.cpp:57
-msgid "Save page layout design"
-msgstr "図枠の保存"
-
-#: pagelayout_editor/toolbars_pl_editor.cpp:64
-msgid "Print page layout"
-msgstr "図枠の印刷"
-
-#: pagelayout_editor/toolbars_pl_editor.cpp:68
-msgid "Delete selected item"
-msgstr "選択したアイテムを削除"
-
-#: pagelayout_editor/toolbars_pl_editor.cpp:94
-msgid ""
-"Show title block like it will be displayed in applications\n"
-"texts with format are replaced by the full text"
-msgstr ""
-"アプリケーションで表示されるようにタイトルブロック内文字列が表示されます。\n"
-"テキストはページ設定で指定された内容で表示されます。"
-
-#: pagelayout_editor/toolbars_pl_editor.cpp:99
-msgid ""
-"Show title block in edit mode: texts are shown as is:\n"
-"texts with format are displayed with no change"
-msgstr ""
-"編集モードでタイトルブロックを表示: テキスト部は記号で表示されます。\n"
-"フォーマット付きの変数記号で表示され、実際の表示内容は変更されません。"
-
-#: pagelayout_editor/toolbars_pl_editor.cpp:107
-msgid "Left Top paper corner"
-msgstr "用紙の左上角"
-
-# orペア下層
-#: pagelayout_editor/toolbars_pl_editor.cpp:108
-msgid "Right Bottom page corner"
-msgstr "ページの右下角"
-
-# orペア下層
-#: pagelayout_editor/toolbars_pl_editor.cpp:109
-msgid "Left Bottom page corner"
-msgstr "ページの左下角"
-
-#: pagelayout_editor/toolbars_pl_editor.cpp:110
-msgid "Right Top page corner"
-msgstr "ページの右上角"
-
-#: pagelayout_editor/toolbars_pl_editor.cpp:111
-msgid "Left Top page corner"
-msgstr "ページの左上角"
-
-#: pagelayout_editor/toolbars_pl_editor.cpp:118
-msgid " Origin of coordinates displayed to the status bar"
-msgstr "ステータスバーに現在の原点設定が表示されています"
-
-#: pagelayout_editor/toolbars_pl_editor.cpp:131
-msgid "Page 1"
-msgstr "ページ1"
-
-#: pagelayout_editor/toolbars_pl_editor.cpp:132
-msgid "Other pages"
-msgstr "その他のページ"
-
-#: pagelayout_editor/toolbars_pl_editor.cpp:139
-msgid ""
-"Simulate page 1 or other pages to show how items\n"
-"which are not on all page are displayed"
-msgstr ""
-"アイテム表示を、1ページ目、またはそれ以降のページ用に表示させます。\n"
-"これらは全てのページは表示されません。"
-
-#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:28
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:218
-msgid "Pos X (mm)"
-msgstr "X位置(mm)"
-
-#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:35
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:231
-msgid "Pos Y (mm)"
-msgstr "Y位置(mm)"
-
-#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:52
-#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:96
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:252
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:307
-msgid "Upper Right"
-msgstr "左上"
-
-#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:52
-#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:96
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:253
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:308
-msgid "Upper Left"
-msgstr "右上"
-
-#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:52
-#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:96
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:251
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:254
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:306
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:309
-msgid "Lower Right"
-msgstr "左下"
-
-#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:52
-#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:96
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:255
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:310
-msgid "Lower Left"
-msgstr "左下"
-
-#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:72
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:273
-msgid "End X (mm)"
-msgstr "終点X位置(mm)"
-
-#: pagelayout_editor/dialogs/dialog_new_dataitem_base.cpp:79
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:286
-msgid "End Y (mm)"
-msgstr "終点Y位置(mm)"
-
-#: pagelayout_editor/dialogs/dialogs_for_printing.cpp:219
-msgid "Print Page Layout"
-msgstr "図枠の印刷"
-
-#: pagelayout_editor/dialogs/dialogs_for_printing.cpp:224
-msgid "An error occurred attempting to print the page layout."
-msgstr "図枠の印刷中にエラーが発生しました。"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:44
-msgid "Page 1 option"
-msgstr "1ページ目の設定"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:50
-msgid "Page 1 only"
-msgstr "1ページ目のみ"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:50
-msgid "Not on page 1"
-msgstr "1ページ目には適用しない"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:80
-msgid "H justification"
-msgstr "水平位置合わせ"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:99
-msgid "V justification"
-msgstr "垂直位置合わせ"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:124
-msgid "Text Width (mm)"
-msgstr "テキスト幅(mm)"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:137
-msgid "Text Height (mm)"
-msgstr "テキスト高さ(mm)"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:150
-msgid "Constraints:"
-msgstr "制約:"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:160
-msgid "Max Size X (mm)"
-msgstr "最大Xサイズ(mm)"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:173
-msgid "Max Size Y (mm)"
-msgstr "最大Yサイズ(mm)"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:199
-msgid "Comment"
-msgstr "コメント"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:335
-msgid "Set to 0 to use default"
-msgstr "0を指定すると、デフォルト値が使用されます"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:365
-msgid "Bitmap PPI"
-msgstr "ビットマップPixel/Inch"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:378
-msgid "Repeat parameters:"
-msgstr "パラメータの繰り返し:"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:388
-msgid "Repeat count"
-msgstr "繰り返し数"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:400
-msgid "Text Increment"
-msgstr "テキストの増分"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:419
-msgid "Step X (mm)"
-msgstr "Xステップ(mm)"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:432
-msgid "Step Y (mm)"
-msgstr "Yステップ(mm)"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:449
-msgid "Item Properties"
-msgstr "アイテムのプロパティ"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:458
-msgid "Default Values:"
-msgstr "デフォルト値:"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:468
-msgid "Text Size X (mm)"
-msgstr "テキストサイズ X(mm)"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:481
-msgid "Text Size Y (mm)"
-msgstr "テキストサイズ Y(mm)"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:500
-msgid "Line Thickness (mm)"
-msgstr "線幅(mm)"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:529
-msgid "Set to Default"
-msgstr "デフォルトに設定"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:538
-msgid "Page Margins"
-msgstr "ページ余白"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:548
-msgid "Left Margin (mm)"
-msgstr "左余白(mm)"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:561
-msgid "Right Margin (mm)"
-msgstr "右余白(mm)"
-
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:580
-msgid "Top Margin (mm)"
-msgstr "上余白(mm)"
-
-# orペア下層
-#: pagelayout_editor/dialogs/properties_frame_base.cpp:593
-msgid "Bottom Margin (mm)"
-msgstr "下余白"
-
-#: new/sch_lib.cpp:237
-#, c-format
-msgid "part '%s' not found in lib %s"
-msgstr "パーツ '%s' はライブラリ %s 中に見つかりませんでした"
-
-#: new/sch_lpid.cpp:208
-msgid "Illegal character found in LPID string"
-msgstr "FPID文字列中に不正な文字があります"
-
-#: new/sch_lpid.cpp:375
-msgid "Illegal character found in logical lib name"
-msgstr "論理的なライブラリ名の中に不正な文字があります"
-
-#: new/sch_lpid.cpp:406
-msgid "Illegal character found in category"
-msgstr "カテゴリに不正な文字があります"
-
-#: new/sch_lpid.cpp:417
-msgid "Illegal character found in base name"
-msgstr "ベース名に不正な文字があります"
-
-#: new/sch_sweet_parser.cpp:338
-msgid "invalid extends LPID"
-msgstr "不正な拡張 LPID"
-
-#: new/sch_sweet_parser.cpp:354
-msgid "'extends' may not have self as any ancestor"
-msgstr "'extends' はいかなる先祖も持っていないようです"
-
-#: new/sch_sweet_parser.cpp:364
-msgid "max allowed extends depth exceeded"
-msgstr "深度が超過しています"
-
-#: new/sch_sweet_parser.cpp:392
-msgid "invalid alternates LPID"
-msgstr "不正な代替 LPID"
-
-#: new/sch_sweet_parser.cpp:709 new/sch_sweet_parser.cpp:748
-#: new/sch_sweet_parser.cpp:761 new/sch_sweet_parser.cpp:790
-#: new/sch_sweet_parser.cpp:821
-msgid "undefined pin"
-msgstr "未定義のピン"
-
-#: new/sch_sweet_parser.cpp:852 new/sch_sweet_parser.cpp:949
-#, c-format
-msgid "undefined pin %s"
-msgstr "未定義のピン %s"
-
-#: new/sch_sweet_parser.cpp:862 new/sch_sweet_parser.cpp:959
-#, c-format
-msgid "pin %s already in pin_merge group %s"
-msgstr "ピン %s は既にピングループ %s に存在します。"
-
-#: new/sch_sweet_parser.cpp:903
-#, c-format
-msgid "no pins with signal %s"
-msgstr "信号 %s のピンがありません"
-
-#: new/sch_sweet_parser.cpp:915
-#, c-format
-msgid "signal pin %s already in pin_merge group %s"
-msgstr "信号ピン %s は既にピングループ %s に存在します"
-
-#: new/sch_sweet_parser.cpp:998
-#, c-format
-msgid "Unable to find property: %s"
-msgstr "プロパティが見つかりませんでした: %s"
-
-#: new/sweet_editor_panel.cpp:31
-msgid "Sweet"
-msgstr "甘い"
-
-#: new/sweet_editor_panel.cpp:42
-msgid "Visual Part"
-msgstr "可視部分"
-
-#: new/sweet_editor_panel.cpp:59
-msgid "Parsing Errors"
-msgstr "構文エラー"
-
-#: kicad/dialogs/dialog_template_selector_base.h:68
-msgid "Project Template Selector"
-msgstr "プロジェクト テンプレートの選択"
-
-#: pcbnew/help_common_strings.h:17
-msgid "Find components and text in current loaded board"
-msgstr "現在の基板からコンポーネントとテキストを検索"
-
-#: pcbnew/help_common_strings.h:21
-msgid "Zoom to fit the board on the screen"
-msgstr "スクリーンに合わせてボードをズーム"
-
-#: pcbnew/help_common_strings.h:22
-msgid "Redraw the screen of the board"
-msgstr "スクリーン上のボードを再描画"
-
-#: pcbnew/help_common_strings.h:26
-msgid ""
-"Show/hide the toolbar for microwave tools\n"
-"This is a experimental feature (under development)"
-msgstr ""
-"高周波設計支援ツールバーの表示/非表示\n"
-"これは将来に向けた開発中の機能です。"
-
-#: pcbnew/dialogs/dialog_cleaning_options_base.h:54
-msgid "Cleaning Options"
-msgstr "削除設定"
-
-#: pcbnew/dialogs/dialog_copper_zones_base.h:130
-msgid "Copper Zone Properties"
-msgstr "導体ゾーンのプロパティ"
-
-#: pcbnew/dialogs/dialog_create_array_base.h:114
-msgid "Create Array"
-msgstr "配列の作成"
-
-#: pcbnew/dialogs/dialog_design_rules_base.h:114
-msgid "Design Rules Editor"
-msgstr "デザインルール エディタ"
-
-#: pcbnew/dialogs/dialog_dimension_editor_base.h:70
-msgid "Dimension Properties"
-msgstr "寸法線のプロパティ"
-
-#: pcbnew/dialogs/dialog_drc_base.h:103
-msgid "DRC Control"
-msgstr "DRC"
-
-#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.h:140
-#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.h:122
-msgid "Footprint Properties"
-msgstr "フットプリントのプロパティ"
-
-#: pcbnew/dialogs/dialog_edit_module_text_base.h:70
-msgid "Footprint Text Properties"
-msgstr "フットプリント テキストのプロパティ"
-
-#: pcbnew/dialogs/dialog_enum_pads_base.h:53
-msgid "Pad enumeration settings"
-msgstr "パッド配置の設定"
-
-#: pcbnew/dialogs/dialog_exchange_modules_base.h:71
-msgid "Change Footprint"
-msgstr "フットプリントの変更"
-
-#: pcbnew/dialogs/dialog_export_idf_base.h:62
-msgid "Export IDFv3"
-msgstr "IDFv3のエクスポート"
-
-#: pcbnew/dialogs/dialog_export_vrml_base.h:77
-msgid "VRML Export Options"
-msgstr "VRML出力オプション"
-
-#: pcbnew/dialogs/dialog_footprint_wizard_list_base.h:51
-msgid "Footprint Wizards"
-msgstr "フットプリント ウイザード"
-
-#: pcbnew/dialogs/dialog_fp_lib_table_base.h:81
-msgid "PCB Library Tables"
-msgstr "PCBライブラリ一覧"
-
-#: pcbnew/dialogs/dialog_gen_module_position_file_base.h:62
-msgid "Generate Component Position Files"
-msgstr "コンポーネント 座標 ファイルの作成"
-
-#: pcbnew/dialogs/dialog_gendrill_base.h:80
-msgid "Drill Files Generation"
-msgstr "ドリル ファイル生成"
-
-#: pcbnew/dialogs/dialog_global_deletion_base.h:75
-msgid "Delete Items"
-msgstr "アイテム削除"
-
-#: pcbnew/dialogs/dialog_global_edit_tracks_and_vias_base.h:69
-msgid "Global Edition of Tracks and Vias"
-msgstr "配線とビアのグローバル編集"
-
-#: pcbnew/dialogs/dialog_global_modules_fields_edition_base.h:68
-msgid "Set Text Size"
-msgstr "テキストサイズの設定"
-
-#: pcbnew/dialogs/dialog_global_pads_edition_base.h:58
-msgid "Global Pads Edition"
-msgstr "グローバルパッド編集"
-
-#: pcbnew/dialogs/dialog_graphic_item_properties_base.h:79
-msgid "Graphic Item Properties"
+#: eeschema/dialogs/dialog_annotate_base.h:89
+msgid "Annotate Schematic"
+msgstr "回路図のアノテーション"
+
+#: eeschema/dialogs/dialog_bom_base.h:93
+msgid "Bill of Material"
+msgstr "部品表(BOM)"
+
+#: eeschema/dialogs/dialog_color_config_base.h:47
+msgid "EESchema Colors"
+msgstr "Eeschema カラー"
+
+#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.h:103
+#: eeschema/dialogs/dialog_lib_new_component_base.h:62
+msgid "Component Properties"
+msgstr "コンポーネント プロパティ"
+
+#: eeschema/dialogs/dialog_edit_label_base.h:70
+msgid "Text Editor"
+msgstr "テキスト エディタ"
+
+#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.h:87
+msgid "Field Properties"
+msgstr "フィールドのプロパティ"
+
+#: eeschema/dialogs/dialog_eeschema_options_base.h:139
+msgid "Schematic Editor Options"
+msgstr "回路図エディタ オプション"
+
+#: eeschema/dialogs/dialog_erc_base.h:83
+msgid "Electrical Rules Checker"
+msgstr "エレクトリックルールチェッカ(ERC)"
+
+#: eeschema/dialogs/dialog_lib_edit_draw_item_base.h:59
+msgid "Drawing Properties"
 msgstr "図形のプロパティ"
 
-#: pcbnew/dialogs/dialog_graphic_items_options_base.h:71
-msgid "Texts and Drawings"
-msgstr "テキストと図形"
+#: eeschema/dialogs/dialog_lib_edit_pin_base.h:99
+msgid "Pin Properties"
+msgstr "ピンのプロパティ"
 
-#: pcbnew/dialogs/dialog_keepout_area_properties_base.h:70
-msgid "Keepout Area Properties"
-msgstr "キープアウト(禁止)エリアのプロパティ"
+#: eeschema/dialogs/dialog_lib_edit_pin_table_base.h:48
+msgid "Pin Table"
+msgstr "ピン一覧"
 
-#: pcbnew/dialogs/dialog_layer_selection_base.h:81
-msgid "Select Copper Layer Pair:"
-msgstr "導体ペアレイヤの選択:"
+#: eeschema/dialogs/dialog_lib_edit_text_base.h:69
+msgid "Library Text Properties"
+msgstr "ライブラリ テキスト プロパティ"
 
-#: pcbnew/dialogs/dialog_layers_setup_base.h:418
-msgid "Layer Setup"
-msgstr "レイヤ セットアップ"
+#: eeschema/dialogs/dialog_libedit_options_base.h:80
+msgid "Library Editor Options"
+msgstr "コンポーネント ライブラリ エディタ オプション"
 
-#: pcbnew/dialogs/dialog_mask_clearance_base.h:74
-msgid "Pads Mask Clearance"
-msgstr "パッド - レジストのクリアランス"
-
-#: pcbnew/dialogs/dialog_modedit_options_base.h:86
-msgid "Footprint Editor Options"
-msgstr "フットプリントエディタオプション"
-
-#: pcbnew/dialogs/dialog_netlist_fbp.h:84
 #: eeschema/dialogs/dialog_netlist_base.h:78
+#: pcbnew/dialogs/dialog_netlist_fbp.h:84
 msgid "Netlist"
 msgstr "ネットリスト"
 
-#: pcbnew/dialogs/dialog_non_copper_zones_properties_base.h:67
-msgid "Non Copper Zones Properties"
-msgstr "テクニカル層のゾーンのプロパティ"
+#: eeschema/dialogs/dialog_netlist_base.h:119
+msgid "Plugins:"
+msgstr "プラグイン ファイル:"
 
-#: pcbnew/dialogs/dialog_orient_footprints_base.h:53
-msgid "Footprints Orientation"
-msgstr "フットプリントの角度"
+#: eeschema/dialogs/dialog_plot_schematic_base.h:86
+msgid "Plot Schematic"
+msgstr "回路図のプロット"
 
-#: pcbnew/dialogs/dialog_pad_properties_base.h:167
-msgid "Pad Properties"
-msgstr "パッドプロパティ"
+#: eeschema/dialogs/dialog_rescue_each_base.h:65
+msgid "Project Rescue Helper"
+msgstr "プロジェクト・レスキュー・ヘルパー"
 
-#: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.h:64
-msgid "Differential Pair Dimensions"
-msgstr "差動ペアの寸法"
+#: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.h:56
+msgid "Sheet Pin Properties"
+msgstr "シート ピン プロパティ"
 
-#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.h:79
-msgid "Trace length tuning"
-msgstr "配線長の調整"
-
-#: pcbnew/dialogs/dialog_pns_settings_base.h:73
-msgid "Interactive Router Settings"
-msgstr "インタラクティブ ルーターの設定"
-
-#: pcbnew/dialogs/dialog_select_pretty_lib_base.h:57
-msgid "Select Footprint Library Folder"
-msgstr "フットプリント ライブラリのフォルダを指定"
-
-#: pcbnew/dialogs/dialog_set_grid_base.h:70
-msgid "Grid Properties"
-msgstr "グリッドプロパティ"
-
-#: pcbnew/dialogs/dialog_SVG_print_base.h:73
-msgid "Export SVG file"
-msgstr "SVGファイルのエクスポート"
-
-#: pcbnew/dialogs/dialog_target_properties_base.h:61
-msgid "Target Properties"
-msgstr "ターゲットのプロパティ"
-
-#: pcbnew/dialogs/dialog_track_via_properties_base.h:92
-msgid "Track & Via Properties"
-msgstr "配線とビアのプロパティ"
-
-#: pcbnew/dialogs/dialog_track_via_size_base.h:57
-msgid "Track width and via size"
-msgstr "配線幅とビアサイズ"
-
-#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.h:80
-msgid "Add 3D Shape Libraries Wizard"
-msgstr "3D シェイプ ライブラリの追加ウイザード"
-
-#: pcbnew/dialogs/wizard_add_fplib_base.h:88
-msgid "Add Footprint Libraries Wizard"
-msgstr "フットプリント ライブラリの追加ウィザード"
-
-#: pcbnew/import_dxf/dialog_dxf_import_base.h:72
-msgid "Import DXF File"
-msgstr "DXFファイルのインポート"
+#: eeschema/dialogs/dialog_sch_sheet_props_base.h:60
+msgid "Schematic Sheet Properties"
+msgstr "回路図 シート プロパティ"
 
 #: eeschema/help_common_strings.h:41
 msgid "Redo last command"
@@ -22233,89 +22217,6 @@ msgstr "ERCマーカー"
 msgid "No Connect"
 msgstr "未接続"
 
-#: eeschema/dialogs/dialog_annotate_base.h:89
-msgid "Annotate Schematic"
-msgstr "回路図のアノテーション"
-
-#: eeschema/dialogs/dialog_bom_base.h:93
-msgid "Bill of Material"
-msgstr "部品表(BOM)"
-
-#: eeschema/dialogs/dialog_color_config_base.h:52
-msgid "EESchema Colors"
-msgstr "Eeschema カラー"
-
-#: eeschema/dialogs/dialog_edit_component_in_schematic_fbp.h:103
-#: eeschema/dialogs/dialog_lib_new_component_base.h:62
-msgid "Component Properties"
-msgstr "コンポーネント プロパティ"
-
-#: eeschema/dialogs/dialog_edit_label_base.h:70
-msgid "Text Editor"
-msgstr "テキスト エディタ"
-
-#: eeschema/dialogs/dialog_edit_libentry_fields_in_lib_base.h:87
-msgid "Field Properties"
-msgstr "フィールドのプロパティ"
-
-#: eeschema/dialogs/dialog_eeschema_options_base.h:139
-msgid "Schematic Editor Options"
-msgstr "回路図エディタ オプション"
-
-#: eeschema/dialogs/dialog_erc_base.h:98
-msgid "Electrical Rules Checker"
-msgstr "エレクトリックルールチェッカ(ERC)"
-
-#: eeschema/dialogs/dialog_lib_edit_draw_item_base.h:59
-msgid "Drawing Properties"
-msgstr "図形のプロパティ"
-
-#: eeschema/dialogs/dialog_lib_edit_pin_base.h:98
-msgid "Pin Properties"
-msgstr "ピンのプロパティ"
-
-#: eeschema/dialogs/dialog_lib_edit_pin_table_base.h:48
-msgid "Pin Table"
-msgstr "ピン一覧"
-
-#: eeschema/dialogs/dialog_lib_edit_text_base.h:69
-msgid "Library Text Properties"
-msgstr "ライブラリ テキスト プロパティ"
-
-#: eeschema/dialogs/dialog_libedit_options_base.h:80
-msgid "Library Editor Options"
-msgstr "コンポーネント ライブラリ エディタ オプション"
-
-#: eeschema/dialogs/dialog_netlist_base.h:119
-msgid "Plugins:"
-msgstr "プラグイン ファイル:"
-
-#: eeschema/dialogs/dialog_plot_schematic_base.h:86
-msgid "Plot Schematic"
-msgstr "回路図のプロット"
-
-#: eeschema/dialogs/dialog_rescue_each_base.h:65
-msgid "Project Rescue Helper"
-msgstr "プロジェクト・レスキュー・ヘルパー"
-
-#: eeschema/dialogs/dialog_sch_edit_sheet_pin_base.h:56
-msgid "Sheet Pin Properties"
-msgstr "シート ピン プロパティ"
-
-#: eeschema/dialogs/dialog_sch_sheet_props_base.h:60
-msgid "Schematic Sheet Properties"
-msgstr "回路図 シート プロパティ"
-
-#: cvpcb/common_help_msg.h:28
-msgid "Save footprint association in schematic component footprint fields"
-msgstr ""
-"回路図のコンポーネントのフットプリント フィールドへ関連付けてフットプリントを"
-"保存する"
-
-#: cvpcb/dialogs/dialog_display_options_base.h:63
-msgid "Display Options"
-msgstr "表示オプション"
-
 #: gerbview/dialogs/dialog_show_page_borders_base.h:50
 msgid "Page Borders"
 msgstr "ページ境界線"
@@ -22323,46 +22224,6 @@ msgstr "ページ境界線"
 #: gerbview/dialogs/gerbview_dialog_display_options_frame_base.h:65
 msgid "Gerbview Options"
 msgstr "Gerbview オプション"
-
-#: common/dialog_about/dialog_about_base.h:51
-msgid "About..."
-msgstr "このソフトウェアについて(&A)"
-
-#: common/dialogs/dialog_env_var_config_base.h:53
-msgid "Path Configuration"
-msgstr "環境変数の設定"
-
-#: common/dialogs/dialog_hotkeys_editor_base.h:53
-msgid "Hotkeys Editor"
-msgstr "ホットキー エディタ"
-
-#: common/dialogs/dialog_image_editor_base.h:64
-msgid "Image Editor"
-msgstr "イメージ エディタ"
-
-#: common/dialogs/dialog_page_settings_base.h:121
-msgid "Page Settings"
-msgstr "ページ設定"
-
-#: 3d-viewer/dialogs/dialog_3D_view_option_base.h:79
-msgid "3D Display Options"
-msgstr "3D表示オプション"
-
-#: bitmap2component/bitmap2cmp_gui_base.h:92
-msgid "Bitmap to Component Converter"
-msgstr "ビットマップ - コンポーネント変換"
-
-#: pcb_calculator/dialogs/dialog_regulator_data_base.h:62
-msgid "Regulator Parameters"
-msgstr "レギュレータのパラメータ"
-
-#: pcb_calculator/dialogs/pcb_calculator_frame_base.h:304
-msgid "PCB Calculator"
-msgstr "Pcb Calculator"
-
-#: pagelayout_editor/dialogs/dialog_new_dataitem_base.h:71
-msgid "New Item"
-msgstr "新規アイテム"
 
 #: include/class_drc_item.h:164
 #, c-format
@@ -22411,6 +22272,513 @@ msgstr ""
 "行 %d\n"
 "位置 %d\n"
 "%s : %s"
+
+#: kicad/dialogs/dialog_template_selector_base.h:68
+msgid "Project Template Selector"
+msgstr "プロジェクト テンプレートの選択"
+
+#: pagelayout_editor/dialogs/dialog_new_dataitem_base.h:71
+msgid "New Item"
+msgstr "新規アイテム"
+
+#: pcb_calculator/dialogs/dialog_regulator_data_base.h:62
+msgid "Regulator Parameters"
+msgstr "レギュレータのパラメータ"
+
+#: pcb_calculator/dialogs/pcb_calculator_frame_base.h:304
+msgid "PCB Calculator"
+msgstr "Pcb Calculator"
+
+#: pcbnew/dialogs/dialog_SVG_print_base.h:73
+msgid "Export SVG file"
+msgstr "SVGファイルのエクスポート"
+
+#: pcbnew/dialogs/dialog_cleaning_options_base.h:54
+msgid "Cleaning Options"
+msgstr "削除設定"
+
+#: pcbnew/dialogs/dialog_copper_zones_base.h:130
+msgid "Copper Zone Properties"
+msgstr "導体ゾーンのプロパティ"
+
+#: pcbnew/dialogs/dialog_create_array_base.h:114
+msgid "Create Array"
+msgstr "配列の作成"
+
+#: pcbnew/dialogs/dialog_design_rules_base.h:114
+msgid "Design Rules Editor"
+msgstr "デザインルール エディタ"
+
+#: pcbnew/dialogs/dialog_dimension_editor_base.h:70
+msgid "Dimension Properties"
+msgstr "寸法線のプロパティ"
+
+#: pcbnew/dialogs/dialog_drc_base.h:103
+msgid "DRC Control"
+msgstr "DRC"
+
+#: pcbnew/dialogs/dialog_edit_module_for_BoardEditor_base.h:140
+#: pcbnew/dialogs/dialog_edit_module_for_Modedit_base.h:122
+msgid "Footprint Properties"
+msgstr "フットプリントのプロパティ"
+
+#: pcbnew/dialogs/dialog_edit_module_text_base.h:70
+msgid "Footprint Text Properties"
+msgstr "フットプリント テキストのプロパティ"
+
+#: pcbnew/dialogs/dialog_enum_pads_base.h:53
+msgid "Pad enumeration settings"
+msgstr "パッド配置の設定"
+
+#: pcbnew/dialogs/dialog_exchange_modules_base.h:71
+msgid "Change Footprint"
+msgstr "フットプリントの変更"
+
+#: pcbnew/dialogs/dialog_export_idf_base.h:62
+msgid "Export IDFv3"
+msgstr "IDFv3のエクスポート"
+
+#: pcbnew/dialogs/dialog_export_vrml_base.h:78
+msgid "VRML Export Options"
+msgstr "VRML出力オプション"
+
+#: pcbnew/dialogs/dialog_footprint_wizard_list_base.h:51
+msgid "Footprint Wizards"
+msgstr "フットプリント ウイザード"
+
+#: pcbnew/dialogs/dialog_fp_lib_table_base.h:81
+msgid "PCB Library Tables"
+msgstr "PCBライブラリ一覧"
+
+#: pcbnew/dialogs/dialog_gen_module_position_file_base.h:62
+msgid "Generate Component Position Files"
+msgstr "コンポーネント 座標 ファイルの作成"
+
+#: pcbnew/dialogs/dialog_gendrill_base.h:80
+msgid "Drill Files Generation"
+msgstr "ドリル ファイル生成"
+
+#: pcbnew/dialogs/dialog_global_deletion_base.h:75
+msgid "Delete Items"
+msgstr "アイテム削除"
+
+#: pcbnew/dialogs/dialog_global_edit_tracks_and_vias_base.h:69
+msgid "Global Edition of Tracks and Vias"
+msgstr "配線とビアのグローバル編集"
+
+#: pcbnew/dialogs/dialog_global_modules_fields_edition_base.h:68
+msgid "Set Text Size"
+msgstr "テキストサイズの設定"
+
+#: pcbnew/dialogs/dialog_global_pads_edition_base.h:58
+msgid "Global Pads Edition"
+msgstr "グローバルパッド編集"
+
+#: pcbnew/dialogs/dialog_graphic_item_properties_base.h:79
+msgid "Graphic Item Properties"
+msgstr "図形のプロパティ"
+
+#: pcbnew/dialogs/dialog_graphic_items_options_base.h:71
+msgid "Text and Drawings"
+msgstr ""
+
+#: pcbnew/dialogs/dialog_keepout_area_properties_base.h:70
+msgid "Keepout Area Properties"
+msgstr "キープアウト(禁止)エリアのプロパティ"
+
+#: pcbnew/dialogs/dialog_layer_selection_base.h:81
+msgid "Select Copper Layer Pair:"
+msgstr "導体ペアレイヤの選択:"
+
+#: pcbnew/dialogs/dialog_layers_setup_base.h:418
+msgid "Layer Setup"
+msgstr "レイヤ セットアップ"
+
+#: pcbnew/dialogs/dialog_mask_clearance_base.h:74
+msgid "Pads Mask Clearance"
+msgstr "パッド - レジストのクリアランス"
+
+#: pcbnew/dialogs/dialog_modedit_options_base.h:86
+msgid "Footprint Editor Options"
+msgstr "フットプリントエディタオプション"
+
+#: pcbnew/dialogs/dialog_non_copper_zones_properties_base.h:67
+msgid "Non Copper Zones Properties"
+msgstr "テクニカル層のゾーンのプロパティ"
+
+#: pcbnew/dialogs/dialog_orient_footprints_base.h:53
+msgid "Footprints Orientation"
+msgstr "フットプリントの角度"
+
+#: pcbnew/dialogs/dialog_pad_properties_base.h:167
+msgid "Pad Properties"
+msgstr "パッドプロパティ"
+
+#: pcbnew/dialogs/dialog_pns_diff_pair_dimensions_base.h:64
+msgid "Differential Pair Dimensions"
+msgstr "差動ペアの寸法"
+
+#: pcbnew/dialogs/dialog_pns_length_tuning_settings_base.h:79
+msgid "Trace length tuning"
+msgstr "配線長の調整"
+
+#: pcbnew/dialogs/dialog_pns_settings_base.h:73
+msgid "Interactive Router Settings"
+msgstr "インタラクティブ ルーターの設定"
+
+#: pcbnew/dialogs/dialog_select_pretty_lib_base.h:59
+msgid "Select Footprint Library Folder"
+msgstr "フットプリント ライブラリのフォルダを指定"
+
+#: pcbnew/dialogs/dialog_set_grid_base.h:70
+msgid "Grid Properties"
+msgstr "グリッドプロパティ"
+
+#: pcbnew/dialogs/dialog_target_properties_base.h:61
+msgid "Target Properties"
+msgstr "ターゲットのプロパティ"
+
+#: pcbnew/dialogs/dialog_track_via_properties_base.h:92
+msgid "Track & Via Properties"
+msgstr "配線とビアのプロパティ"
+
+#: pcbnew/dialogs/dialog_track_via_size_base.h:57
+msgid "Track width and via size"
+msgstr "配線幅とビアサイズ"
+
+#: pcbnew/dialogs/wizard_3DShape_Libs_downloader_base.h:82
+msgid "Add 3D Shape Libraries Wizard"
+msgstr "3D シェイプ ライブラリの追加ウイザード"
+
+#: pcbnew/dialogs/wizard_add_fplib_base.h:88
+msgid "Add Footprint Libraries Wizard"
+msgstr "フットプリント ライブラリの追加ウィザード"
+
+#: pcbnew/help_common_strings.h:17
+msgid "Find components and text in current loaded board"
+msgstr "現在の基板からコンポーネントとテキストを検索"
+
+#: pcbnew/help_common_strings.h:21
+msgid "Zoom to fit the board on the screen"
+msgstr "スクリーンに合わせてボードをズーム"
+
+#: pcbnew/help_common_strings.h:22
+msgid "Redraw the screen of the board"
+msgstr "スクリーン上のボードを再描画"
+
+#: pcbnew/help_common_strings.h:26
+msgid ""
+"Show/hide the toolbar for microwave tools\n"
+"This is a experimental feature (under development)"
+msgstr ""
+"高周波設計支援ツールバーの表示/非表示\n"
+"これは将来に向けた開発中の機能です。"
+
+#: pcbnew/import_dxf/dialog_dxf_import_base.h:72
+msgid "Import DXF File"
+msgstr "DXFファイルのインポート"
+
+#~ msgid "(%d bytes, compressed %d bytes)\n"
+#~ msgstr "(%d bytes, %d bytes 圧縮)\n"
+
+#~ msgid "%s opened [pid=%ld]\n"
+#~ msgstr "%s の起動 [pid=%ld]\n"
+
+#~ msgid "Select wizard to use"
+#~ msgstr "参照するウィザードの選択"
+
+#~ msgid "Select previous editable item"
+#~ msgstr "前の編集可能アイテムを選択"
+
+#~ msgid "Select next editable item"
+#~ msgstr "次の編集可能アイテムを選択"
+
+#~ msgid "Add footprint to board"
+#~ msgstr "ボードへフットプリントを挿入"
+
+#~ msgid ""
+#~ "invalid PFID in\n"
+#~ "file: <%s>\n"
+#~ "line: %d\n"
+#~ "offset: %d"
+#~ msgstr ""
+#~ "不正なPFIDが見つかりました: \n"
+#~ "ファイル:<%s>\n"
+#~ "%d行目\n"
+#~ "%d文字目"
+
+#~ msgid "Modules [%d items]"
+#~ msgstr "モジュール [%d アイテム]"
+
+#~ msgid ""
+#~ "Clean stubs, vias, delete break points, or connect dangling tracks to "
+#~ "pads and vias"
+#~ msgstr ""
+#~ "パッドやビアに接続している浮き配線・スタブ・ビア・ブレークポイントをクリア"
+
+#~ msgid "&Reset Footprint Field Sizes"
+#~ msgstr "フットプリントフィールドのサイズをリセット(&R)"
+
+#~ msgid ""
+#~ "Reset text size and width of all footprint fields to current defaults"
+#~ msgstr ""
+#~ "全フットプリントの定数の文字サイズ、文字太さを現在のデフォルト値にリセット"
+
+#~ msgid "&Contents"
+#~ msgstr "目次(&C)"
+
+#~ msgid "Open the Pcbnew handbook"
+#~ msgstr "Pcbnew のマニュアルを開く"
+
+#~ msgid "About Pcbnew printed circuit board designer"
+#~ msgstr "Pcbnew プリント基板デザイナーについて"
+
+#~ msgid ""
+#~ "invalid PFID in\n"
+#~ "file: <%s>\n"
+#~ "line: %d"
+#~ msgstr ""
+#~ "不正なPFIDが見つかりました: \n"
+#~ "ファイル:<%s>\n"
+#~ "%d行目"
+
+#~ msgid "New footprint using wizard"
+#~ msgstr "ウィザードを使用して新規フットプリントを作成"
+
+#~ msgid "Tracks and vias:"
+#~ msgstr "配線とビア"
+
+#~ msgid "Tracks sketch mode"
+#~ msgstr "配線をスケッチモードで表示"
+
+#~ msgid "Vias sketch mode"
+#~ msgstr "ビアをスケッチモードで表示"
+
+#~ msgid ""
+#~ "Show (or not) via holes.\n"
+#~ "If Defined Holes is selected, only the non default size holes are shown"
+#~ msgstr ""
+#~ "ビア穴の表示設定\n"
+#~ "\"定義された穴のみ\"を選択した場合、デフォルト径以外の穴のみ表示します"
+
+#~ msgid "Routing help:"
+#~ msgstr "配線のヘルプ:"
+
+#~ msgid "Show or not net names on pads and/or tracks"
+#~ msgstr "パッド/配線のネット名を表示/非表示"
+
+#~ msgid "Show Tracks Clearance:"
+#~ msgstr "配線クリアランスの表示 "
+
+#~ msgid ""
+#~ "Show( or not) tracks clearance area.\n"
+#~ "If New track is selected,  track clearance area is shown only when "
+#~ "creating the track."
+#~ msgstr ""
+#~ "配線のクリアランス エリアの表示設定\n"
+#~ "新しい配線が選択された場合、クリアランス エリアは配線が作成されたときのみ"
+#~ "表示されます"
+
+#~ msgid "Outlines sketch mode"
+#~ msgstr "外形をスケッチモードで表示"
+
+#~ msgid "Pads sketch mode"
+#~ msgstr "パッドをスケッチモードで表示"
+
+#~ msgid "Show pad NoConnect"
+#~ msgstr "未接続パッドの表示"
+
+#~ msgid "Others:"
+#~ msgstr "その他"
+
+#~ msgid "Auto Adjust"
+#~ msgstr "自動設定"
+
+#~ msgid "X ref:"
+#~ msgstr "X ref:"
+
+#~ msgid "Clear Board"
+#~ msgstr "ボードをクリア"
+
+#~ msgid "Start point X"
+#~ msgstr "始点 X"
+
+#~ msgid "Start point Y"
+#~ msgstr "始点 Y"
+
+#~ msgid "End point X"
+#~ msgstr "終点 X"
+
+#~ msgid "End point Y"
+#~ msgstr "終点 Y"
+
+#~ msgid "Graphic segm Width"
+#~ msgstr "図形セグメントの幅"
+
+#~ msgid "Board Edges Width"
+#~ msgstr "ボード エッジの幅"
+
+#~ msgid "Copper Text Width"
+#~ msgstr "テキストの幅"
+
+#~ msgid "Text Size V"
+#~ msgstr "テキストの縦幅"
+
+#~ msgid "Text Size H"
+#~ msgstr "テキストの横幅"
+
+#~ msgid "Edges Width"
+#~ msgstr "エッジの幅"
+
+#~ msgid "Tracks, vias and pads are allowed. The keepout is useless"
+#~ msgstr "配線とビアの配置が可能です。禁止エリアではありません。"
+
+#~ msgid "No Tracks"
+#~ msgstr "配線禁止"
+
+#~ msgid "No Vias"
+#~ msgstr "ビア禁止"
+
+#~ msgid "No Copper Pour"
+#~ msgstr "塗りつぶし禁止"
+
+#~ msgid "Circular shape"
+#~ msgstr "円形シェイプ"
+
+#~ msgid "Oval shape"
+#~ msgstr "楕円形シェイプ"
+
+#~ msgid "Rectangular shape"
+#~ msgstr "長方形シェイプ"
+
+#~ msgid "Trapezoidal shape"
+#~ msgstr "台形シェイプ"
+
+#~ msgid "Trap. delta dim:"
+#~ msgstr "台形作成時の短辺長:"
+
+#~ msgid "Trap. direction:"
+#~ msgstr "台形作成時の方向:"
+
+#~ msgid "Library Path (.pretty will be appended to folder)"
+#~ msgstr "ライブラリパス (.pretty フォルダ)"
+
+#~ msgid "Position X"
+#~ msgstr "ポジション X"
+
+#~ msgid "Position Y"
+#~ msgstr "ポジション Y"
+
+#~ msgid "Polyline at (%s, %s) with %zu points"
+#~ msgstr "ポリライン (%s, %s)  %zu 個の構成点"
+
+#~ msgid ""
+#~ "Select one of %zu components to delete\n"
+#~ "from library '%s'."
+#~ msgstr ""
+#~ "削除するコンポーネント(1 of %zu )を選択\n"
+#~ "(ライブラリ '%s' )."
+
+#~ msgid "Eesc&hema Manual"
+#~ msgstr "Eeschema マニュアル(&H)"
+
+#~ msgid "Open the Eeschema manual"
+#~ msgstr "Eeschema マニュアルを開く"
+
+#~ msgid "Net count = %zu"
+#~ msgstr "ネット数 = %zu"
+
+#~ msgid "No Connect Symbol"
+#~ msgstr "空き端子フラグ"
+
+#~ msgid "Erc warning"
+#~ msgstr "ERC 警告"
+
+#~ msgid "Erc error"
+#~ msgstr "ERC エラー"
+
+#~ msgid ""
+#~ "Warning:\n"
+#~ "Some items have the same color as the background\n"
+#~ "and they will not be seen on screen"
+#~ msgstr ""
+#~ "警告:\n"
+#~ "いくつかのアイテムが背景色と同色です\n"
+#~ "それらは画面上で見えないかもしれません"
+
+#~ msgid "Check for cache/library conflicts at schematic load"
+#~ msgstr "回路図の読込み時にキャッシュ/ライブラリの衝突をチェック"
+
+#~ msgid "Equ file '%s' could not be found in the default search paths."
+#~ msgstr ""
+#~ "フットプリント エイリアス ライブラリファイル '%s' はデフォルトの検索パス中"
+#~ "にありませんでした。"
+
+#~ msgid "Error opening equ file '%s'."
+#~ msgstr "Equファイルを開く際にエラーが発生しました '%s'."
+
+#~ msgid "Equ files Load Error"
+#~ msgstr "Equファイルの読み込みエラー"
+
+#~ msgid "%d footprint/cmp equivalences found."
+#~ msgstr "%d フットプリント/コンポーネントの関連付けが見つかりました."
+
+#~ msgid "&CvPcb Manual"
+#~ msgstr "CvPcbマニュアル(&C)"
+
+#~ msgid "Open CvPcb manual"
+#~ msgstr "CvPcbのマニュアルを開く"
+
+#~ msgid "&About CvPcb"
+#~ msgstr "CvPcbについて(&A)"
+
+#~ msgid "About CvPcb footprint selector"
+#~ msgstr "CvPcbフットプリントセレクタについて"
+
+#~ msgid "OK to change the existing file ?"
+#~ msgstr "既存のファイルを変更します、宜しいですか？"
+
+#~ msgid "Open the GerbView handbook"
+#~ msgstr "GerbViewのマニュアルを開く"
+
+#~ msgid "&About GerbView"
+#~ msgstr "GerbViewについて(&A)"
+
+#~ msgid "About GerbView gerber and drill viewer"
+#~ msgstr "GerbView ガーバー&ドリルデータビューアについて"
+
+#~ msgid "Apply a grid/cloud textures to Board, Solder Mask and Silkscreen"
+#~ msgstr "基板に対してグリッド、半田マスク、シルク等テクスチャを適用します"
+
+#~ msgid "Show 3D F&ootprints"
+#~ msgstr "3Dフットプリントの表示"
+
+#~ msgid "Show &Silkscreen Layer"
+#~ msgstr "シルクレイヤの表示(&S)"
+
+#~ msgid "Show &Comments and Drawings Layer"
+#~ msgstr "コメント/図面描画レイヤの表示(&C)"
+
+#~ msgid "Show component 3D shapes"
+#~ msgstr "コンポーネントの3D形状を表示"
+
+#~ msgid "File '%s' could not be created"
+#~ msgstr "ファイル '%s' を作成できません。"
+
+#~ msgid "Create a lib file for Eeschema"
+#~ msgstr "Eeschema 用の libファイルを作成する"
+
+#~ msgid "Create a footprint file for PcbNew"
+#~ msgstr "Pcbnew 用フットプリントファイルの作成"
+
+#~ msgid "&About Page Layout Editor"
+#~ msgstr "図枠エディタについて(&A)"
+
+#~ msgid "About page layout description editor"
+#~ msgstr "図枠エディタについて"
+
+#~ msgid "Texts and Drawings"
+#~ msgstr "テキストと図形"
 
 #~ msgid "No Modules!"
 #~ msgstr "モジュールがありません！"


### PR DESCRIPTION
フットプリントエディタのパッドプロパティ：形状に未翻訳がありましたので翻訳しました。

Rectangular：四角
Trapezoidal：台形

変更自体はこれだけなのですが、poeditの設定によるのかメッセージの順番が変わって大きなパッチになってしまいました。

変更点を確認しづらく面倒かと思いますが、よろしくお願いいたします。
